### PR TITLE
fix(docker): include package directory in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN pip install --no-cache-dir --upgrade pip
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy the rest of the application code
-COPY main.py sanitize.py .
+COPY main.py sanitize.py ./
+COPY telegram_mcp ./telegram_mcp
 # COPY session_string_generator.py . # Optional: if needed within the container, otherwise can be run outside
 
 # Create a non-root user and switch to it


### PR DESCRIPTION
## Summary
Fix Docker runtime startup failures after upstream project restructuring.
## Why
After recent upstream changes, container startup failed with:
- `ModuleNotFoundError: No module named 'telegram_mcp'`
because the package directory was not copied into the image.

With package copy fixed, startup then failed on env parsing due to empty API ID default:
- `ValueError: invalid literal for int() with base 10: ''`

## Validation
- `docker build -t telegram-mcp:smoke .` passes.
- Runtime no longer fails on missing package import.
- Runtime now correctly proceeds to Telethon credential validation (requires real `TELEGRAM_API_ID`/`TELEGRAM_API_HASH` at run time).
