### PR TITLE
feat: Add forum topics support with `list_topics` tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This MCP server exposes a huge suite of Telegram tools. **Every major Telegram/T
 ### Messaging
 - **get_messages(chat_id, page, page_size)**: Paginated messages
 - **list_messages(chat_id, limit, search_query, from_date, to_date)**: Filtered messages
+- **list_topics(chat_id, limit, offset_topic, search_query)**: List forum topics in supergroups
 - **send_message(chat_id, message)**: Send a message
 - **reply_to_message(chat_id, message_id, text)**: Reply to a message
 - **edit_message(chat_id, message_id, new_text)**: Edit your message


### PR DESCRIPTION
Add new `list_topics()` MCP tool to retrieve forum topics from Telegram supergroups with forum feature enabled.

Features:
- Validates chat is a supergroup with forum enabled
- Supports pagination via offset_topic parameter
- Supports search filtering via search_query parameter
- Returns comprehensive topic metadata:
  * Topic ID and title
  * Total messages and unread count
  * Status flags (closed, hidden)
  * Last activity timestamp
- Proper error handling and logging

Documentation:
- Added list_topics to README Messaging tools list

Uses Telethon's GetForumTopicsRequest API for reliable forum topic retrieval from supergroups.