### PR TITLE
feat: add proxy support (SOCKS5/SOCKS4/HTTP/MTProxy)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,22 @@ TELEGRAM_SESSION_STRING=1231231232erfdfdffd
 # Shared API_ID and API_HASH are used for all accounts.
 # TELEGRAM_SESSION_STRING_WORK=<session string for work account>
 # TELEGRAM_SESSION_STRING_PERSONAL=<session string for personal account>
+
+# --- Proxy (optional) ---
+# Route Telegram traffic through a proxy. Set TELEGRAM_PROXY_TYPE to enable.
+# Supported types: socks5, socks4, http, mtproxy.
+# SOCKS/HTTP proxies require the 'python-socks' package (install via
+# `uv sync --extra proxy` or `pip install python-socks`).
+# Per-account overrides use the same _<LABEL> suffix as session variables.
+# TELEGRAM_PROXY_TYPE=socks5
+# TELEGRAM_PROXY_HOST=127.0.0.1
+# TELEGRAM_PROXY_PORT=1080
+# TELEGRAM_PROXY_USERNAME=<optional>
+# TELEGRAM_PROXY_PASSWORD=<optional>
+# TELEGRAM_PROXY_RDNS=true
+# For MTProxy, set TELEGRAM_PROXY_TYPE=mtproxy and provide the secret:
+# TELEGRAM_PROXY_SECRET=<hex secret>
+# Per-account override example:
+# TELEGRAM_PROXY_TYPE_WORK=http
+# TELEGRAM_PROXY_HOST_WORK=proxy.work.example
+# TELEGRAM_PROXY_PORT_WORK=3128

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Message sent successfully:
 - [Quick Start](#quick-start)
 - [MCP Client Configuration](#mcp-client-configuration)
 - [Multi-Account Setup](#multi-account-setup)
+- [Proxy Support](#proxy-support)
 - [File Path Security](#file-path-security)
 - [Docker](#docker)
 - [Development](#development)
@@ -165,6 +166,58 @@ Example prompts:
 - "List my accounts"
 - "Show unread messages from all accounts"
 - "Send this from my work account to @example"
+
+## Proxy Support
+
+Route Telegram traffic through a proxy by setting the `TELEGRAM_PROXY_*`
+environment variables. Supported types are `socks5`, `socks4`, `http`, and
+`mtproxy`.
+
+SOCKS and HTTP proxies require the optional `python-socks` package:
+
+```bash
+uv sync --extra proxy
+# or
+pip install python-socks
+```
+
+Single-account configuration:
+
+```env
+TELEGRAM_PROXY_TYPE=socks5
+TELEGRAM_PROXY_HOST=127.0.0.1
+TELEGRAM_PROXY_PORT=1080
+TELEGRAM_PROXY_USERNAME=optional_user
+TELEGRAM_PROXY_PASSWORD=optional_pass
+TELEGRAM_PROXY_RDNS=true
+```
+
+MTProxy:
+
+```env
+TELEGRAM_PROXY_TYPE=mtproxy
+TELEGRAM_PROXY_HOST=mtproxy.example
+TELEGRAM_PROXY_PORT=443
+TELEGRAM_PROXY_SECRET=ee0123456789abcdef...
+```
+
+Per-account overrides use the same `_<LABEL>` suffix as session variables and
+take precedence over the unsuffixed defaults:
+
+```env
+TELEGRAM_PROXY_TYPE=socks5
+TELEGRAM_PROXY_HOST=127.0.0.1
+TELEGRAM_PROXY_PORT=1080
+
+TELEGRAM_PROXY_TYPE_WORK=http
+TELEGRAM_PROXY_HOST_WORK=proxy.work.example
+TELEGRAM_PROXY_PORT_WORK=3128
+```
+
+Misconfigured proxy settings (unknown type, missing host/port, invalid port,
+missing MTProxy secret, or a missing `python-socks` package) cause the server
+to fail fast at startup with a clear error message instead of silently
+bypassing the proxy.
 
 ## File Path Security
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,12 @@ dependencies = [
     "telethon>=1.42.0",
 ]
 
+[project.optional-dependencies]
+# Required only when TELEGRAM_PROXY_TYPE is set to socks5/socks4/http.
+proxy = [
+    "python-socks>=2.4.3",
+]
+
 [project.urls]
 "Homepage" = "https://github.com/chigwell/telegram-mcp"
 "Bug Tracker" = "https://github.com/chigwell/telegram-mcp/issues"

--- a/telegram_mcp/runtime.py
+++ b/telegram_mcp/runtime.py
@@ -133,6 +133,108 @@ _install_annotation_hook()
 # ---------------------------------------------------------------------------
 
 
+_PROXY_TYPES_SOCKS_HTTP = {"socks5", "socks4", "http"}
+_PROXY_TYPES_ALL = _PROXY_TYPES_SOCKS_HTTP | {"mtproxy"}
+
+
+def _get_proxy_env(name: str, label: str) -> Optional[str]:
+    """Resolve a TELEGRAM_PROXY_* env var with optional ``_<LABEL>`` suffix.
+
+    Per-account values override the unsuffixed defaults so a global proxy can
+    coexist with per-label overrides.
+    """
+    suffixed = os.getenv(f"TELEGRAM_PROXY_{name}_{label.upper()}")
+    if suffixed:
+        return suffixed
+    return os.getenv(f"TELEGRAM_PROXY_{name}") or None
+
+
+def _parse_bool_env(value: Optional[str], default: bool) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _build_proxy_for_label(label: str) -> tuple[Optional[Any], Optional[Any]]:
+    """Return ``(proxy, connection)`` kwargs for ``TelegramClient`` for a label.
+
+    Reads ``TELEGRAM_PROXY_*`` env vars (with optional ``_<LABEL>`` suffix).
+    Returns ``(None, None)`` when no proxy is configured. Raises
+    :class:`ValidationError` for malformed configuration so the server fails
+    fast instead of silently bypassing the proxy.
+    """
+    proxy_type = _get_proxy_env("TYPE", label)
+    if not proxy_type:
+        return None, None
+
+    proxy_type = proxy_type.strip().lower()
+    if proxy_type not in _PROXY_TYPES_ALL:
+        raise ValidationError(
+            f"Invalid TELEGRAM_PROXY_TYPE '{proxy_type}'. "
+            f"Expected one of: {', '.join(sorted(_PROXY_TYPES_ALL))}."
+        )
+
+    host = _get_proxy_env("HOST", label)
+    port_raw = _get_proxy_env("PORT", label)
+    if not host or not port_raw:
+        raise ValidationError(
+            "TELEGRAM_PROXY_HOST and TELEGRAM_PROXY_PORT are required when "
+            "TELEGRAM_PROXY_TYPE is set."
+        )
+    try:
+        port = int(port_raw)
+    except ValueError as exc:
+        raise ValidationError(
+            f"TELEGRAM_PROXY_PORT must be an integer, got '{port_raw}'."
+        ) from exc
+
+    if proxy_type == "mtproxy":
+        secret = _get_proxy_env("SECRET", label)
+        if not secret:
+            raise ValidationError("TELEGRAM_PROXY_SECRET is required for mtproxy.")
+        try:
+            from telethon.network import ConnectionTcpMTProxyRandomizedIntermediate
+        except ImportError as exc:  # pragma: no cover - defensive guard
+            raise ValidationError(
+                "Telethon MTProxy connection class is unavailable; upgrade telethon."
+            ) from exc
+        return (host, port, secret), ConnectionTcpMTProxyRandomizedIntermediate
+
+    # SOCKS4/SOCKS5/HTTP via python-socks (Telethon's optional dependency).
+    try:
+        import python_socks  # noqa: F401
+    except ImportError as exc:
+        raise ValidationError(
+            f"Proxy type '{proxy_type}' requires the 'python-socks' package. "
+            "Install it with `pip install python-socks` or `uv sync --extra proxy`."
+        ) from exc
+
+    proxy: dict[str, Any] = {
+        "proxy_type": proxy_type,
+        "addr": host,
+        "port": port,
+        "rdns": _parse_bool_env(_get_proxy_env("RDNS", label), default=True),
+    }
+    username = _get_proxy_env("USERNAME", label)
+    password = _get_proxy_env("PASSWORD", label)
+    if username:
+        proxy["username"] = username
+    if password:
+        proxy["password"] = password
+    return proxy, None
+
+
+def _build_client(session: Any, label: str) -> TelegramClient:
+    """Construct a ``TelegramClient`` honoring per-label proxy configuration."""
+    proxy, connection = _build_proxy_for_label(label)
+    kwargs: dict[str, Any] = {}
+    if proxy is not None:
+        kwargs["proxy"] = proxy
+    if connection is not None:
+        kwargs["connection"] = connection
+    return TelegramClient(session, TELEGRAM_API_ID, TELEGRAM_API_HASH, **kwargs)
+
+
 def _discover_accounts() -> dict[str, TelegramClient]:
     """Scan env vars to build account label -> TelegramClient mapping.
 
@@ -140,6 +242,9 @@ def _discover_accounts() -> dict[str, TelegramClient]:
     - TELEGRAM_SESSION_STRING_<LABEL> / TELEGRAM_SESSION_NAME_<LABEL> -> multi-mode
     - Unsuffixed TELEGRAM_SESSION_STRING / TELEGRAM_SESSION_NAME -> label "default"
     - If both suffixed and unsuffixed exist -> unsuffixed becomes "default"
+
+    Each client is constructed via :func:`_build_client`, which applies any
+    matching ``TELEGRAM_PROXY_*`` configuration (optionally per-label).
     """
     accounts: dict[str, TelegramClient] = {}
 
@@ -149,23 +254,19 @@ def _discover_accounts() -> dict[str, TelegramClient]:
     for key, value in os.environ.items():
         if key.startswith(prefix_str) and value:
             label = key[len(prefix_str) :].lower()
-            accounts[label] = TelegramClient(
-                StringSession(value), TELEGRAM_API_ID, TELEGRAM_API_HASH
-            )
+            accounts[label] = _build_client(StringSession(value), label)
         elif key.startswith(prefix_name) and value:
             label = key[len(prefix_name) :].lower()
-            accounts[label] = TelegramClient(value, TELEGRAM_API_ID, TELEGRAM_API_HASH)
+            accounts[label] = _build_client(value, label)
 
     # Backward-compatible unsuffixed variables
     session_string = os.getenv("TELEGRAM_SESSION_STRING")
     session_name = os.getenv("TELEGRAM_SESSION_NAME")
 
     if session_string and "default" not in accounts:
-        accounts["default"] = TelegramClient(
-            StringSession(session_string), TELEGRAM_API_ID, TELEGRAM_API_HASH
-        )
+        accounts["default"] = _build_client(StringSession(session_string), "default")
     elif session_name and "default" not in accounts:
-        accounts["default"] = TelegramClient(session_name, TELEGRAM_API_ID, TELEGRAM_API_HASH)
+        accounts["default"] = _build_client(session_name, "default")
 
     if not accounts:
         print(

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -19,8 +19,9 @@ def _clear_session_env(monkeypatch):
 
 
 class _FakeTelegramClient:
-    def __init__(self, *args):
+    def __init__(self, *args, **kwargs):
         self.args = args
+        self.kwargs = kwargs
 
 
 def test_discover_accounts_supports_suffixed_and_default_sessions(monkeypatch):
@@ -44,6 +45,161 @@ def test_discover_accounts_exits_when_no_sessions_configured(monkeypatch):
 
     with pytest.raises(SystemExit):
         runtime._discover_accounts()
+
+
+def _clear_proxy_env(monkeypatch):
+    for key in list(runtime.os.environ):
+        if key.startswith("TELEGRAM_PROXY_"):
+            monkeypatch.delenv(key, raising=False)
+
+
+def test_build_proxy_returns_none_when_unset(monkeypatch):
+    _clear_proxy_env(monkeypatch)
+    assert runtime._build_proxy_for_label("default") == (None, None)
+
+
+def _stub_python_socks(monkeypatch):
+    """Make ``import python_socks`` succeed without installing the package."""
+    import sys
+    import types
+
+    stub = types.ModuleType("python_socks")
+    monkeypatch.setitem(sys.modules, "python_socks", stub)
+
+
+def test_build_proxy_socks5_with_credentials(monkeypatch):
+    _clear_proxy_env(monkeypatch)
+    _stub_python_socks(monkeypatch)
+    monkeypatch.setenv("TELEGRAM_PROXY_TYPE", "socks5")
+    monkeypatch.setenv("TELEGRAM_PROXY_HOST", "127.0.0.1")
+    monkeypatch.setenv("TELEGRAM_PROXY_PORT", "1080")
+    monkeypatch.setenv("TELEGRAM_PROXY_USERNAME", "alice")
+    monkeypatch.setenv("TELEGRAM_PROXY_PASSWORD", "secret")
+    monkeypatch.setenv("TELEGRAM_PROXY_RDNS", "false")
+
+    proxy, connection = runtime._build_proxy_for_label("default")
+
+    assert connection is None
+    assert proxy == {
+        "proxy_type": "socks5",
+        "addr": "127.0.0.1",
+        "port": 1080,
+        "rdns": False,
+        "username": "alice",
+        "password": "secret",
+    }
+
+
+def test_build_proxy_per_label_overrides_default(monkeypatch):
+    _clear_proxy_env(monkeypatch)
+    _stub_python_socks(monkeypatch)
+    monkeypatch.setenv("TELEGRAM_PROXY_TYPE", "socks5")
+    monkeypatch.setenv("TELEGRAM_PROXY_HOST", "127.0.0.1")
+    monkeypatch.setenv("TELEGRAM_PROXY_PORT", "1080")
+    monkeypatch.setenv("TELEGRAM_PROXY_TYPE_WORK", "http")
+    monkeypatch.setenv("TELEGRAM_PROXY_HOST_WORK", "proxy.work.example")
+    monkeypatch.setenv("TELEGRAM_PROXY_PORT_WORK", "3128")
+
+    proxy, connection = runtime._build_proxy_for_label("work")
+
+    assert connection is None
+    assert proxy["proxy_type"] == "http"
+    assert proxy["addr"] == "proxy.work.example"
+    assert proxy["port"] == 3128
+
+
+def test_build_proxy_mtproxy_returns_connection_class(monkeypatch):
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("TELEGRAM_PROXY_TYPE", "mtproxy")
+    monkeypatch.setenv("TELEGRAM_PROXY_HOST", "mtproxy.example")
+    monkeypatch.setenv("TELEGRAM_PROXY_PORT", "443")
+    monkeypatch.setenv("TELEGRAM_PROXY_SECRET", "ee0123456789abcdef")
+
+    proxy, connection = runtime._build_proxy_for_label("default")
+
+    from telethon.network import ConnectionTcpMTProxyRandomizedIntermediate
+
+    assert proxy == ("mtproxy.example", 443, "ee0123456789abcdef")
+    assert connection is ConnectionTcpMTProxyRandomizedIntermediate
+
+
+def test_build_proxy_rejects_unknown_type(monkeypatch):
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("TELEGRAM_PROXY_TYPE", "carrier-pigeon")
+    monkeypatch.setenv("TELEGRAM_PROXY_HOST", "127.0.0.1")
+    monkeypatch.setenv("TELEGRAM_PROXY_PORT", "1080")
+
+    with pytest.raises(runtime.ValidationError, match="Invalid TELEGRAM_PROXY_TYPE"):
+        runtime._build_proxy_for_label("default")
+
+
+def test_build_proxy_requires_host_and_port(monkeypatch):
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("TELEGRAM_PROXY_TYPE", "socks5")
+
+    with pytest.raises(runtime.ValidationError, match="HOST and TELEGRAM_PROXY_PORT"):
+        runtime._build_proxy_for_label("default")
+
+
+def test_build_proxy_rejects_non_integer_port(monkeypatch):
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("TELEGRAM_PROXY_TYPE", "socks5")
+    monkeypatch.setenv("TELEGRAM_PROXY_HOST", "127.0.0.1")
+    monkeypatch.setenv("TELEGRAM_PROXY_PORT", "not-a-port")
+
+    with pytest.raises(runtime.ValidationError, match="must be an integer"):
+        runtime._build_proxy_for_label("default")
+
+
+def test_build_proxy_mtproxy_requires_secret(monkeypatch):
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("TELEGRAM_PROXY_TYPE", "mtproxy")
+    monkeypatch.setenv("TELEGRAM_PROXY_HOST", "mtproxy.example")
+    monkeypatch.setenv("TELEGRAM_PROXY_PORT", "443")
+
+    with pytest.raises(runtime.ValidationError, match="SECRET"):
+        runtime._build_proxy_for_label("default")
+
+
+def test_build_proxy_socks_requires_python_socks(monkeypatch):
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("TELEGRAM_PROXY_TYPE", "socks5")
+    monkeypatch.setenv("TELEGRAM_PROXY_HOST", "127.0.0.1")
+    monkeypatch.setenv("TELEGRAM_PROXY_PORT", "1080")
+
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "python_socks":
+            raise ImportError("simulated missing python-socks")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(runtime.ValidationError, match="python-socks"):
+        runtime._build_proxy_for_label("default")
+
+
+def test_discover_accounts_passes_proxy_kwargs_to_client(monkeypatch):
+    _clear_session_env(monkeypatch)
+    _clear_proxy_env(monkeypatch)
+    monkeypatch.setenv("TELEGRAM_SESSION_STRING", "default-session")
+    monkeypatch.setenv("TELEGRAM_PROXY_TYPE", "mtproxy")
+    monkeypatch.setenv("TELEGRAM_PROXY_HOST", "mtproxy.example")
+    monkeypatch.setenv("TELEGRAM_PROXY_PORT", "443")
+    monkeypatch.setenv("TELEGRAM_PROXY_SECRET", "ee0123456789abcdef")
+    monkeypatch.setattr(runtime, "TelegramClient", _FakeTelegramClient)
+    monkeypatch.setattr(runtime, "StringSession", lambda value: f"StringSession:{value}")
+
+    accounts = runtime._discover_accounts()
+
+    client = accounts["default"]
+    assert client.kwargs["proxy"] == ("mtproxy.example", 443, "ee0123456789abcdef")
+    from telethon.network import ConnectionTcpMTProxyRandomizedIntermediate
+
+    assert client.kwargs["connection"] is ConnectionTcpMTProxyRandomizedIntermediate
 
 
 def test_get_client_single_and_multi_account_paths(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -1002,6 +1002,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-socks"
+version = "2.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/0b/cd77011c1bc01b76404f7aba07fca18aca02a19c7626e329b40201217624/python_socks-2.8.1.tar.gz", hash = "sha256:698daa9616d46dddaffe65b87db222f2902177a2d2b2c0b9a9361df607ab3687", size = 38909, upload-time = "2026-02-16T05:24:00.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/fe/9a58cb6eec633ff6afae150ca53c16f8cc8b65862ccb3d088051efdfceb7/python_socks-2.8.1-py3-none-any.whl", hash = "sha256:28232739c4988064e725cdbcd15be194743dd23f1c910f784163365b9d7be035", size = 55087, upload-time = "2026-02-16T05:23:59.147Z" },
+]
+
+[[package]]
 name = "pytokens"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1328,6 +1337,11 @@ dependencies = [
     { name = "telethon" },
 ]
 
+[package.optional-dependencies]
+proxy = [
+    { name = "python-socks" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "black" },
@@ -1346,9 +1360,11 @@ requires-dist = [
     { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "python-json-logger", specifier = ">=3.3.0" },
+    { name = "python-socks", marker = "extra == 'proxy'", specifier = ">=2.4.3" },
     { name = "qrcode", specifier = ">=8.2" },
     { name = "telethon", specifier = ">=1.42.0" },
 ]
+provides-extras = ["proxy"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Adds proxy support to the Telegram MCP server, resolving #99. Users can route
Telegram traffic through SOCKS5/SOCKS4/HTTP or MTProxy by setting
`TELEGRAM_PROXY_*` environment variables. Per-account overrides reuse the
existing `_<LABEL>` suffix convention so a single global proxy can coexist
with per-account proxies.

## Changes

- New `_build_proxy_for_label(label)` resolves env vars and returns
  `(proxy, connection)` kwargs for `TelegramClient`.
- New `_build_client(session, label)` wraps `TelegramClient(...)` so every
  account constructed in `_discover_accounts()` honors its proxy config.
- `python-socks` exposed as an optional `[proxy]` extra in `pyproject.toml`
  so the default install stays lean.
- MTProxy uses Telethon's `ConnectionTcpMTProxyRandomizedIntermediate`.
- Misconfigured settings (unknown type, missing host/port, non-integer port,
  missing MTProxy secret, missing `python-socks`) raise `ValidationError`
  at startup instead of silently bypassing the proxy.
- `.env.example` and `README.md` updated with a dedicated **Proxy Support**
  section, single-account, MTProxy, and per-account override examples.

## Configuration

Single account:

```env
TELEGRAM_PROXY_TYPE=socks5
TELEGRAM_PROXY_HOST=127.0.0.1
TELEGRAM_PROXY_PORT=1080
TELEGRAM_PROXY_USERNAME=optional_user
TELEGRAM_PROXY_PASSWORD=optional_pass
TELEGRAM_PROXY_RDNS=true
```

MTProxy:

```env
TELEGRAM_PROXY_TYPE=mtproxy
TELEGRAM_PROXY_HOST=mtproxy.example
TELEGRAM_PROXY_PORT=443
TELEGRAM_PROXY_SECRET=ee0123456789abcdef...
```

Per-account override (takes precedence over the unsuffixed defaults):

```env
TELEGRAM_PROXY_TYPE=socks5
TELEGRAM_PROXY_HOST=127.0.0.1
TELEGRAM_PROXY_PORT=1080

TELEGRAM_PROXY_TYPE_WORK=http
TELEGRAM_PROXY_HOST_WORK=proxy.work.example
TELEGRAM_PROXY_PORT_WORK=3128
```

## Validation

- `uv run pytest` — 85 passed (75 baseline + 10 new tests).
- `uv run pytest --cov` — 91.80% (gate is 80%).
- `uv run black --check .` — clean.
- `uv run flake8 . --select=E9,F63,F7,F82` — 0 errors.
- New tests cover: socks5 with credentials, per-label override beats
  defaults, mtproxy returns the right connection class, unknown-type
  rejection, missing host/port rejection, non-integer port rejection,
  missing mtproxy secret, missing `python-socks`, and end-to-end pass-through
  of proxy kwargs through `_discover_accounts`.

## Backward Compatibility

- No proxy env vars set → behavior is identical to current `main`.
- Existing `_FakeTelegramClient` in tests extended to capture `**kwargs`;
  prior `args[0]`-only assertions still pass unchanged.
- `python-socks` is optional; users who don't use SOCKS/HTTP proxies don't
  need to install it.

## Adherence to Contribution Guidelines

- Forked the repository, branched from `main`.
- Single focused change addressing #99.
- Tests added for both success and validation paths.
- `pre-commit` hooks pass locally (black, flake8 critical selectors,
  end-of-file-fixer, trailing-whitespace, check-merge-conflict).
- Tagging @chigwell and @l1v0n1 for review.

Closes #99