### PR TITLE
chore(pre-commit): add pre-push pytest coverage hook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ TELEGRAM_API_HASH=0123456789abcdef0123456789abcdef
 # Option 1: File-based session (a .session file will be created)
 TELEGRAM_SESSION_NAME=telegram_session
 # Option 2: String-based session
-TELEGRAM_SESSION_STRING=1231231232erfdfdffd
+# TELEGRAM_SESSION_STRING=1231231232erfdfdffd
 
 # --- Multiple accounts ---
 # Add _<LABEL> suffix to session variables. Labels become account identifiers.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,9 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-push]
+      - id: pytest-coverage-ci
+        name: pytest with coverage (ci parity)
+        entry: uv run --env-file .env.example pytest --cov --cov-report=term-missing --cov-report=xml
+        language: system
+        pass_filenames: false
+        stages: [pre-push]


### PR DESCRIPTION
## Summary
Adds a CI-parity pre-push test gate in pre-commit and fixes `.env.example` to avoid invalid session parsing during test collection.

## Changes
- Added local pre-push hook:
  - `pytest-coverage-ci`
  - command: `uv run --env-file .env.example pytest --cov --cov-report=term-missing --cov-report=xml`
- Updated `.env.example`:
  - switched `TELEGRAM_SESSION_STRING` from active invalid placeholder to commented example
  - keeps `TELEGRAM_SESSION_NAME` as the default test-friendly session mode

## Why
- Tests were recently added and should be enforced before push as well.
- Coverage threshold is already configured in `pyproject.toml` (`fail_under = 80`), so this hook enforces the same quality gate locally.
- Loading `.env.example` previously could trigger `StringSession` parsing errors due to placeholder session string content.

## Validation
- `pre-commit run pytest-coverage-ci --hook-stage pre-push --all-files` passes.
- Hook now mirrors CI command style via `uv run`.