### PR TITLE
feat: show unread mentions count in list_chats output

### DIFF
--- a/main.py
+++ b/main.py
@@ -1323,6 +1323,11 @@ async def list_chats(chat_type: str = None, limit: int = 20) -> str:
             else:
                 chat_info += ", No unread messages"
 
+            # Add unread mentions count if available
+            unread_mentions = getattr(dialog, "unread_mentions_count", 0) or 0
+            if unread_mentions > 0:
+                chat_info += f", Unread mentions: {unread_mentions}"
+
             results.append(chat_info)
 
         if not results:


### PR DESCRIPTION
## Summary
- Display `unread_mentions_count` for each chat in `list_chats` output when the count is greater than zero
- The value is already available on the dialog object from Telegram API, so this adds no extra API calls
- Follows the existing pattern of conditionally showing fields (like `Unread` and `Username`)

## Test plan
- [ ] Call `list_chats` and verify chats with unread mentions show `Unread mentions: N`
- [ ] Verify chats with zero unread mentions do not include the field in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)