### PR TITLE
Resolve unmarked channel/chat IDs passed as positive integers

### DIFF
--- a/telegram_mcp/runtime.py
+++ b/telegram_mcp/runtime.py
@@ -638,54 +638,108 @@ def format_entity(entity) -> Dict[str, Any]:
     return result
 
 
+def _marked_id_candidates(identifier: Union[int, str]) -> list[int]:
+    """Return marked chat/channel ID variants for a bare positive integer ID."""
+    if not isinstance(identifier, int) or identifier <= 0:
+        return []
+
+    return [
+        -1000000000000 - identifier,
+        -identifier,
+    ]
+
+
 async def resolve_entity(identifier: Union[int, str], client=None) -> Any:
-    """Resolve entity with automatic cache warming and auto-reconnect.
+    """Resolve entity with automatic cache warming, marked-ID fallback, and reconnect.
 
     StringSession has no persistent entity cache. If get_entity() fails
     because the cache is cold (ValueError on PeerUser lookup for group IDs),
     warm the cache via get_dialogs() and retry.
 
+    If the value is a bare positive channel/chat ID, try Telethon's marked
+    channel/chat ID variants before raising.
+
     On ConnectionError, reconnects and retries once.
     """
     if client is None:
         client = get_client()
     await ensure_connected(client)
+    last_error = None
     try:
         try:
             return await client.get_entity(identifier)
-        except ValueError:
+        except ValueError as error:
+            last_error = error
             await client.get_dialogs()
-            return await client.get_entity(identifier)
+            try:
+                return await client.get_entity(identifier)
+            except ValueError as error:
+                last_error = error
     except ConnectionError:
         await ensure_connected(client)
         try:
             return await client.get_entity(identifier)
-        except ValueError:
+        except ValueError as error:
+            last_error = error
             await client.get_dialogs()
-            return await client.get_entity(identifier)
+            try:
+                return await client.get_entity(identifier)
+            except ValueError as error:
+                last_error = error
+
+    for candidate in _marked_id_candidates(identifier):
+        try:
+            return await client.get_entity(candidate)
+        except ValueError as error:
+            last_error = error
+
+    raise ValueError(
+        f"Could not resolve entity for {identifier!r}, "
+        f"including marked variants {_marked_id_candidates(identifier)}"
+    ) from last_error
 
 
 async def resolve_input_entity(identifier: Union[int, str], client=None) -> Any:
     """Like resolve_entity() but returns an InputPeer.
 
-    On ConnectionError, reconnects and retries once.
+    Uses the same cache warming, marked-ID fallback, and reconnect behavior.
     """
     if client is None:
         client = get_client()
     await ensure_connected(client)
+    last_error = None
     try:
         try:
             return await client.get_input_entity(identifier)
-        except ValueError:
+        except ValueError as error:
+            last_error = error
             await client.get_dialogs()
-            return await client.get_input_entity(identifier)
+            try:
+                return await client.get_input_entity(identifier)
+            except ValueError as error:
+                last_error = error
     except ConnectionError:
         await ensure_connected(client)
         try:
             return await client.get_input_entity(identifier)
-        except ValueError:
+        except ValueError as error:
+            last_error = error
             await client.get_dialogs()
-            return await client.get_input_entity(identifier)
+            try:
+                return await client.get_input_entity(identifier)
+            except ValueError as error:
+                last_error = error
+
+    for candidate in _marked_id_candidates(identifier):
+        try:
+            return await client.get_input_entity(candidate)
+        except ValueError as error:
+            last_error = error
+
+    raise ValueError(
+        f"Could not resolve input entity for {identifier!r}, "
+        f"including marked variants {_marked_id_candidates(identifier)}"
+    ) from last_error
 
 
 def format_message(message) -> Dict[str, Any]:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -307,6 +307,7 @@ class _ResolvingClient:
         self.method_name = method_name
         self.failures = list(failures)
         self.dialogs_loaded = 0
+        self.calls = []
 
     async def get_dialogs(self):
         self.dialogs_loaded += 1
@@ -318,6 +319,7 @@ class _ResolvingClient:
         return await self._resolve(identifier)
 
     async def _resolve(self, identifier):
+        self.calls.append(identifier)
         if self.failures:
             raise self.failures.pop(0)
         return f"{self.method_name}:{identifier}"
@@ -345,6 +347,39 @@ async def test_resolve_input_entity_retries_after_connection_error(monkeypatch):
 
     assert await runtime.resolve_input_entity("chat", client) == "input:chat"
     assert client.dialogs_loaded == 1
+
+
+def test_marked_id_candidates_only_for_positive_integers():
+    assert runtime._marked_id_candidates(123) == [-1000000000123, -123]
+    assert runtime._marked_id_candidates(0) == []
+    assert runtime._marked_id_candidates(-123) == []
+    assert runtime._marked_id_candidates("123") == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_entity_tries_marked_id_candidates_after_cache_miss(monkeypatch):
+    async def noop(_client):
+        return None
+
+    client = _ResolvingClient("entity", [ValueError("not a user"), ValueError("still cold")])
+    monkeypatch.setattr(runtime, "ensure_connected", noop)
+
+    assert await runtime.resolve_entity(123, client) == "entity:-1000000000123"
+    assert client.dialogs_loaded == 1
+    assert client.calls == [123, 123, -1000000000123]
+
+
+@pytest.mark.asyncio
+async def test_resolve_input_entity_tries_marked_id_candidates_after_cache_miss(monkeypatch):
+    async def noop(_client):
+        return None
+
+    client = _ResolvingClient("input", [ValueError("not a user"), ValueError("still cold")])
+    monkeypatch.setattr(runtime, "ensure_connected", noop)
+
+    assert await runtime.resolve_input_entity(123, client) == "input:-1000000000123"
+    assert client.dialogs_loaded == 1
+    assert client.calls == [123, 123, -1000000000123]
 
 
 def test_json_serializer_handles_supported_and_unsupported_values():


### PR DESCRIPTION
## What's broken

When a caller passes a bare channel ID like `1676885811` (without the `-100` prefix), Telethon's `get_entity(int)` runs it through `resolve_id()`, gets `PeerUser`, and looks for a user with that ID. There is no such user, so it throws `ValueError`.

The existing fallback (`get_dialogs()` cache warming) doesn't help — Telethon still reads the positive int as PeerUser on retry, so the second attempt fails the same way.

This happens often with MCP callers (LLMs, automation tools) that store or copy channel IDs as plain numbers without the `-100` marker.

## The fix

`_marked_id_candidates()` generates `-100{id}` (PeerChannel) and `-{id}` (PeerChat) from a positive int.

Both `resolve_entity()` and `resolve_input_entity()` now try these variants as a last resort: original ID first, then cache warming + retry, then marked candidates. If everything fails, the error message lists what was tried.

## How to test

- Call `resolve_username` for a channel, extract the raw `channel_id` from the response
- Pass that bare positive int to `search_messages` or `get_history` — should work now instead of throwing `ValueError`
- Negative (already marked) IDs still work as before — `_marked_id_candidates` returns an empty list for non-positive ints