### PR TITLE
feat: add macOS Keychain support for secure credential storage

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,6 +49,8 @@ def get_credential(env_var: str, keychain_account: str) -> Optional[str]:
         return value
     # Fall back to environment variable
     return os.getenv(env_var)
+
+
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 from pythonjsonlogger import jsonlogger


### PR DESCRIPTION
## Summary
Add support for storing Telegram API credentials in macOS Keychain instead of plain text .env files.

## Changes
- Add `get_credential_from_keychain()` function to read from macOS Keychain
- Add `get_credential()` wrapper that tries Keychain first, falls back to environment variables
- Update credential loading to use the new functions
- Full backward compatibility: existing .env setups continue to work

## Usage
Store credentials in Keychain:
```bash
security add-generic-password -a "api_id" -s "telegram-mcp" -w "YOUR_API_ID" -U
security add-generic-password -a "api_hash" -s "telegram-mcp" -w "YOUR_API_HASH" -U
security add-generic-password -a "session_string" -s "telegram-mcp" -w "YOUR_SESSION_STRING" -U
```

## Benefits
- Credentials never stored in plain text on disk
- Protected by macOS security (Touch ID, password)
- Not accidentally committed to git
- No changes required for existing users (falls back to .env)

## Platform Support
- macOS: Full Keychain support
- Linux/Windows: Falls back to environment variables (no change in behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)