### PR TITLE
feat: add with_about to list_chats for dispatch disambiguation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This MCP server exposes a huge suite of Telegram tools. **Every major Telegram/T
 
 ### Chat & Group Management
 - **get_chats(page, page_size)**: Paginated list of chats
-- **list_chats(chat_type, limit)**: List chats with metadata and filtering
+- **list_chats(chat_type, limit, unread_only, unmuted_only, with_about)**: List chats with metadata and filtering; `with_about=True` enriches output with each chat's description (slower).
 - **get_chat(chat_id)**: Detailed info about a chat
 - **create_group(title, user_ids)**: Create a new group
 - **invite_to_group(group_id, user_ids)**: Invite users to a group or channel

--- a/main.py
+++ b/main.py
@@ -1384,7 +1384,11 @@ async def list_topics(
 
 @mcp.tool(annotations=ToolAnnotations(title="List Chats", openWorldHint=True, readOnlyHint=True))
 async def list_chats(
-    chat_type: str = None, limit: int = 20, unread_only: bool = False, unmuted_only: bool = False
+    chat_type: str = None,
+    limit: int = 20,
+    unread_only: bool = False,
+    unmuted_only: bool = False,
+    with_about: bool = False,
 ) -> str:
     """
     List available chats with metadata.
@@ -1394,6 +1398,12 @@ async def list_chats(
         limit: Maximum number of chats to retrieve from Telegram API (applied before filtering, so fewer results may be returned when filters are active).
         unread_only: If True, only return chats with unread messages.
         unmuted_only: If True, only return unmuted chats.
+        with_about: If True, fetch each chat's description/bio via an additional
+            API call per chat (slower — use only when needed for dispatch
+            disambiguation).
+
+    **Performance:** when `with_about=True`, makes one extra API call per chat
+    returned. Avoid large `limit` values.
     """
     try:
         await ensure_connected()
@@ -1465,6 +1475,36 @@ async def list_chats(
             if unread_mentions > 0:
                 chat_info += f", Unread mentions: {unread_mentions}"
 
+            # Optionally fetch per-chat description/bio. Each call is guarded
+            # so one failure (permissions, flood, etc.) doesn't abort the whole
+            # listing.
+            if with_about:
+                about_text = ""
+                try:
+                    if isinstance(entity, Channel):
+                        full = await client(
+                            functions.channels.GetFullChannelRequest(channel=entity)
+                        )
+                        about_text = getattr(full.full_chat, "about", "") or ""
+                    elif isinstance(entity, Chat):
+                        full = await client(
+                            functions.messages.GetFullChatRequest(chat_id=entity.id)
+                        )
+                        about_text = getattr(full.full_chat, "about", "") or ""
+                    elif isinstance(entity, User):
+                        full = await client(functions.users.GetFullUserRequest(id=entity))
+                        about_text = getattr(full.full_user, "about", "") or ""
+                except Exception as about_err:
+                    logger.warning(
+                        f"list_chats: failed to fetch about for {entity.id}: {about_err}"
+                    )
+                    about_text = "<error fetching description>"
+
+                if len(about_text) > 200:
+                    about_text = about_text[:200] + "..."
+
+                chat_info += f', About: "{about_text}"'
+
             results.append(chat_info)
 
         if not results:
@@ -1479,6 +1519,7 @@ async def list_chats(
             limit=limit,
             unread_only=unread_only,
             unmuted_only=unmuted_only,
+            with_about=with_about,
         )
 
 


### PR DESCRIPTION
## Summary

Extends `list_chats` with an optional `with_about: bool = False` parameter. When `True`, each returned chat row is enriched with its description (`about`) via `GetFullChannel` / `GetFullChat` / `GetFullUser`.

Primary use case: LLM-based chat dispatch. When titles alone are ambiguous (e.g. multiple chats called "Accounting" with different scopes), the description disambiguates without needing a follow-up `get_chat` call per chat.

## Design choices

- **Opt-in** — default `False` keeps the fast path fast; `True` adds one API call per chat returned.
- **Per-chat error isolation** — each enrichment is wrapped in its own try/except with `logger.warning`. Flood-waits or permission errors substitute `<error fetching description>` and don't abort the whole listing.
- **Truncation** — descriptions over 200 chars get `[:200] + "..."` to keep output compact.
- **Entity dispatch** — `isinstance(entity, Channel)` → `channels.GetFullChannelRequest`, `isinstance(entity, Chat)` → `messages.GetFullChatRequest`, `isinstance(entity, User)` → `users.GetFullUserRequest` (bio).

## Output format

Extends the existing line:
```
Chat ID: 123, Title: Foo, Type: Group, Unread: 0, Muted: no, About: "some description here"
```

## Test plan

- [ ] `list_chats(with_about=False)` — unchanged output (no extra API calls)
- [ ] `list_chats(with_about=True, limit=10)` — each row has `About: "..."` field
- [ ] `list_chats(with_about=True)` on a chat with empty description — `About: ""`
- [ ] `list_chats(with_about=True)` including a chat where `get_full_*` fails — row shows `About: "<error fetching description>"`, other rows unaffected