### PR TITLE
feat(folders): add 7 tools for Telegram folder management

### DIFF
--- a/main.py
+++ b/main.py
@@ -3668,7 +3668,9 @@ async def get_folder(folder_id: int) -> str:
                 break
 
         if not target_folder:
-            return f"Folder with ID {folder_id} not found. Use list_folders to see available folders."
+            return (
+                f"Folder with ID {folder_id} not found. Use list_folders to see available folders."
+            )
 
         # Resolve included peers to readable names
         included_chats = []
@@ -3677,7 +3679,8 @@ async def get_folder(folder_id: int) -> str:
                 entity = await client.get_entity(peer)
                 chat_info = {
                     "id": entity.id,
-                    "name": getattr(entity, "title", None) or getattr(entity, "first_name", "Unknown"),
+                    "name": getattr(entity, "title", None)
+                    or getattr(entity, "first_name", "Unknown"),
                     "type": type(entity).__name__,
                 }
                 if hasattr(entity, "username") and entity.username:
@@ -3693,7 +3696,8 @@ async def get_folder(folder_id: int) -> str:
                 entity = await client.get_entity(peer)
                 chat_info = {
                     "id": entity.id,
-                    "name": getattr(entity, "title", None) or getattr(entity, "first_name", "Unknown"),
+                    "name": getattr(entity, "title", None)
+                    or getattr(entity, "first_name", "Unknown"),
                     "type": type(entity).__name__,
                 }
                 excluded_chats.append(chat_info)
@@ -3707,7 +3711,8 @@ async def get_folder(folder_id: int) -> str:
                 entity = await client.get_entity(peer)
                 chat_info = {
                     "id": entity.id,
-                    "name": getattr(entity, "title", None) or getattr(entity, "first_name", "Unknown"),
+                    "name": getattr(entity, "title", None)
+                    or getattr(entity, "first_name", "Unknown"),
                     "type": type(entity).__name__,
                 }
                 pinned_chats.append(chat_info)
@@ -3872,7 +3877,9 @@ async def add_chat_to_folder(
                 break
 
         if not target_folder:
-            return f"Folder with ID {folder_id} not found. Use list_folders to see available folders."
+            return (
+                f"Folder with ID {folder_id} not found. Use list_folders to see available folders."
+            )
 
         # Resolve chat to input peer
         try:
@@ -3922,7 +3929,9 @@ async def add_chat_to_folder(
             functions.messages.UpdateDialogFilterRequest(id=folder_id, filter=updated_filter)
         )
 
-        return f"Chat {chat_id} added to folder {folder_id}" + (" (pinned)" if pinned else "") + "."
+        return (
+            f"Chat {chat_id} added to folder {folder_id}" + (" (pinned)" if pinned else "") + "."
+        )
     except Exception as e:
         logger.exception(f"add_chat_to_folder failed (folder_id={folder_id}, chat_id={chat_id})")
         return log_and_format_error(
@@ -3958,7 +3967,9 @@ async def remove_chat_from_folder(folder_id: int, chat_id: Union[int, str]) -> s
                 break
 
         if not target_folder:
-            return f"Folder with ID {folder_id} not found. Use list_folders to see available folders."
+            return (
+                f"Folder with ID {folder_id} not found. Use list_folders to see available folders."
+            )
 
         # Resolve chat to get peer ID
         try:
@@ -3969,17 +3980,24 @@ async def remove_chat_from_folder(folder_id: int, chat_id: Union[int, str]) -> s
 
         # Filter out the peer from both include and pinned lists
         include_peers = [
-            p for p in getattr(target_folder, "include_peers", []) if utils.get_peer_id(p) != peer_id
+            p
+            for p in getattr(target_folder, "include_peers", [])
+            if utils.get_peer_id(p) != peer_id
         ]
         pinned_peers = [
-            p for p in getattr(target_folder, "pinned_peers", []) if utils.get_peer_id(p) != peer_id
+            p
+            for p in getattr(target_folder, "pinned_peers", [])
+            if utils.get_peer_id(p) != peer_id
         ]
 
         original_include_count = len(getattr(target_folder, "include_peers", []))
         original_pinned_count = len(getattr(target_folder, "pinned_peers", []))
 
         # Check if anything was removed (idempotent)
-        if len(include_peers) == original_include_count and len(pinned_peers) == original_pinned_count:
+        if (
+            len(include_peers) == original_include_count
+            and len(pinned_peers) == original_pinned_count
+        ):
             return f"Chat {chat_id} was not in folder {folder_id}."
 
         # Update the folder (keep all original attributes)
@@ -4012,7 +4030,11 @@ async def remove_chat_from_folder(folder_id: int, chat_id: Union[int, str]) -> s
             f"remove_chat_from_folder failed (folder_id={folder_id}, chat_id={chat_id})"
         )
         return log_and_format_error(
-            "remove_chat_from_folder", e, ErrorCategory.FOLDER, folder_id=folder_id, chat_id=chat_id
+            "remove_chat_from_folder",
+            e,
+            ErrorCategory.FOLDER,
+            folder_id=folder_id,
+            chat_id=chat_id,
         )
 
 
@@ -4097,7 +4119,9 @@ async def reorder_folders(folder_ids: List[int]) -> str:
         return f"Folders reordered: {folder_ids}"
     except Exception as e:
         logger.exception(f"reorder_folders failed (folder_ids={folder_ids})")
-        return log_and_format_error("reorder_folders", e, ErrorCategory.FOLDER, folder_ids=folder_ids)
+        return log_and_format_error(
+            "reorder_folders", e, ErrorCategory.FOLDER, folder_ids=folder_ids
+        )
 
 
 async def _main() -> None:


### PR DESCRIPTION
This PR adds 7 new MCP tools to manage Telegram dialog folders (filters):

| Tool | Purpose |
|------|---------|
| `list_folders` | Get all folders with IDs, names, emoji, and filter settings |
| `get_folder` | Get folder details including all included/excluded/pinned chats |
| `create_folder` | Create new folder with title, emoji, filters, and initial chat list |
| `add_chat_to_folder` | Add chat to existing folder (idempotent) |
| `remove_chat_from_folder` | Remove chat from folder (idempotent) |
| `delete_folder` | Delete folder (chats are preserved) |
| `reorder_folders` | Change folder display order |

## Implementation Details

- Added `FOLDER` to `ErrorCategory` enum
- Added imports for `DialogFilter`, `DialogFilterDefault`, `TextWithEntities`
- All tools follow existing patterns (error handling, logging, annotations)

### Telegram API specifics handled:
- `title` field requires `TextWithEntities` object, not plain string
- `title_noanimate` and `color` attributes must be preserved when updating
- Maximum 10 custom folders (Telegram limit) - rejected with clear message
- System folders (ID < 2) protected from deletion
- Idempotent operations for add/remove (safe to call multiple times)

## Test Plan

- [x] `list_folders` - returns all folders with correct data
- [x] `get_folder` - returns folder details with resolved chat names
- [x] `create_folder` - correctly rejects when 10 folders exist
- [x] `add_chat_to_folder` - adds user chats successfully
- [x] `remove_chat_from_folder` - idempotent behavior verified
- [x] `delete_folder` - rejects system folders
- [x] `reorder_folders` - validates all IDs must be included
- [x] Import test passes
- [x] No changes to existing 84 tools

## Known Limitations

Telegram API may silently reject some peers when adding to folders (e.g., channels the user hasn't joined). This is Telegram's behavior, not a bug in the implementation.
