### PR TITLE
docs: add uvx quick start guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,102 @@ docker run -it --rm \
 
 ---
 
+## Quick Start with uvx
+
+For the fastest setup without cloning the repository, you can use `uvx` (part of the `uv` toolchain) to run `telegram-mcp` directly from PyPI:
+
+### Prerequisites
+- Python 3.10 or higher
+- [uv](https://docs.astral.sh/uv/) installed (`curl -LsSf https://astral.sh/uv/install.sh | sh`)
+- Telegram API credentials from [my.telegram.org/apps](https://my.telegram.org/apps)
+- A session string (generate one first—see below)
+
+### Generate a Session String
+
+Before using `uvx`, you need to generate a session string. Clone the repository temporarily to use the session generator:
+
+```bash
+git clone https://github.com/chigwell/telegram-mcp.git
+cd telegram-mcp
+uv run session_string_generator.py
+```
+
+Follow the prompts to authenticate with your Telegram account. Save the generated session string securely.
+
+### Running with uvx
+
+Once you have your session string, you can run the server directly:
+
+```bash
+uvx telegram-mcp
+```
+
+The server will look for environment variables or a `.env` file in your current directory. Make sure to set:
+
+```bash
+export TELEGRAM_API_ID=your_api_id_here
+export TELEGRAM_API_HASH=your_api_hash_here
+export TELEGRAM_SESSION_STRING=your_session_string_here
+```
+
+Alternatively, create a `.env` file in your working directory with these values.
+
+### MCP Configuration for uvx
+
+To use `telegram-mcp` via `uvx` in Claude or Cursor, update your MCP configuration:
+
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+```json
+{
+  "mcpServers": {
+    "telegram-mcp": {
+      "command": "uvx",
+      "args": ["telegram-mcp"],
+      "env": {
+        "TELEGRAM_API_ID": "your_api_id_here",
+        "TELEGRAM_API_HASH": "your_api_hash_here",
+        "TELEGRAM_SESSION_STRING": "your_session_string_here"
+      }
+    }
+  }
+}
+```
+
+**Cursor** (`~/.cursor/mcp.json`): Same format as above.
+
+### Benefits of uvx
+
+- **No repository clone required**: Run directly from PyPI
+- **Automatic dependency management**: `uv` handles all dependencies in isolated environments
+- **Easy updates**: `uvx telegram-mcp` always runs the latest published version
+- **Clean system**: No global installation or virtual environment clutter
+
+For file-path tools (e.g., `send_file`, `download_media`), pass allowed root directories as arguments:
+
+```bash
+uvx telegram-mcp /path/to/allowed/dir1 /path/to/allowed/dir2
+```
+
+Or in your MCP config:
+
+```json
+{
+  "mcpServers": {
+    "telegram-mcp": {
+      "command": "uvx",
+      "args": ["telegram-mcp", "/data/telegram", "/tmp/telegram-mcp"],
+      "env": {
+        "TELEGRAM_API_ID": "your_api_id_here",
+        "TELEGRAM_API_HASH": "your_api_hash_here",
+        "TELEGRAM_SESSION_STRING": "your_session_string_here"
+      }
+    }
+  }
+}
+```
+
+---
+
 ## ⚙️ Configuration for Claude & Cursor
 
 ### MCP Configuration

--- a/README.md
+++ b/README.md
@@ -309,12 +309,10 @@ For the fastest setup without cloning the repository, you can use `uvx` (part of
 
 ### Generate a Session String
 
-Before using `uvx`, you need to generate a session string. Clone the repository temporarily to use the session generator:
+Before using `uvx`, you need to generate a session string. Run the session generator directly via `uvx` — no repository clone needed:
 
 ```bash
-git clone https://github.com/chigwell/telegram-mcp.git
-cd telegram-mcp
-uv run session_string_generator.py
+uvx --from telegram-mcp telegram-mcp-generate-session
 ```
 
 Follow the prompts to authenticate with your Telegram account. Save the generated session string securely.
@@ -341,7 +339,7 @@ Alternatively, create a `.env` file in your working directory with these values.
 
 To use `telegram-mcp` via `uvx` in Claude or Cursor, update your MCP configuration:
 
-**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+**Claude Desktop** (`claude_desktop_config.json` — typically `~/Library/Application Support/Claude/` on macOS or `%APPDATA%\Claude\` on Windows):
 ```json
 {
   "mcpServers": {
@@ -364,7 +362,7 @@ To use `telegram-mcp` via `uvx` in Claude or Cursor, update your MCP configurati
 
 - **No repository clone required**: Run directly from PyPI
 - **Automatic dependency management**: `uv` handles all dependencies in isolated environments
-- **Easy updates**: `uvx telegram-mcp` always runs the latest published version
+- **Easy updates**: run `uv tool upgrade telegram-mcp` to update to the latest published version
 - **Clean system**: No global installation or virtual environment clutter
 
 For file-path tools (e.g., `send_file`, `download_media`), pass allowed root directories as arguments:


### PR DESCRIPTION
## Summary

Adds a Quick Start with uvx section to the README, addressing issue #42. The `uvx` deployment method was already supported via the `project.scripts` entry in `pyproject.toml` but was not documented anywhere in the README.

## Changes

- New section placed between the Docker section and the Configuration section
- Covers prerequisites, session string generation via `uvx --from telegram-mcp telegram-mcp-generate-session` (no repository clone needed), running the server with `uvx telegram-mcp`, and MCP configuration examples for Claude Desktop and Cursor
- Config path covers both macOS and Windows
- Documents file-path tools usage with allowed root directories passed as arguments
- Lists accurate benefits of the uvx deployment method

## Why This Matters

Users currently have no documentation for the uvx deployment path. This addition means users can get started without cloning the repository at all, which is the main advantage of uvx.

## Accuracy Notes

- Session generation uses `uvx --from telegram-mcp telegram-mcp-generate-session`, matching the `telegram-mcp-generate-session` entry point defined in `pyproject.toml`
- Update instructions correctly state `uv tool upgrade telegram-mcp` rather than implying uvx auto-updates on each run
- Claude Desktop config path references both macOS (`~/Library/Application Support/Claude/`) and Windows (`%APPDATA%\Claude\`)

## Testing

- Verified section renders correctly in the README
- Confirmed all commands match the `pyproject.toml` script definitions
- Checked formatting consistency with the rest of the README

## Adherence to Contributing Guidelines

- Forked repository, feature branch created from main
- Focused scope: documentation only, no code changes
- Descriptive conventional commit message with issue reference
- Tagged @chigwell and @l1v0n1 for review

Fixes #42