### PR TITLE
feat: add edit_chat_about tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This MCP server exposes a huge suite of Telegram tools. **Every major Telegram/T
 - **invite_to_group(group_id, user_ids)**: Invite users to a group or channel
 - **create_channel(title, about, megagroup)**: Create a channel or supergroup
 - **edit_chat_title(chat_id, title)**: Change chat/group/channel title
+- **edit_chat_about(chat_id, about)**: Edit chat/group/channel description (About, max 255 chars)
 - **delete_chat_photo(chat_id)**: Remove chat/group/channel photo
 - **leave_chat(chat_id)**: Leave a group or channel
 - **get_participants(chat_id)**: List all participants

--- a/main.py
+++ b/main.py
@@ -2649,6 +2649,38 @@ async def edit_chat_photo(
 
 @mcp.tool(
     annotations=ToolAnnotations(
+        title="Edit Chat About",
+        openWorldHint=True,
+        destructiveHint=True,
+        idempotentHint=True,
+    )
+)
+@validate_id("chat_id")
+async def edit_chat_about(chat_id: Union[int, str], about: str) -> str:
+    """
+    Edit the description ("About") of a chat, group, or channel.
+
+    Args:
+        chat_id: The ID or username of the chat.
+        about: New description text. Telegram limits About to 255 characters.
+    """
+    try:
+        entity = await resolve_entity(chat_id)
+        await client(functions.messages.EditChatAboutRequest(peer=entity, about=about))
+        return f"Chat {chat_id} description updated."
+    except telethon.errors.rpcerrorlist.ChatAboutNotModifiedError:
+        return f"Chat {chat_id} description is already set to the requested value."
+    except telethon.errors.rpcerrorlist.ChatAboutTooLongError:
+        return "Error: description exceeds Telegram's 255 character limit."
+    except telethon.errors.rpcerrorlist.ChatAdminRequiredError:
+        return "Error: admin rights required to edit the chat description."
+    except Exception as e:
+        logger.exception(f"edit_chat_about failed (chat_id={chat_id})")
+        return log_and_format_error("edit_chat_about", e, chat_id=chat_id)
+
+
+@mcp.tool(
+    annotations=ToolAnnotations(
         title="Delete Chat Photo", openWorldHint=True, destructiveHint=True, idempotentHint=True
     )
 )


### PR DESCRIPTION
## Summary
Adds `edit_chat_about` tool mirroring the existing `edit_chat_title` pattern.

Uses `messages.EditChatAboutRequest` which accepts a generic peer and works for basic groups, supergroups, and channels without needing an `isinstance` branch.

## Errors handled
- `ChatAboutNotModifiedError` — description already matches the requested value (idempotent no-op)
- `ChatAboutTooLongError` — exceeds Telegram's 255-char About limit
- `ChatAdminRequiredError` — caller lacks admin rights

## Test plan
- [ ] Call `edit_chat_about(chat_id, "New description")` against a test supergroup — expect success
- [ ] Call again with same text — expect "already set" message (idempotent)
- [ ] Call with >255 chars — expect length error
- [ ] Call on a chat where user is not admin — expect admin error