### PR TITLE
feat: add draft management tools (save_draft, get_drafts, clear_draft)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ This MCP server exposes a huge suite of Telegram tools. **Every major Telegram/T
 - **unarchive_chat(chat_id)**: Unarchive a chat
 - **get_recent_actions(chat_id)**: Get recent admin actions
 
+### Drafts
+- **save_draft(chat_id, message, reply_to_msg_id, no_webpage)**: Save a draft message to a chat/channel
+- **get_drafts()**: Get all draft messages across all chats
+- **clear_draft(chat_id)**: Clear/delete a draft from a specific chat
+
 ### Input Validation
 
 To improve robustness, all functions accepting `chat_id` or `user_id` parameters now include input validation. You can use any of the following formats for these IDs:


### PR DESCRIPTION
## Summary

Adds three new tools for managing Telegram drafts:

- **save_draft(chat_id, message, reply_to_msg_id, no_webpage)**: Save a draft message to any chat/channel. The draft appears in Telegram's input field when you open that chat, allowing review before sending.
- **get_drafts()**: List all draft messages across all chats with metadata (message, date, reply info).
- **clear_draft(chat_id)**: Clear/delete a draft from a specific chat.

## Implementation

Uses Telethon's native draft APIs:
- `SaveDraftRequest` for saving/clearing drafts
- `GetAllDraftsRequest` for listing all drafts

## Use Case

This enables AI assistants to prepare channel/chat posts for human review before publishing - useful for content workflows where posts should be reviewed before sending.

## Test Plan

- [x] Tested `save_draft` - draft appears in Telegram app input field
- [x] Tested `get_drafts` - returns list of all drafts
- [x] Tested `clear_draft` - draft is removed from chat
- [x] Code passes `black` formatting
- [x] Code passes `flake8` linting
- [x] Updated README.md with new tools documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)