### PR TITLE
Fix channel/chat IDs being misinterpreted as user IDs

### DIFF
--- a/telegram_mcp/runtime.py
+++ b/telegram_mcp/runtime.py
@@ -76,6 +76,15 @@ def get_entity_type(entity: Any) -> str:
     return type(entity).__name__
 
 
+def get_marked_id(entity: Any) -> int:
+    """Return a Telethon-compatible marked ID for an entity."""
+    if isinstance(entity, Channel):
+        return -1000000000000 - entity.id
+    if isinstance(entity, Chat):
+        return -entity.id
+    return entity.id
+
+
 def get_entity_filter_type(entity: Any) -> Optional[str]:
     """Return list_chats-compatible filter type: user/group/channel."""
     entity_type = get_entity_type(entity)
@@ -617,7 +626,7 @@ def format_entity(entity) -> Dict[str, Any]:
 
     Names and titles are sanitized to prevent prompt injection.
     """
-    result = {"id": entity.id}
+    result = {"id": get_marked_id(entity)}
 
     if hasattr(entity, "title"):
         result["name"] = sanitize_name(entity.title)

--- a/telegram_mcp/tools/chats.py
+++ b/telegram_mcp/tools/chats.py
@@ -29,7 +29,7 @@ async def get_chats(account: str = None, page: int = 1, page_size: int = 20) -> 
             title = getattr(entity, "title", None) or getattr(entity, "first_name", "Unknown")
             records.append(
                 {
-                    "chat_id": entity.id,
+                    "chat_id": get_marked_id(entity),
                     "title": sanitize_name(title),
                 }
             )
@@ -212,7 +212,7 @@ async def list_chats(
                 continue
 
             # Build chat record
-            record = {"chat_id": entity.id}
+            record = {"chat_id": get_marked_id(entity)}
 
             if hasattr(entity, "title"):
                 record["title"] = sanitize_name(entity.title)
@@ -323,7 +323,7 @@ async def get_chat(chat_id: Union[int, str], account: str = None) -> str:
         cl = get_client(account)
         entity = await resolve_entity(chat_id, cl)
 
-        record = {"id": entity.id}
+        record = {"id": get_marked_id(entity)}
 
         is_user = isinstance(entity, User)
 
@@ -444,7 +444,7 @@ async def get_full_chat(chat_id: Union[int, str], account: str = None) -> str:
         full_chat = full.full_chat
 
         result = {
-            "id": chat.id if chat else None,
+            "id": get_marked_id(chat) if chat else None,
             "title": sanitize_name(getattr(chat, "title", None)) if chat else None,
             "username": getattr(chat, "username", None) if chat else None,
             "about": sanitize_user_content(full_chat.about or "", max_length=1024),
@@ -636,7 +636,7 @@ async def get_common_chats(
 
         lines = []
         for chat in chats:
-            line = f"Chat ID: {chat.id}"
+            line = f"Chat ID: {get_marked_id(chat)}"
             if hasattr(chat, "title") and chat.title:
                 line += f", Title: {sanitize_name(chat.title)}"
             line += f", Type: {get_entity_type(chat)}"

--- a/telegram_mcp/tools/contacts.py
+++ b/telegram_mcp/tools/contacts.py
@@ -144,7 +144,7 @@ async def get_direct_chat_by_contact(contact_query: str, account: str = None) ->
             for dialog in dialogs:
                 if isinstance(dialog.entity, User) and dialog.entity.id == contact.id:
                     record = {
-                        "chat_id": dialog.entity.id,
+                        "chat_id": get_marked_id(dialog.entity),
                         "contact": contact_name,
                     }
                     if getattr(contact, "username", ""):
@@ -196,7 +196,7 @@ async def get_contact_chats(contact_id: Union[int, str], account: str = None) ->
         # Look for direct chat
         for dialog in dialogs:
             if isinstance(dialog.entity, User) and dialog.entity.id == contact_id:
-                record = {"chat_id": dialog.entity.id, "type": "Private"}
+                record = {"chat_id": get_marked_id(dialog.entity), "type": "Private"}
                 if dialog.unread_count:
                     record["unread"] = dialog.unread_count
                 records.append(record)
@@ -208,7 +208,7 @@ async def get_contact_chats(contact_id: Union[int, str], account: str = None) ->
             for chat in common:
                 records.append(
                     {
-                        "chat_id": chat.id,
+                        "chat_id": get_marked_id(chat),
                         "title": sanitize_name(chat.title),
                         "type": get_entity_type(chat),
                     }

--- a/telegram_mcp/tools/folders.py
+++ b/telegram_mcp/tools/folders.py
@@ -100,7 +100,7 @@ async def get_folder(folder_id: int, account: str = None) -> str:
             try:
                 entity = await resolve_entity(peer, cl)
                 chat_info = {
-                    "id": entity.id,
+                    "id": get_marked_id(entity),
                     "name": sanitize_name(
                         getattr(entity, "title", None) or getattr(entity, "first_name", "Unknown")
                     ),
@@ -118,7 +118,7 @@ async def get_folder(folder_id: int, account: str = None) -> str:
             try:
                 entity = await resolve_entity(peer, cl)
                 chat_info = {
-                    "id": entity.id,
+                    "id": get_marked_id(entity),
                     "name": sanitize_name(
                         getattr(entity, "title", None) or getattr(entity, "first_name", "Unknown")
                     ),
@@ -134,7 +134,7 @@ async def get_folder(folder_id: int, account: str = None) -> str:
             try:
                 entity = await resolve_entity(peer, cl)
                 chat_info = {
-                    "id": entity.id,
+                    "id": get_marked_id(entity),
                     "name": sanitize_name(
                         getattr(entity, "title", None) or getattr(entity, "first_name", "Unknown")
                     ),

--- a/telegram_mcp/tools/groups.py
+++ b/telegram_mcp/tools/groups.py
@@ -41,9 +41,9 @@ async def create_group(title: str, user_ids: List[Union[int, str]], account: str
             # Check what type of response we got
             if hasattr(result, "chats") and result.chats:
                 created_chat = result.chats[0]
-                return f"Group created with ID: {created_chat.id}"
+                return f"Group created with ID: {get_marked_id(created_chat)}"
             elif hasattr(result, "chat") and result.chat:
-                return f"Group created with ID: {result.chat.id}"
+                return f"Group created with ID: {get_marked_id(result.chat)}"
             elif hasattr(result, "chat_id"):
                 return f"Group created with ID: {result.chat_id}"
             else:
@@ -53,7 +53,7 @@ async def create_group(title: str, user_ids: List[Union[int, str]], account: str
                 dialogs = await cl.get_dialogs(limit=5)  # Get recent dialogs
                 for dialog in dialogs:
                     if dialog.title == title:
-                        return f"Group created with ID: {dialog.id}"
+                        return f"Group created with ID: {get_marked_id(dialog.entity)}"
 
                 # If we still can't find it, at least return success
                 return f"Group created successfully. Please check your recent chats for '{sanitize_name(title)}'."

--- a/telegram_mcp/tools/profile.py
+++ b/telegram_mcp/tools/profile.py
@@ -308,7 +308,7 @@ async def get_bot_info(bot_username: str, account: str = None) -> str:
         # user content (names, about) directly in the tool result.
         info = {
             "bot_info": {
-                "id": entity.id,
+                "id": get_marked_id(entity),
                 "username": entity.username,
                 "first_name": sanitize_name(entity.first_name),
                 "last_name": sanitize_name(getattr(entity, "last_name", "")),

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -459,6 +459,10 @@ def test_entity_type_filter_and_formatting_helpers():
     assert runtime.get_entity_type(supergroup) == "Supergroup"
     assert runtime.get_entity_filter_type(supergroup) == "group"
     assert runtime.get_entity_filter_type(object()) is None
+    assert runtime.get_marked_id(user) == 1
+    assert runtime.get_marked_id(chat) == -2
+    assert runtime.get_marked_id(channel) == -1000000000003
+    assert runtime.get_marked_id(supergroup) == -1000000000004
 
     assert runtime.format_entity(user) == {
         "id": 1,
@@ -467,8 +471,12 @@ def test_entity_type_filter_and_formatting_helpers():
         "username": "jdoe",
         "phone": "123",
     }
-    assert runtime.format_entity(chat) == {"id": 2, "name": "GroupName", "type": "group"}
-    assert runtime.format_entity(channel) == {"id": 3, "name": "Channel", "type": "channel"}
+    assert runtime.format_entity(chat) == {"id": -2, "name": "GroupName", "type": "group"}
+    assert runtime.format_entity(channel) == {
+        "id": -1000000000003,
+        "name": "Channel",
+        "type": "channel",
+    }
 
 
 def test_message_formatting_sender_and_engagement_helpers():


### PR DESCRIPTION
## What's broken

Telethon uses unmarked IDs internally — positive integers for everything. When the server returns these raw IDs to callers (say, from `list_chats`), and the caller passes them back into `get_entity(int)`, Telethon sees a positive number and assumes it's a user. Channels and group chats get a `ValueError: Could not find the input entity for PeerUser`.

Any "list chats → pick one → do something" workflow breaks intermittently, especially after long sessions when entity cache expires.

## The fix

`get_marked_id()` helper that converts entity IDs to Telethon's marked format before returning:
- Channels: `-100{id}` (PeerChannel)
- Chats: `-{id}` (PeerChat)
- Users: unchanged

Applied in all places where entity IDs go out to callers: `list_chats`, `get_chats`, `get_chat`, `format_entity`, `get_direct_chat_by_contact`, `get_contact_chats`, `create_group`, `get_bot_info`, `get_folder`.

## How to test

- Call `list_chats`, grab a channel ID, pass it to `search_messages` or `get_history` — should work without errors
- Channel IDs now look like `-1001676885811` instead of `1676885811`