### PR TITLE
feat: add HTTP transport for Docker and URL-based MCP connections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,7 @@ TELEGRAM_SESSION_STRING=1231231232erfdfdffd
 # Docker Compose sets this automatically. Leave unset for direct runs (stdio).
 # TELEGRAM_MCP_HTTP=true
 # TELEGRAM_MCP_HTTP_PORT=8000
+
+# Read-only mode: when true, only expose read tools (get chats, list messages, etc.).
+# Write tools (send message, react, edit, delete, etc.) are hidden from the agent.
+# TELEGRAM_READ_ONLY=true

--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,8 @@ TELEGRAM_SESSION_STRING=1231231232erfdfdffd
 # Read-only mode: when true, only expose read tools (get chats, list messages, etc.).
 # Write tools (send message, react, edit, delete, etc.) are hidden from the agent.
 # TELEGRAM_READ_ONLY=true
+
+# HTTP transport: when true, run as HTTP server so Cursor connects via URL.
+# Docker Compose sets this automatically. Leave unset for direct runs (stdio).
+# TELEGRAM_MCP_HTTP=true
+# TELEGRAM_MCP_HTTP_PORT=8000

--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,8 @@ TELEGRAM_API_HASH=0123456789abcdef0123456789abcdef
 TELEGRAM_SESSION_NAME=telegram_session
 # Option 2: String-based session (if you generate one, e.g., using Telethon's string session generator)
 TELEGRAM_SESSION_STRING=1231231232erfdfdffd
+
+# HTTP transport: when true, run as HTTP server so Cursor connects via URL.
+# Docker Compose sets this automatically. Leave unset for direct runs (stdio).
+# TELEGRAM_MCP_HTTP=true
+# TELEGRAM_MCP_HTTP_PORT=8000

--- a/.env.example
+++ b/.env.example
@@ -16,8 +16,3 @@ TELEGRAM_SESSION_STRING=1231231232erfdfdffd
 # Read-only mode: when true, only expose read tools (get chats, list messages, etc.).
 # Write tools (send message, react, edit, delete, etc.) are hidden from the agent.
 # TELEGRAM_READ_ONLY=true
-
-# HTTP transport: when true, run as HTTP server so Cursor connects via URL.
-# Docker Compose sets this automatically. Leave unset for direct runs (stdio).
-# TELEGRAM_MCP_HTTP=true
-# TELEGRAM_MCP_HTTP_PORT=8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ ENV TELEGRAM_SESSION_NAME="telegram_mcp_session"
 # Or provide the session string directly
 ENV TELEGRAM_SESSION_STRING=""
 
-# Expose any ports if the application were a web server (not needed for stdio MCP)
-# EXPOSE 8000
+# Expose port for HTTP transport (when TELEGRAM_MCP_HTTP=true)
+EXPOSE 8000
 
 # Define the command to run the application
 CMD ["python", "main.py"] 

--- a/README.md
+++ b/README.md
@@ -214,8 +214,9 @@ You have two options:
 
 This method uses the `docker-compose.yml` file and automatically reads your credentials from a `.env` file.
 
-1.  **Create `.env` File:** Ensure you have a `.env` file in the project root containing your `TELEGRAM_API_ID`, `TELEGRAM_API_HASH`, and `TELEGRAM_SESSION_STRING` (or `TELEGRAM_SESSION_NAME`). Use `.env.example` as a template.
-2.  **Run Compose:**
+1.  **Create `.env` File:** Ensure you have a `.env` file in the project root containing your `TELEGRAM_API_ID`, `TELEGRAM_API_HASH`, and **`TELEGRAM_SESSION_STRING`**. Use `.env.example` as a template.
+2.  **Session string required for Docker:** Docker has no interactive terminal, so you must generate a session string **before** running in Docker. Run `uv run session_string_generator.py` locally (outside Docker), follow the prompts, then add the output to `.env` as `TELEGRAM_SESSION_STRING`.
+3.  **Run Compose:**
     ```bash
     docker compose up --build
     ```

--- a/README.md
+++ b/README.md
@@ -192,6 +192,16 @@ TELEGRAM_SESSION_STRING=your_session_string_here
 ```
 Get your API credentials at [my.telegram.org/apps](https://my.telegram.org/apps).
 
+### Read-Only Mode (Summarization / Analysis Only)
+
+To restrict the agent to **read-only** access—e.g., for summarizing messages without sending, reacting, or editing—set:
+
+```
+TELEGRAM_READ_ONLY=true
+```
+
+When enabled, only read tools are exposed (get chats, list messages, get history, search, etc.). Write tools (send message, reply, edit, delete, react, create group, etc.) are hidden, so the agent cannot modify your Telegram account.
+
 ---
 
 ## 🐳 Running with Docker

--- a/README.md
+++ b/README.md
@@ -237,12 +237,44 @@ docker run -it --rm \
 *   Use `-e TELEGRAM_SESSION_NAME=your_session_file_name` instead of `TELEGRAM_SESSION_STRING` if you prefer file-based sessions (requires volume mounting, see `docker-compose.yml` for an example).
 *   The `-it` flags are crucial for interacting with the server.
 
+### HTTP Mode: Server Runs, Cursor Connects via URL
+
+When using Docker Compose, the server runs with **HTTP transport** by default. The server stays running and Cursor connects to it via URL—no process spawning.
+
+1. **Start the server:** `docker compose up --build` (or `-d` for background)
+2. **Configure Cursor** in `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "telegram-mcp": {
+      "url": "http://localhost:8000/mcp"
+    }
+  }
+}
+```
+
+The server is available at `http://localhost:8000/mcp`. Restart Cursor after changing the config.
+
 ---
 
 ## ⚙️ Configuration for Claude & Cursor
 
 ### MCP Configuration
-Edit your Claude desktop config (e.g. `~/Library/Application Support/Claude/claude_desktop_config.json`) or Cursor config (`~/.cursor/mcp.json`):
+
+**Option A: URL (recommended with Docker)** — Server runs independently, Cursor connects:
+
+```json
+{
+  "mcpServers": {
+    "telegram-mcp": {
+      "url": "http://localhost:8000/mcp"
+    }
+  }
+}
+```
+
+**Option B: Command (stdio)** — Cursor spawns the server process:
 
 ```json
 {
@@ -259,6 +291,8 @@ Edit your Claude desktop config (e.g. `~/Library/Application Support/Claude/clau
   }
 }
 ```
+
+Or with Docker: `"command": "docker", "args": ["run", "-i", "--rm", "--env-file", "/path/to/.env", "telegram-mcp:latest"]`
 
 ## 📝 Tool Examples with Code & Output
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,11 +11,12 @@ services:
       - .env
     # HTTP transport by default for Docker: server runs, Cursor connects via URL.
     # (Direct runs default to stdio; set TELEGRAM_MCP_HTTP=true in .env to override.)
+    # TELEGRAM_MCP_HTTP_PORT from .env (default 8000) controls the port.
     environment:
       - TELEGRAM_MCP_HTTP=true
-      - TELEGRAM_MCP_HTTP_PORT=8000
+      - TELEGRAM_MCP_HTTP_PORT=${TELEGRAM_MCP_HTTP_PORT:-8000}
     ports:
-      - "8000:8000"
+      - "${TELEGRAM_MCP_HTTP_PORT:-8000}:${TELEGRAM_MCP_HTTP_PORT:-8000}"
     # Optional: Uncomment the following lines to mount a local directory
     # for persisting the Telegram session file if NOT using TELEGRAM_SESSION_STRING.
     # Replace './telegram_sessions' with your desired host path.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,13 @@ services:
     # Load environment variables from a .env file in the same directory
     env_file:
       - .env
-    # Keep stdin open and allocate a pseudo-TTY, crucial for stdio MCP servers
-    stdin_open: true
-    tty: true
+    # HTTP transport by default for Docker: server runs, Cursor connects via URL.
+    # (Direct runs default to stdio; set TELEGRAM_MCP_HTTP=true in .env to override.)
+    environment:
+      - TELEGRAM_MCP_HTTP=true
+      - TELEGRAM_MCP_HTTP_PORT=8000
+    ports:
+      - "8000:8000"
     # Optional: Uncomment the following lines to mount a local directory
     # for persisting the Telegram session file if NOT using TELEGRAM_SESSION_STRING.
     # Replace './telegram_sessions' with your desired host path.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,12 +11,20 @@ services:
       - .env
     # HTTP transport by default for Docker: server runs, Cursor connects via URL.
     # (Direct runs default to stdio; set TELEGRAM_MCP_HTTP=true in .env to override.)
+<<<<<<< HEAD
     # TELEGRAM_MCP_HTTP_PORT from .env (default 8000) controls the port.
     environment:
       - TELEGRAM_MCP_HTTP=true
       - TELEGRAM_MCP_HTTP_PORT=${TELEGRAM_MCP_HTTP_PORT:-8000}
     ports:
       - "${TELEGRAM_MCP_HTTP_PORT:-8000}:${TELEGRAM_MCP_HTTP_PORT:-8000}"
+=======
+    environment:
+      - TELEGRAM_MCP_HTTP=true
+      - TELEGRAM_MCP_HTTP_PORT=8000
+    ports:
+      - "8000:8000"
+>>>>>>> e7a74d2 (feat: add HTTP transport - server runs, Cursor connects via URL)
     # Optional: Uncomment the following lines to mount a local directory
     # for persisting the Telegram session file if NOT using TELEGRAM_SESSION_STRING.
     # Replace './telegram_sessions' with your desired host path.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,20 +11,12 @@ services:
       - .env
     # HTTP transport by default for Docker: server runs, Cursor connects via URL.
     # (Direct runs default to stdio; set TELEGRAM_MCP_HTTP=true in .env to override.)
-<<<<<<< HEAD
     # TELEGRAM_MCP_HTTP_PORT from .env (default 8000) controls the port.
     environment:
       - TELEGRAM_MCP_HTTP=true
       - TELEGRAM_MCP_HTTP_PORT=${TELEGRAM_MCP_HTTP_PORT:-8000}
     ports:
       - "${TELEGRAM_MCP_HTTP_PORT:-8000}:${TELEGRAM_MCP_HTTP_PORT:-8000}"
-=======
-    environment:
-      - TELEGRAM_MCP_HTTP=true
-      - TELEGRAM_MCP_HTTP_PORT=8000
-    ports:
-      - "8000:8000"
->>>>>>> e7a74d2 (feat: add HTTP transport - server runs, Cursor connects via URL)
     # Optional: Uncomment the following lines to mount a local directory
     # for persisting the Telegram session file if NOT using TELEGRAM_SESSION_STRING.
     # Replace './telegram_sessions' with your desired host path.

--- a/main.py
+++ b/main.py
@@ -99,11 +99,6 @@ MCP_HTTP_PORT = int(os.getenv("TELEGRAM_MCP_HTTP_PORT", "8000"))
 
 # Read-only mode: when set, only expose tools that read data (no send, edit, delete, react, etc.)
 READ_ONLY = os.getenv("TELEGRAM_READ_ONLY", "").lower() in ("true", "1", "yes")
-# HTTP transport: when set, run as HTTP server so clients (e.g. Cursor) can connect via URL.
-# Default: False (stdio) when running directly. Docker Compose sets this to True automatically.
-MCP_HTTP = os.getenv("TELEGRAM_MCP_HTTP", "").lower() in ("true", "1", "yes")
-MCP_HTTP_PORT = int(os.getenv("TELEGRAM_MCP_HTTP_PORT", "8000"))
-
 
 def _tool(annotations=None, **kwargs):
     """
@@ -4266,35 +4261,14 @@ async def reorder_folders(folder_ids: List[int]) -> str:
         )
 
 
-<<<<<<< HEAD
-async def _run_stdio() -> None:
-    """Run MCP server over stdio (default: client spawns this process)."""
-    print("Starting Telegram client...")
-    try:
-        if READ_ONLY:
-            print("Read-only mode: only read tools exposed (no send, edit, react, etc.)")
-        await client.start()
-        print("Telegram client started. Running MCP server...")
-=======
 async def _connect_client() -> None:
     """Connect the Telethon client. Must run before MCP server starts."""
     print("Starting Telegram client...")
     if READ_ONLY:
         print("Read-only mode: only read tools exposed (no send, edit, react, etc.)")
-    await client.start()
-    print("Telegram client started.")
-
-
-async def _run_stdio() -> None:
-    """Run MCP server over stdio (default: client spawns this process)."""
-    await mcp.run_stdio_async()
-
-
-def main() -> None:
-    nest_asyncio.apply()
     try:
-        asyncio.run(_connect_client())
->>>>>>> e7a74d2 (feat: add HTTP transport - server runs, Cursor connects via URL)
+        await client.start()
+        print("Telegram client started.")
     except Exception as e:
         print(f"Error starting client: {e}", file=sys.stderr)
         if isinstance(e, sqlite3.OperationalError) and "database is locked" in str(e):
@@ -4310,22 +4284,20 @@ def main() -> None:
                 file=sys.stderr,
             )
         sys.exit(1)
+
+
+async def _run_stdio() -> None:
+    """Run MCP server over stdio (default: client spawns this process)."""
+    await _connect_client()
     await mcp.run_stdio_async()
 
-<<<<<<< HEAD
 
 def main() -> None:
     nest_asyncio.apply()
     if MCP_HTTP:
         print(f"MCP server running at http://0.0.0.0:{MCP_HTTP_PORT}/mcp")
         print("Connect Cursor with: {\"url\": \"http://localhost:" + str(MCP_HTTP_PORT) + "/mcp\"}")
-        mcp.run(transport="streamable-http")
-=======
-    if MCP_HTTP:
-        print(f"MCP server running at http://0.0.0.0:{MCP_HTTP_PORT}/mcp")
-        print("Connect Cursor with: {\"url\": \"http://localhost:" + str(MCP_HTTP_PORT) + "/mcp\"}")
         mcp.run(transport="streamable-http", host="0.0.0.0", port=MCP_HTTP_PORT)
->>>>>>> e7a74d2 (feat: add HTTP transport - server runs, Cursor connects via URL)
     else:
         print("Running MCP server (stdio)...")
         asyncio.run(_run_stdio())

--- a/main.py
+++ b/main.py
@@ -97,6 +97,23 @@ SESSION_STRING = os.getenv("TELEGRAM_SESSION_STRING")
 MCP_HTTP = os.getenv("TELEGRAM_MCP_HTTP", "").lower() in ("true", "1", "yes")
 MCP_HTTP_PORT = int(os.getenv("TELEGRAM_MCP_HTTP_PORT", "8000"))
 
+# Read-only mode: when set, only expose tools that read data (no send, edit, delete, react, etc.)
+READ_ONLY = os.getenv("TELEGRAM_READ_ONLY", "").lower() in ("true", "1", "yes")
+
+
+def _tool(annotations=None, **kwargs):
+    """
+    Register a tool with MCP. In read-only mode, only tools with readOnlyHint=True
+    are registered; write tools are skipped so the agent cannot send, edit, or
+    otherwise modify Telegram state.
+    """
+    is_read_only = annotations and getattr(annotations, "readOnlyHint", False)
+    if not is_read_only and READ_ONLY:
+        def _noop(f):
+            return f
+        return _noop
+    return mcp.tool(annotations=annotations, **kwargs)
+
 if SESSION_STRING:
     client = TelegramClient(StringSession(SESSION_STRING), TELEGRAM_API_ID, TELEGRAM_API_HASH)
 else:
@@ -107,6 +124,8 @@ else:
 async def _telegram_lifespan(app):
     """Connect Telethon in the server's event loop so tools run in the same loop."""
     print("Starting Telegram client...")
+    if READ_ONLY:
+        print("Read-only mode: only read tools exposed (no send, edit, react, etc.)")
     try:
         await client.start()
         print("Telegram client started.")
@@ -398,7 +417,7 @@ def get_engagement_info(message) -> str:
     return f" | {', '.join(engagement_parts)}" if engagement_parts else ""
 
 
-@mcp.tool(annotations=ToolAnnotations(title="Get Chats", openWorldHint=True, readOnlyHint=True))
+@_tool(annotations=ToolAnnotations(title="Get Chats", openWorldHint=True, readOnlyHint=True))
 async def get_chats(page: int = 1, page_size: int = 20) -> str:
     """
     Get a paginated list of chats.
@@ -424,7 +443,7 @@ async def get_chats(page: int = 1, page_size: int = 20) -> str:
         return log_and_format_error("get_chats", e)
 
 
-@mcp.tool(annotations=ToolAnnotations(title="Get Messages", openWorldHint=True, readOnlyHint=True))
+@_tool(annotations=ToolAnnotations(title="Get Messages", openWorldHint=True, readOnlyHint=True))
 @validate_id("chat_id")
 async def get_messages(chat_id: Union[int, str], page: int = 1, page_size: int = 20) -> str:
     """
@@ -459,7 +478,7 @@ async def get_messages(chat_id: Union[int, str], page: int = 1, page_size: int =
         )
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Send Message", openWorldHint=True, destructiveHint=True)
 )
 @validate_id("chat_id")
@@ -478,7 +497,7 @@ async def send_message(chat_id: Union[int, str], message: str) -> str:
         return log_and_format_error("send_message", e, chat_id=chat_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Subscribe Public Channel",
         openWorldHint=True,
@@ -505,7 +524,7 @@ async def subscribe_public_channel(channel: Union[int, str]) -> str:
         return log_and_format_error("subscribe_public_channel", e, channel=channel)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="List Inline Buttons", openWorldHint=True, readOnlyHint=True)
 )
 @validate_id("chat_id")
@@ -571,7 +590,7 @@ async def list_inline_buttons(
         )
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Press Inline Button", openWorldHint=True, destructiveHint=True
     )
@@ -690,7 +709,7 @@ async def press_inline_button(
         )
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="List Contacts", openWorldHint=True, readOnlyHint=True)
 )
 async def list_contacts() -> str:
@@ -718,7 +737,7 @@ async def list_contacts() -> str:
         return log_and_format_error("list_contacts", e)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Search Contacts", openWorldHint=True, readOnlyHint=True)
 )
 async def search_contacts(query: str) -> str:
@@ -748,7 +767,7 @@ async def search_contacts(query: str) -> str:
         return log_and_format_error("search_contacts", e, query=query)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Get Contact Ids", openWorldHint=True, readOnlyHint=True)
 )
 async def get_contact_ids() -> str:
@@ -764,7 +783,7 @@ async def get_contact_ids() -> str:
         return log_and_format_error("get_contact_ids", e)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="List Messages", openWorldHint=True, readOnlyHint=True)
 )
 @validate_id("chat_id")
@@ -891,7 +910,7 @@ async def list_messages(
         return log_and_format_error("list_messages", e, chat_id=chat_id)
 
 
-@mcp.tool(annotations=ToolAnnotations(title="List Topics", openWorldHint=True, readOnlyHint=True))
+@_tool(annotations=ToolAnnotations(title="List Topics", openWorldHint=True, readOnlyHint=True))
 async def list_topics(
     chat_id: int,
     limit: int = 200,
@@ -978,7 +997,7 @@ async def list_topics(
         )
 
 
-@mcp.tool(annotations=ToolAnnotations(title="List Chats", openWorldHint=True, readOnlyHint=True))
+@_tool(annotations=ToolAnnotations(title="List Chats", openWorldHint=True, readOnlyHint=True))
 async def list_chats(chat_type: str = None, limit: int = 20) -> str:
     """
     List available chats with metadata.
@@ -1041,7 +1060,7 @@ async def list_chats(chat_type: str = None, limit: int = 20) -> str:
         return log_and_format_error("list_chats", e, chat_type=chat_type, limit=limit)
 
 
-@mcp.tool(annotations=ToolAnnotations(title="Get Chat", openWorldHint=True, readOnlyHint=True))
+@_tool(annotations=ToolAnnotations(title="Get Chat", openWorldHint=True, readOnlyHint=True))
 @validate_id("chat_id")
 async def get_chat(chat_id: Union[int, str]) -> str:
     """
@@ -1113,7 +1132,7 @@ async def get_chat(chat_id: Union[int, str]) -> str:
         return log_and_format_error("get_chat", e, chat_id=chat_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Get Direct Chat By Contact", openWorldHint=True, readOnlyHint=True
     )
@@ -1172,7 +1191,7 @@ async def get_direct_chat_by_contact(contact_query: str) -> str:
         return log_and_format_error("get_direct_chat_by_contact", e, contact_query=contact_query)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Get Contact Chats", openWorldHint=True, readOnlyHint=True)
 )
 @validate_id("contact_id")
@@ -1227,7 +1246,7 @@ async def get_contact_chats(contact_id: Union[int, str]) -> str:
         return log_and_format_error("get_contact_chats", e, contact_id=contact_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Get Last Interaction", openWorldHint=True, readOnlyHint=True
     )
@@ -1268,7 +1287,7 @@ async def get_last_interaction(contact_id: Union[int, str]) -> str:
         return log_and_format_error("get_last_interaction", e, contact_id=contact_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Get Message Context", openWorldHint=True, readOnlyHint=True)
 )
 @validate_id("chat_id")
@@ -1337,7 +1356,7 @@ async def get_message_context(
         )
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Add Contact", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -1470,7 +1489,7 @@ async def add_contact(
         return log_and_format_error("add_contact", e, phone=phone, username=username)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Delete Contact", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -1490,7 +1509,7 @@ async def delete_contact(user_id: Union[int, str]) -> str:
         return log_and_format_error("delete_contact", e, user_id=user_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Block User", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -1510,7 +1529,7 @@ async def block_user(user_id: Union[int, str]) -> str:
         return log_and_format_error("block_user", e, user_id=user_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Unblock User", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -1530,7 +1549,7 @@ async def unblock_user(user_id: Union[int, str]) -> str:
         return log_and_format_error("unblock_user", e, user_id=user_id)
 
 
-@mcp.tool(annotations=ToolAnnotations(title="Get Me", openWorldHint=True, readOnlyHint=True))
+@_tool(annotations=ToolAnnotations(title="Get Me", openWorldHint=True, readOnlyHint=True))
 async def get_me() -> str:
     """
     Get your own user information.
@@ -1542,7 +1561,7 @@ async def get_me() -> str:
         return log_and_format_error("get_me", e)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Create Group", openWorldHint=True, destructiveHint=True)
 )
 @validate_id("user_ids")
@@ -1603,7 +1622,7 @@ async def create_group(title: str, user_ids: List[Union[int, str]]) -> str:
         return log_and_format_error("create_group", e, title=title, user_ids=user_ids)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Invite To Group", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -1657,7 +1676,7 @@ async def invite_to_group(group_id: Union[int, str], user_ids: List[Union[int, s
         return log_and_format_error("invite_to_group", e, group_id=group_id, user_ids=user_ids)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Leave Chat", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -1742,7 +1761,7 @@ async def leave_chat(chat_id: Union[int, str]) -> str:
         return log_and_format_error("leave_chat", e, chat_id=chat_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Get Participants", openWorldHint=True, readOnlyHint=True)
 )
 @validate_id("chat_id")
@@ -1763,7 +1782,7 @@ async def get_participants(chat_id: Union[int, str]) -> str:
         return log_and_format_error("get_participants", e, chat_id=chat_id)
 
 
-@mcp.tool(annotations=ToolAnnotations(title="Send File", openWorldHint=True, destructiveHint=True))
+@_tool(annotations=ToolAnnotations(title="Send File", openWorldHint=True, destructiveHint=True))
 @validate_id("chat_id")
 async def send_file(chat_id: Union[int, str], file_path: str, caption: str = None) -> str:
     """
@@ -1787,7 +1806,7 @@ async def send_file(chat_id: Union[int, str], file_path: str, caption: str = Non
         )
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Download Media", openWorldHint=True, readOnlyHint=True)
 )
 @validate_id("chat_id")
@@ -1822,7 +1841,7 @@ async def download_media(chat_id: Union[int, str], message_id: int, file_path: s
         )
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Update Profile", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -1844,7 +1863,7 @@ async def update_profile(first_name: str = None, last_name: str = None, about: s
         )
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Set Profile Photo", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -1862,7 +1881,7 @@ async def set_profile_photo(file_path: str) -> str:
         return log_and_format_error("set_profile_photo", e, file_path=file_path)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Delete Profile Photo", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -1883,7 +1902,7 @@ async def delete_profile_photo() -> str:
         return log_and_format_error("delete_profile_photo", e)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Get Privacy Settings", openWorldHint=True, readOnlyHint=True
     )
@@ -1911,7 +1930,7 @@ async def get_privacy_settings() -> str:
         return log_and_format_error("get_privacy_settings", e)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Set Privacy Settings", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -2012,7 +2031,7 @@ async def set_privacy_settings(
         return log_and_format_error("set_privacy_settings", e, key=key)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Import Contacts", openWorldHint=True, destructiveHint=True)
 )
 async def import_contacts(contacts: list) -> str:
@@ -2035,7 +2054,7 @@ async def import_contacts(contacts: list) -> str:
         return log_and_format_error("import_contacts", e, contacts=contacts)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Export Contacts", openWorldHint=True, readOnlyHint=True)
 )
 async def export_contacts() -> str:
@@ -2050,7 +2069,7 @@ async def export_contacts() -> str:
         return log_and_format_error("export_contacts", e)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Get Blocked Users", openWorldHint=True, readOnlyHint=True)
 )
 async def get_blocked_users() -> str:
@@ -2064,7 +2083,7 @@ async def get_blocked_users() -> str:
         return log_and_format_error("get_blocked_users", e)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Create Channel", openWorldHint=True, destructiveHint=True)
 )
 async def create_channel(title: str, about: str = "", megagroup: bool = False) -> str:
@@ -2082,7 +2101,7 @@ async def create_channel(title: str, about: str = "", megagroup: bool = False) -
         )
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Edit Chat Title", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -2106,7 +2125,7 @@ async def edit_chat_title(chat_id: Union[int, str], title: str) -> str:
         return log_and_format_error("edit_chat_title", e, chat_id=chat_id, title=title)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Edit Chat Photo", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -2144,7 +2163,7 @@ async def edit_chat_photo(chat_id: Union[int, str], file_path: str) -> str:
         return log_and_format_error("edit_chat_photo", e, chat_id=chat_id, file_path=file_path)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Delete Chat Photo", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -2177,7 +2196,7 @@ async def delete_chat_photo(chat_id: Union[int, str]) -> str:
         return log_and_format_error("delete_chat_photo", e, chat_id=chat_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Promote Admin", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -2248,7 +2267,7 @@ async def promote_admin(
         return log_and_format_error("promote_admin", e, group_id=group_id, user_id=user_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Demote Admin", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -2301,7 +2320,7 @@ async def demote_admin(group_id: Union[int, str], user_id: Union[int, str]) -> s
         return log_and_format_error("demote_admin", e, group_id=group_id, user_id=user_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Ban User", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -2352,7 +2371,7 @@ async def ban_user(chat_id: Union[int, str], user_id: Union[int, str]) -> str:
         return log_and_format_error("ban_user", e, chat_id=chat_id, user_id=user_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Unban User", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -2403,7 +2422,7 @@ async def unban_user(chat_id: Union[int, str], user_id: Union[int, str]) -> str:
         return log_and_format_error("unban_user", e, chat_id=chat_id, user_id=user_id)
 
 
-@mcp.tool(annotations=ToolAnnotations(title="Get Admins", openWorldHint=True, readOnlyHint=True))
+@_tool(annotations=ToolAnnotations(title="Get Admins", openWorldHint=True, readOnlyHint=True))
 @validate_id("chat_id")
 async def get_admins(chat_id: Union[int, str]) -> str:
     """
@@ -2422,7 +2441,7 @@ async def get_admins(chat_id: Union[int, str]) -> str:
         return log_and_format_error("get_admins", e, chat_id=chat_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Get Banned Users", openWorldHint=True, readOnlyHint=True)
 )
 @validate_id("chat_id")
@@ -2445,7 +2464,7 @@ async def get_banned_users(chat_id: Union[int, str]) -> str:
         return log_and_format_error("get_banned_users", e, chat_id=chat_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Get Invite Link", openWorldHint=True, readOnlyHint=True)
 )
 @validate_id("chat_id")
@@ -2491,7 +2510,7 @@ async def get_invite_link(chat_id: Union[int, str]) -> str:
         return log_and_format_error("get_invite_link", e, chat_id=chat_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Join Chat By Link", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -2539,7 +2558,7 @@ async def join_chat_by_link(link: str) -> str:
         return f"Error joining chat: {e}"
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Export Chat Invite", openWorldHint=True, readOnlyHint=True)
 )
 @validate_id("chat_id")
@@ -2576,7 +2595,7 @@ async def export_chat_invite(chat_id: Union[int, str]) -> str:
         return log_and_format_error("export_chat_invite", e, chat_id=chat_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Import Chat Invite", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -2637,7 +2656,7 @@ async def import_chat_invite(hash: str) -> str:
         return log_and_format_error("import_chat_invite", e, hash=hash)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Send Voice", openWorldHint=True, destructiveHint=True)
 )
 @validate_id("chat_id")
@@ -2673,7 +2692,7 @@ async def send_voice(chat_id: Union[int, str], file_path: str) -> str:
         return log_and_format_error("send_voice", e, chat_id=chat_id, file_path=file_path)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Forward Message", openWorldHint=True, destructiveHint=True)
 )
 @validate_id("from_chat_id", "to_chat_id")
@@ -2698,7 +2717,7 @@ async def forward_message(
         )
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Edit Message", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -2718,7 +2737,7 @@ async def edit_message(chat_id: Union[int, str], message_id: int, new_text: str)
         )
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Delete Message", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -2736,7 +2755,7 @@ async def delete_message(chat_id: Union[int, str], message_id: int) -> str:
         return log_and_format_error("delete_message", e, chat_id=chat_id, message_id=message_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Pin Message", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -2754,7 +2773,7 @@ async def pin_message(chat_id: Union[int, str], message_id: int) -> str:
         return log_and_format_error("pin_message", e, chat_id=chat_id, message_id=message_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Unpin Message", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -2772,7 +2791,7 @@ async def unpin_message(chat_id: Union[int, str], message_id: int) -> str:
         return log_and_format_error("unpin_message", e, chat_id=chat_id, message_id=message_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Mark As Read", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -2790,7 +2809,7 @@ async def mark_as_read(chat_id: Union[int, str]) -> str:
         return log_and_format_error("mark_as_read", e, chat_id=chat_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Reply To Message", openWorldHint=True, destructiveHint=True)
 )
 @validate_id("chat_id")
@@ -2808,7 +2827,7 @@ async def reply_to_message(chat_id: Union[int, str], message_id: int, text: str)
         )
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Get Media Info", openWorldHint=True, readOnlyHint=True)
 )
 @validate_id("chat_id")
@@ -2832,7 +2851,7 @@ async def get_media_info(chat_id: Union[int, str], message_id: int) -> str:
         return log_and_format_error("get_media_info", e, chat_id=chat_id, message_id=message_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Search Public Chats", openWorldHint=True, readOnlyHint=True)
 )
 async def search_public_chats(query: str) -> str:
@@ -2846,7 +2865,7 @@ async def search_public_chats(query: str) -> str:
         return log_and_format_error("search_public_chats", e, query=query)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Search Messages", openWorldHint=True, readOnlyHint=True)
 )
 @validate_id("chat_id")
@@ -2874,7 +2893,7 @@ async def search_messages(chat_id: Union[int, str], query: str, limit: int = 20)
         )
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Resolve Username", openWorldHint=True, readOnlyHint=True)
 )
 async def resolve_username(username: str) -> str:
@@ -2888,7 +2907,7 @@ async def resolve_username(username: str) -> str:
         return log_and_format_error("resolve_username", e, username=username)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Mute Chat", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -2931,7 +2950,7 @@ async def mute_chat(chat_id: Union[int, str]) -> str:
         return log_and_format_error("mute_chat", e, chat_id=chat_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Unmute Chat", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -2974,7 +2993,7 @@ async def unmute_chat(chat_id: Union[int, str]) -> str:
         return log_and_format_error("unmute_chat", e, chat_id=chat_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Archive Chat", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -2997,7 +3016,7 @@ async def archive_chat(chat_id: Union[int, str]) -> str:
         return log_and_format_error("archive_chat", e, chat_id=chat_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Unarchive Chat", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -3020,7 +3039,7 @@ async def unarchive_chat(chat_id: Union[int, str]) -> str:
         return log_and_format_error("unarchive_chat", e, chat_id=chat_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Get Sticker Sets", openWorldHint=True, readOnlyHint=True)
 )
 async def get_sticker_sets() -> str:
@@ -3034,7 +3053,7 @@ async def get_sticker_sets() -> str:
         return log_and_format_error("get_sticker_sets", e)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Send Sticker", openWorldHint=True, destructiveHint=True)
 )
 @validate_id("chat_id")
@@ -3061,7 +3080,7 @@ async def send_sticker(chat_id: Union[int, str], file_path: str) -> str:
         return log_and_format_error("send_sticker", e, chat_id=chat_id, file_path=file_path)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Get Gif Search", openWorldHint=True, readOnlyHint=True)
 )
 async def get_gif_search(query: str, limit: int = 10) -> str:
@@ -3119,7 +3138,7 @@ async def get_gif_search(query: str, limit: int = 10) -> str:
         return log_and_format_error("get_gif_search", e, query=query, limit=limit)
 
 
-@mcp.tool(annotations=ToolAnnotations(title="Send Gif", openWorldHint=True, destructiveHint=True))
+@_tool(annotations=ToolAnnotations(title="Send Gif", openWorldHint=True, destructiveHint=True))
 @validate_id("chat_id")
 async def send_gif(chat_id: Union[int, str], gif_id: int) -> str:
     """
@@ -3139,7 +3158,7 @@ async def send_gif(chat_id: Union[int, str], gif_id: int) -> str:
         return log_and_format_error("send_gif", e, chat_id=chat_id, gif_id=gif_id)
 
 
-@mcp.tool(annotations=ToolAnnotations(title="Get Bot Info", openWorldHint=True, readOnlyHint=True))
+@_tool(annotations=ToolAnnotations(title="Get Bot Info", openWorldHint=True, readOnlyHint=True))
 async def get_bot_info(bot_username: str) -> str:
     """
     Get information about a bot by username.
@@ -3175,7 +3194,7 @@ async def get_bot_info(bot_username: str) -> str:
         return log_and_format_error("get_bot_info", e, bot_username=bot_username)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Set Bot Commands", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -3226,7 +3245,7 @@ async def set_bot_commands(bot_username: str, commands: list) -> str:
         return log_and_format_error("set_bot_commands", e, bot_username=bot_username)
 
 
-@mcp.tool(annotations=ToolAnnotations(title="Get History", openWorldHint=True, readOnlyHint=True))
+@_tool(annotations=ToolAnnotations(title="Get History", openWorldHint=True, readOnlyHint=True))
 @validate_id("chat_id")
 async def get_history(chat_id: Union[int, str], limit: int = 100) -> str:
     """
@@ -3250,7 +3269,7 @@ async def get_history(chat_id: Union[int, str], limit: int = 100) -> str:
         return log_and_format_error("get_history", e, chat_id=chat_id, limit=limit)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Get User Photos", openWorldHint=True, readOnlyHint=True)
 )
 @validate_id("user_id")
@@ -3268,7 +3287,7 @@ async def get_user_photos(user_id: Union[int, str], limit: int = 10) -> str:
         return log_and_format_error("get_user_photos", e, user_id=user_id, limit=limit)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Get User Status", openWorldHint=True, readOnlyHint=True)
 )
 @validate_id("user_id")
@@ -3283,7 +3302,7 @@ async def get_user_status(user_id: Union[int, str]) -> str:
         return log_and_format_error("get_user_status", e, user_id=user_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Get Recent Actions", openWorldHint=True, readOnlyHint=True)
 )
 @validate_id("chat_id")
@@ -3314,7 +3333,7 @@ async def get_recent_actions(chat_id: Union[int, str]) -> str:
         return log_and_format_error("get_recent_actions", e, chat_id=chat_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Get Pinned Messages", openWorldHint=True, readOnlyHint=True)
 )
 @validate_id("chat_id")
@@ -3355,7 +3374,7 @@ async def get_pinned_messages(chat_id: Union[int, str]) -> str:
         return log_and_format_error("get_pinned_messages", e, chat_id=chat_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(title="Create Poll", openWorldHint=True, destructiveHint=True)
 )
 async def create_poll(
@@ -3430,7 +3449,7 @@ async def create_poll(
         )
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Send Reaction", openWorldHint=True, destructiveHint=False, idempotentHint=True
     )
@@ -3473,7 +3492,7 @@ async def send_reaction(
         )
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Remove Reaction", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -3505,7 +3524,7 @@ async def remove_reaction(
         return log_and_format_error("remove_reaction", e, chat_id=chat_id, message_id=message_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Get Message Reactions", openWorldHint=True, readOnlyHint=True, idempotentHint=True
     )
@@ -3581,7 +3600,7 @@ async def get_message_reactions(
 # ============================================================================
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Save Draft", openWorldHint=True, destructiveHint=False, idempotentHint=True
     )
@@ -3628,7 +3647,7 @@ async def save_draft(
         return log_and_format_error("save_draft", e, chat_id=chat_id)
 
 
-@mcp.tool(annotations=ToolAnnotations(title="Get Drafts", openWorldHint=True, readOnlyHint=True))
+@_tool(annotations=ToolAnnotations(title="Get Drafts", openWorldHint=True, readOnlyHint=True))
 async def get_drafts() -> str:
     """
     Get all draft messages across all chats.
@@ -3685,7 +3704,7 @@ async def get_drafts() -> str:
         return log_and_format_error("get_drafts", e)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Clear Draft", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -3720,7 +3739,7 @@ async def clear_draft(chat_id: Union[int, str]) -> str:
 # ============================================================================
 
 
-@mcp.tool(annotations=ToolAnnotations(title="List Folders", openWorldHint=True, readOnlyHint=True))
+@_tool(annotations=ToolAnnotations(title="List Folders", openWorldHint=True, readOnlyHint=True))
 async def list_folders() -> str:
     """
     Get all dialog folders (filters) with their IDs, names, and emoji.
@@ -3769,7 +3788,7 @@ async def list_folders() -> str:
         return log_and_format_error("list_folders", e, ErrorCategory.FOLDER)
 
 
-@mcp.tool(annotations=ToolAnnotations(title="Get Folder", openWorldHint=True, readOnlyHint=True))
+@_tool(annotations=ToolAnnotations(title="Get Folder", openWorldHint=True, readOnlyHint=True))
 async def get_folder(folder_id: int) -> str:
     """
     Get detailed information about a specific folder including all included chats.
@@ -3868,7 +3887,7 @@ async def get_folder(folder_id: int) -> str:
         return log_and_format_error("get_folder", e, ErrorCategory.FOLDER, folder_id=folder_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Create Folder", openWorldHint=True, destructiveHint=True, idempotentHint=False
     )
@@ -3968,7 +3987,7 @@ async def create_folder(
         return log_and_format_error("create_folder", e, ErrorCategory.FOLDER, title=title)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Add Chat to Folder", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -4058,7 +4077,7 @@ async def add_chat_to_folder(
         )
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Remove Chat from Folder",
         openWorldHint=True,
@@ -4157,7 +4176,7 @@ async def remove_chat_from_folder(folder_id: int, chat_id: Union[int, str]) -> s
         )
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Delete Folder", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -4201,7 +4220,7 @@ async def delete_folder(folder_id: int) -> str:
         return log_and_format_error("delete_folder", e, ErrorCategory.FOLDER, folder_id=folder_id)
 
 
-@mcp.tool(
+@_tool(
     annotations=ToolAnnotations(
         title="Reorder Folders", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
@@ -4247,6 +4266,8 @@ async def _run_stdio() -> None:
     """Run MCP server over stdio (default: client spawns this process)."""
     print("Starting Telegram client...")
     try:
+        if READ_ONLY:
+            print("Read-only mode: only read tools exposed (no send, edit, react, etc.)")
         await client.start()
         print("Telegram client started. Running MCP server...")
     except Exception as e:

--- a/main.py
+++ b/main.py
@@ -96,7 +96,11 @@ SESSION_STRING = os.getenv("TELEGRAM_SESSION_STRING")
 MCP_HTTP = os.getenv("TELEGRAM_MCP_HTTP", "").lower() in ("true", "1", "yes")
 MCP_HTTP_PORT = int(os.getenv("TELEGRAM_MCP_HTTP_PORT", "8000"))
 
-mcp = FastMCP("telegram")
+mcp = FastMCP(
+    "telegram",
+    host="0.0.0.0" if MCP_HTTP else "127.0.0.1",
+    port=MCP_HTTP_PORT,
+)
 
 if SESSION_STRING:
     # Use the string session if available
@@ -4248,7 +4252,7 @@ def main() -> None:
     if MCP_HTTP:
         print(f"MCP server running at http://0.0.0.0:{MCP_HTTP_PORT}/mcp")
         print("Connect Cursor with: {\"url\": \"http://localhost:" + str(MCP_HTTP_PORT) + "/mcp\"}")
-        mcp.run(transport="streamable-http", host="0.0.0.0", port=MCP_HTTP_PORT)
+        mcp.run(transport="streamable-http")
     else:
         print("Running MCP server (stdio)...")
         asyncio.run(_run_stdio())

--- a/main.py
+++ b/main.py
@@ -99,6 +99,10 @@ MCP_HTTP_PORT = int(os.getenv("TELEGRAM_MCP_HTTP_PORT", "8000"))
 
 # Read-only mode: when set, only expose tools that read data (no send, edit, delete, react, etc.)
 READ_ONLY = os.getenv("TELEGRAM_READ_ONLY", "").lower() in ("true", "1", "yes")
+# HTTP transport: when set, run as HTTP server so clients (e.g. Cursor) can connect via URL.
+# Default: False (stdio) when running directly. Docker Compose sets this to True automatically.
+MCP_HTTP = os.getenv("TELEGRAM_MCP_HTTP", "").lower() in ("true", "1", "yes")
+MCP_HTTP_PORT = int(os.getenv("TELEGRAM_MCP_HTTP_PORT", "8000"))
 
 
 def _tool(annotations=None, **kwargs):
@@ -4262,6 +4266,7 @@ async def reorder_folders(folder_ids: List[int]) -> str:
         )
 
 
+<<<<<<< HEAD
 async def _run_stdio() -> None:
     """Run MCP server over stdio (default: client spawns this process)."""
     print("Starting Telegram client...")
@@ -4270,6 +4275,26 @@ async def _run_stdio() -> None:
             print("Read-only mode: only read tools exposed (no send, edit, react, etc.)")
         await client.start()
         print("Telegram client started. Running MCP server...")
+=======
+async def _connect_client() -> None:
+    """Connect the Telethon client. Must run before MCP server starts."""
+    print("Starting Telegram client...")
+    if READ_ONLY:
+        print("Read-only mode: only read tools exposed (no send, edit, react, etc.)")
+    await client.start()
+    print("Telegram client started.")
+
+
+async def _run_stdio() -> None:
+    """Run MCP server over stdio (default: client spawns this process)."""
+    await mcp.run_stdio_async()
+
+
+def main() -> None:
+    nest_asyncio.apply()
+    try:
+        asyncio.run(_connect_client())
+>>>>>>> e7a74d2 (feat: add HTTP transport - server runs, Cursor connects via URL)
     except Exception as e:
         print(f"Error starting client: {e}", file=sys.stderr)
         if isinstance(e, sqlite3.OperationalError) and "database is locked" in str(e):
@@ -4287,6 +4312,7 @@ async def _run_stdio() -> None:
         sys.exit(1)
     await mcp.run_stdio_async()
 
+<<<<<<< HEAD
 
 def main() -> None:
     nest_asyncio.apply()
@@ -4294,6 +4320,12 @@ def main() -> None:
         print(f"MCP server running at http://0.0.0.0:{MCP_HTTP_PORT}/mcp")
         print("Connect Cursor with: {\"url\": \"http://localhost:" + str(MCP_HTTP_PORT) + "/mcp\"}")
         mcp.run(transport="streamable-http")
+=======
+    if MCP_HTTP:
+        print(f"MCP server running at http://0.0.0.0:{MCP_HTTP_PORT}/mcp")
+        print("Connect Cursor with: {\"url\": \"http://localhost:" + str(MCP_HTTP_PORT) + "/mcp\"}")
+        mcp.run(transport="streamable-http", host="0.0.0.0", port=MCP_HTTP_PORT)
+>>>>>>> e7a74d2 (feat: add HTTP transport - server runs, Cursor connects via URL)
     else:
         print("Running MCP server (stdio)...")
         asyncio.run(_run_stdio())

--- a/main.py
+++ b/main.py
@@ -4236,6 +4236,13 @@ def main() -> None:
                 "Database lock detected. Please ensure no other instances are running.",
                 file=sys.stderr,
             )
+        elif "EOF when reading a line" in str(e) or "Please enter your phone" in str(e):
+            print(
+                "Docker/non-interactive: Telethon needs a pre-authorized session. "
+                "Run 'uv run session_string_generator.py' locally (with TTY), then add "
+                "TELEGRAM_SESSION_STRING to your .env before using Docker.",
+                file=sys.stderr,
+            )
         sys.exit(1)
 
     if MCP_HTTP:

--- a/main.py
+++ b/main.py
@@ -100,19 +100,6 @@ MCP_HTTP_PORT = int(os.getenv("TELEGRAM_MCP_HTTP_PORT", "8000"))
 # Read-only mode: when set, only expose tools that read data (no send, edit, delete, react, etc.)
 READ_ONLY = os.getenv("TELEGRAM_READ_ONLY", "").lower() in ("true", "1", "yes")
 
-def _tool(annotations=None, **kwargs):
-    """
-    Register a tool with MCP. In read-only mode, only tools with readOnlyHint=True
-    are registered; write tools are skipped so the agent cannot send, edit, or
-    otherwise modify Telegram state.
-    """
-    is_read_only = annotations and getattr(annotations, "readOnlyHint", False)
-    if not is_read_only and READ_ONLY:
-        def _noop(f):
-            return f
-        return _noop
-    return mcp.tool(annotations=annotations, **kwargs)
-
 if SESSION_STRING:
     client = TelegramClient(StringSession(SESSION_STRING), TELEGRAM_API_ID, TELEGRAM_API_HASH)
 else:
@@ -152,6 +139,19 @@ mcp = FastMCP(
     port=MCP_HTTP_PORT,
     lifespan=_telegram_lifespan,
 )
+
+def _tool(annotations=None, **kwargs):
+    """
+    Register a tool with MCP. In read-only mode, only tools with readOnlyHint=True
+    are registered; write tools are skipped so the agent cannot send, edit, or
+    otherwise modify Telegram state.
+    """
+    is_read_only = annotations and getattr(annotations, "readOnlyHint", False)
+    if not is_read_only and READ_ONLY:
+        def _noop(f):
+            return f
+        return _noop
+    return mcp.tool(annotations=annotations, **kwargs)
 
 # Setup robust logging with both file and console output
 logger = logging.getLogger("telegram_mcp")


### PR DESCRIPTION
## Summary

Adds HTTP transport so the server can run independently and Cursor connects via URL instead of spawning the process. Improves Docker UX and fixes event loop issues when using HTTP transport.

## Motivation

**Why HTTP transport?** With stdio, Cursor spawns the MCP server process. In Docker, that means starting a new container per connection, which is slow and awkward. HTTP transport lets the server run as a long-lived process; Cursor connects via `http://localhost:8000/mcp` instead of spawning it. The server stays up, and Cursor can reconnect without restarting.

**Why the lifespan fix?** In HTTP mode, the Telethon client was started with `asyncio.run()` in one event loop, while the HTTP server (uvicorn) runs in another. Tool calls run in the server's loop, so Telethon raised `RuntimeError: The asyncio event loop must not change after connection`. Using FastMCP's `lifespan` to connect the client when the server starts keeps the client and tools in the same event loop.

**Why require a session string for Docker?** Telethon's first-time auth prompts for phone number and code via stdin. Docker containers don't have an interactive TTY, so that flow fails with `EOF when reading a line`. Generating a session string locally with `uv run session_string_generator.py` and setting `TELEGRAM_SESSION_STRING` in `.env` before running in Docker avoids this.

## Changes

- Add `TELEGRAM_MCP_HTTP` and `TELEGRAM_MCP_HTTP_PORT` env vars
- Docker Compose uses HTTP by default (stdio for direct runs)
- Use FastMCP lifespan to connect Telethon in the server's event loop (HTTP mode)
- Expose port 8000; document Cursor URL config in README
- Document session string requirement for Docker; add EOF error hint when Telethon prompts for login in a non-interactive environment