### PR TITLE
feat: add read-only mode - restrict agent to read tools only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,7 @@ TELEGRAM_SESSION_STRING=1231231232erfdfdffd
 # Docker Compose sets this automatically. Leave unset for direct runs (stdio).
 # TELEGRAM_MCP_HTTP=true
 # TELEGRAM_MCP_HTTP_PORT=8000
+
+# Read-only mode: when true, only expose read tools (get chats, list messages, etc.).
+# Write tools (send message, react, edit, delete, etc.) are hidden from the agent.
+# TELEGRAM_READ_ONLY=true

--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,7 @@ TELEGRAM_API_HASH=0123456789abcdef0123456789abcdef
 TELEGRAM_SESSION_NAME=telegram_session
 # Option 2: String-based session (if you generate one, e.g., using Telethon's string session generator)
 TELEGRAM_SESSION_STRING=1231231232erfdfdffd
+
+# Read-only mode: when true, only expose read tools (get chats, list messages, etc.).
+# Write tools (send message, react, edit, delete, etc.) are hidden from the agent.
+# TELEGRAM_READ_ONLY=true

--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,8 @@ TELEGRAM_API_HASH=0123456789abcdef0123456789abcdef
 TELEGRAM_SESSION_NAME=telegram_session
 # Option 2: String-based session (if you generate one, e.g., using Telethon's string session generator)
 TELEGRAM_SESSION_STRING=1231231232erfdfdffd
+
+# HTTP transport: when true, run as HTTP server so Cursor connects via URL.
+# Docker Compose sets this automatically. Leave unset for direct runs (stdio).
+# TELEGRAM_MCP_HTTP=true
+# TELEGRAM_MCP_HTTP_PORT=8000

--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,8 @@ TELEGRAM_SESSION_STRING=1231231232erfdfdffd
 # Read-only mode: when true, only expose read tools (get chats, list messages, etc.).
 # Write tools (send message, react, edit, delete, etc.) are hidden from the agent.
 # TELEGRAM_READ_ONLY=true
+
+# HTTP transport: when true, run as HTTP server so Cursor connects via URL.
+# Docker Compose sets this automatically. Leave unset for direct runs (stdio).
+# TELEGRAM_MCP_HTTP=true
+# TELEGRAM_MCP_HTTP_PORT=8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ ENV TELEGRAM_SESSION_NAME="telegram_mcp_session"
 # Or provide the session string directly
 ENV TELEGRAM_SESSION_STRING=""
 
-# Expose any ports if the application were a web server (not needed for stdio MCP)
-# EXPOSE 8000
+# Expose port for HTTP transport (when TELEGRAM_MCP_HTTP=true)
+EXPOSE 8000
 
 # Define the command to run the application
 CMD ["python", "main.py"] 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,16 @@ TELEGRAM_SESSION_STRING=your_session_string_here
 ```
 Get your API credentials at [my.telegram.org/apps](https://my.telegram.org/apps).
 
+### Read-Only Mode (Summarization / Analysis Only)
+
+To restrict the agent to **read-only** access—e.g., for summarizing messages without sending, reacting, or editing—set:
+
+```
+TELEGRAM_READ_ONLY=true
+```
+
+When enabled, only read tools are exposed (get chats, list messages, get history, search, etc.). Write tools (send message, reply, edit, delete, react, create group, etc.) are hidden, so the agent cannot modify your Telegram account.
+
 ---
 
 ## 🐳 Running with Docker

--- a/README.md
+++ b/README.md
@@ -247,12 +247,44 @@ docker run -it --rm \
 *   Use `-e TELEGRAM_SESSION_NAME=your_session_file_name` instead of `TELEGRAM_SESSION_STRING` if you prefer file-based sessions (requires volume mounting, see `docker-compose.yml` for an example).
 *   The `-it` flags are crucial for interacting with the server.
 
+### HTTP Mode: Server Runs, Cursor Connects via URL
+
+When using Docker Compose, the server runs with **HTTP transport** by default. The server stays running and Cursor connects to it via URL—no process spawning.
+
+1. **Start the server:** `docker compose up --build` (or `-d` for background)
+2. **Configure Cursor** in `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "telegram-mcp": {
+      "url": "http://localhost:8000/mcp"
+    }
+  }
+}
+```
+
+The server is available at `http://localhost:8000/mcp`. Restart Cursor after changing the config.
+
 ---
 
 ## ⚙️ Configuration for Claude & Cursor
 
 ### MCP Configuration
-Edit your Claude desktop config (e.g. `~/Library/Application Support/Claude/claude_desktop_config.json`) or Cursor config (`~/.cursor/mcp.json`):
+
+**Option A: URL (recommended with Docker)** — Server runs independently, Cursor connects:
+
+```json
+{
+  "mcpServers": {
+    "telegram-mcp": {
+      "url": "http://localhost:8000/mcp"
+    }
+  }
+}
+```
+
+**Option B: Command (stdio)** — Cursor spawns the server process:
 
 ```json
 {
@@ -269,6 +301,8 @@ Edit your Claude desktop config (e.g. `~/Library/Application Support/Claude/clau
   }
 }
 ```
+
+Or with Docker: `"command": "docker", "args": ["run", "-i", "--rm", "--env-file", "/path/to/.env", "telegram-mcp:latest"]`
 
 ## 📝 Tool Examples with Code & Output
 

--- a/README.md
+++ b/README.md
@@ -237,12 +237,44 @@ docker run -it --rm \
 *   Use `-e TELEGRAM_SESSION_NAME=your_session_file_name` instead of `TELEGRAM_SESSION_STRING` if you prefer file-based sessions (requires volume mounting, see `docker-compose.yml` for an example).
 *   The `-it` flags are crucial for interacting with the server.
 
+### HTTP Mode: Server Runs, Cursor Connects via URL
+
+When using Docker Compose, the server runs with **HTTP transport** by default. The server stays running and Cursor connects to it via URL—no process spawning.
+
+1. **Start the server:** `docker compose up --build` (or `-d` for background)
+2. **Configure Cursor** in `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "telegram-mcp": {
+      "url": "http://localhost:8000/mcp"
+    }
+  }
+}
+```
+
+The server is available at `http://localhost:8000/mcp`. Restart Cursor after changing the config.
+
 ---
 
 ## ⚙️ Configuration for Claude & Cursor
 
 ### MCP Configuration
-Edit your Claude desktop config (e.g. `~/Library/Application Support/Claude/claude_desktop_config.json`) or Cursor config (`~/.cursor/mcp.json`):
+
+**Option A: URL (recommended with Docker)** — Server runs independently, Cursor connects:
+
+```json
+{
+  "mcpServers": {
+    "telegram-mcp": {
+      "url": "http://localhost:8000/mcp"
+    }
+  }
+}
+```
+
+**Option B: Command (stdio)** — Cursor spawns the server process:
 
 ```json
 {
@@ -259,6 +291,8 @@ Edit your Claude desktop config (e.g. `~/Library/Application Support/Claude/clau
   }
 }
 ```
+
+Or with Docker: `"command": "docker", "args": ["run", "-i", "--rm", "--env-file", "/path/to/.env", "telegram-mcp:latest"]`
 
 ## 📝 Tool Examples with Code & Output
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,13 @@ services:
     # Load environment variables from a .env file in the same directory
     env_file:
       - .env
-    # Keep stdin open and allocate a pseudo-TTY, crucial for stdio MCP servers
-    stdin_open: true
-    tty: true
+    # HTTP transport by default for Docker: server runs, Cursor connects via URL.
+    # (Direct runs default to stdio; set TELEGRAM_MCP_HTTP=true in .env to override.)
+    environment:
+      - TELEGRAM_MCP_HTTP=true
+      - TELEGRAM_MCP_HTTP_PORT=8000
+    ports:
+      - "8000:8000"
     # Optional: Uncomment the following lines to mount a local directory
     # for persisting the Telegram session file if NOT using TELEGRAM_SESSION_STRING.
     # Replace './telegram_sessions' with your desired host path.

--- a/main.py
+++ b/main.py
@@ -93,6 +93,10 @@ SESSION_STRING = os.getenv("TELEGRAM_SESSION_STRING")
 
 # Read-only mode: when set, only expose tools that read data (no send, edit, delete, react, etc.)
 READ_ONLY = os.getenv("TELEGRAM_READ_ONLY", "").lower() in ("true", "1", "yes")
+# HTTP transport: when set, run as HTTP server so clients (e.g. Cursor) can connect via URL.
+# Default: False (stdio) when running directly. Docker Compose sets this to True automatically.
+MCP_HTTP = os.getenv("TELEGRAM_MCP_HTTP", "").lower() in ("true", "1", "yes")
+MCP_HTTP_PORT = int(os.getenv("TELEGRAM_MCP_HTTP_PORT", "8000"))
 
 mcp = FastMCP("telegram")
 
@@ -4225,17 +4229,24 @@ async def reorder_folders(folder_ids: List[int]) -> str:
         )
 
 
-async def _main() -> None:
-    try:
-        # Start the Telethon client non-interactively
-        print("Starting Telegram client...")
-        if READ_ONLY:
-            print("Read-only mode: only read tools exposed (no send, edit, react, etc.)")
-        await client.start()
+async def _connect_client() -> None:
+    """Connect the Telethon client. Must run before MCP server starts."""
+    print("Starting Telegram client...")
+    if READ_ONLY:
+        print("Read-only mode: only read tools exposed (no send, edit, react, etc.)")
+    await client.start()
+    print("Telegram client started.")
 
-        print("Telegram client started. Running MCP server...")
-        # Use the asynchronous entrypoint instead of mcp.run()
-        await mcp.run_stdio_async()
+
+async def _run_stdio() -> None:
+    """Run MCP server over stdio (default: client spawns this process)."""
+    await mcp.run_stdio_async()
+
+
+def main() -> None:
+    nest_asyncio.apply()
+    try:
+        asyncio.run(_connect_client())
     except Exception as e:
         print(f"Error starting client: {e}", file=sys.stderr)
         if isinstance(e, sqlite3.OperationalError) and "database is locked" in str(e):
@@ -4245,10 +4256,13 @@ async def _main() -> None:
             )
         sys.exit(1)
 
-
-def main() -> None:
-    nest_asyncio.apply()
-    asyncio.run(_main())
+    if MCP_HTTP:
+        print(f"MCP server running at http://0.0.0.0:{MCP_HTTP_PORT}/mcp")
+        print("Connect Cursor with: {\"url\": \"http://localhost:" + str(MCP_HTTP_PORT) + "/mcp\"}")
+        mcp.run(transport="streamable-http", host="0.0.0.0", port=MCP_HTTP_PORT)
+    else:
+        print("Running MCP server (stdio)...")
+        asyncio.run(_run_stdio())
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -98,6 +98,9 @@ READ_ONLY = os.getenv("TELEGRAM_READ_ONLY", "").lower() in ("true", "1", "yes")
 MCP_HTTP = os.getenv("TELEGRAM_MCP_HTTP", "").lower() in ("true", "1", "yes")
 MCP_HTTP_PORT = int(os.getenv("TELEGRAM_MCP_HTTP_PORT", "8000"))
 
+# Read-only mode: when set, only expose tools that read data (no send, edit, delete, react, etc.)
+READ_ONLY = os.getenv("TELEGRAM_READ_ONLY", "").lower() in ("true", "1", "yes")
+
 mcp = FastMCP("telegram")
 
 


### PR DESCRIPTION
## Summary
Adds read-only mode via `TELEGRAM_READ_ONLY` env var. When enabled, only tools with `readOnlyHint=True` are exposed—the agent can read and summarize messages but cannot send, edit, delete, or react.

## Changes
- Add `TELEGRAM_READ_ONLY` env var
- `_tool` wrapper skips write tools when read-only
- Document in README and .env.example