### PR TITLE
feat: add unread_only, unmuted_only filters and mute status to list_chats

### DIFF
--- a/main.py
+++ b/main.py
@@ -1248,13 +1248,15 @@ async def list_topics(
 
 
 @mcp.tool(annotations=ToolAnnotations(title="List Chats", openWorldHint=True, readOnlyHint=True))
-async def list_chats(chat_type: str = None, limit: int = 20) -> str:
+async def list_chats(chat_type: str = None, limit: int = 20, unread_only: bool = False, unmuted_only: bool = False) -> str:
     """
     List available chats with metadata.
 
     Args:
         chat_type: Filter by chat type ('user', 'group', 'channel', or None for all)
-        limit: Maximum number of chats to retrieve.
+        limit: Maximum number of chats to retrieve from Telegram API (applied before filtering, so fewer results may be returned when filters are active).
+        unread_only: If True, only return chats with unread messages.
+        unmuted_only: If True, only return unmuted chats.
     """
     try:
         dialogs = await client.get_dialogs(limit=limit)
@@ -1293,12 +1295,32 @@ async def list_chats(chat_type: str = None, limit: int = 20) -> str:
                 bool(getattr(inner_dialog, "unread_mark", False)) if inner_dialog else False
             )
 
+            # Extract mute status from notify_settings
+            notify_settings = getattr(inner_dialog, "notify_settings", None)
+            mute_until = getattr(notify_settings, "mute_until", None)
+            if mute_until is None:
+                is_muted = False
+            elif isinstance(mute_until, datetime):
+                is_muted = mute_until.timestamp() > time.time()
+            else:
+                is_muted = mute_until > time.time()
+
+            # Filter by mute status if requested
+            if unmuted_only and is_muted:
+                continue
+
+            # Filter by unread status if requested
+            if unread_only and unread_count == 0 and not unread_mark:
+                continue
+
             if unread_count > 0:
                 chat_info += f", Unread: {unread_count}"
             elif unread_mark:
                 chat_info += ", Unread: marked"
             else:
                 chat_info += ", No unread messages"
+
+            chat_info += f", Muted: {'yes' if is_muted else 'no'}"
 
             results.append(chat_info)
 
@@ -1307,7 +1329,7 @@ async def list_chats(chat_type: str = None, limit: int = 20) -> str:
 
         return "\n".join(results)
     except Exception as e:
-        return log_and_format_error("list_chats", e, chat_type=chat_type, limit=limit)
+        return log_and_format_error("list_chats", e, chat_type=chat_type, limit=limit, unread_only=unread_only, unmuted_only=unmuted_only)
 
 
 @mcp.tool(annotations=ToolAnnotations(title="Get Chat", openWorldHint=True, readOnlyHint=True))

--- a/main.py
+++ b/main.py
@@ -1248,7 +1248,9 @@ async def list_topics(
 
 
 @mcp.tool(annotations=ToolAnnotations(title="List Chats", openWorldHint=True, readOnlyHint=True))
-async def list_chats(chat_type: str = None, limit: int = 20, unread_only: bool = False, unmuted_only: bool = False) -> str:
+async def list_chats(
+    chat_type: str = None, limit: int = 20, unread_only: bool = False, unmuted_only: bool = False
+) -> str:
     """
     List available chats with metadata.
 
@@ -1329,7 +1331,14 @@ async def list_chats(chat_type: str = None, limit: int = 20, unread_only: bool =
 
         return "\n".join(results)
     except Exception as e:
-        return log_and_format_error("list_chats", e, chat_type=chat_type, limit=limit, unread_only=unread_only, unmuted_only=unmuted_only)
+        return log_and_format_error(
+            "list_chats",
+            e,
+            chat_type=chat_type,
+            limit=limit,
+            unread_only=unread_only,
+            unmuted_only=unmuted_only,
+        )
 
 
 @mcp.tool(annotations=ToolAnnotations(title="Get Chat", openWorldHint=True, readOnlyHint=True))


### PR DESCRIPTION
## Summary

- Add `unread_only` parameter to `list_chats` to filter chats with unread messages only
- Add `unmuted_only` parameter to `list_chats` to filter out muted chats
- Display mute status (`Muted: yes/no`) in chat info output
- Mute detection based on `notify_settings.mute_until` from Telegram API

These filters are useful for MCP clients (e.g. Claude) to focus on relevant conversations without manually scanning through all chats.

## Test plan

- [ ] Call `list_chats()` without new params — should behave as before, plus show mute status
- [ ] Call `list_chats(unread_only=True)` — only chats with unread messages returned
- [ ] Call `list_chats(unmuted_only=True)` — muted chats excluded
- [ ] Call with both filters combined
- [ ] Verify mute status displays correctly for muted and unmuted chats

🤖 Generated with [Claude Code](https://claude.com/claude-code)