### PR TITLE
feat: add MCPL protocol support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ proxy = [
 
 [tool.setuptools]
 py-modules = ["main", "sanitize", "session_string_generator"]
-packages = ["telegram_mcp", "telegram_mcp.tools"]
+packages = ["telegram_mcp", "telegram_mcp.tools", "telegram_mcp.mcpl"]
 
 [project.scripts]
 telegram-mcp = "main:main"

--- a/telegram_mcp/mcpl/__init__.py
+++ b/telegram_mcp/mcpl/__init__.py
@@ -1,0 +1,33 @@
+"""MCPL (MCP Live) protocol support for the Telegram MCP server.
+
+This subpackage layers the MCPL extension on top of the standard MCP server
+provided by FastMCP. The standard MCP tool surface (send_message, list_chats,
+…) is unchanged; MCPL adds:
+
+  - capability advertisement (experimental.mcpl in initialize)
+  - channel registration (Telegram dialogs → MCPL channels)
+  - push events (Telethon NewMessage → channels/incoming)
+  - host → server publish (channels/publish → Telethon send_message)
+  - lifecycle methods (channels/list/open/close, channels/typing)
+
+Reference: mcpl/SPEC.md in the connectome-typescript monorepo, and the Java
+precedent at discord-mcp/src/main/java/dev/saseq/mcpl/.
+
+Resilience model:
+
+  - Telethon transport disconnects (network blip): handled by chigwell's
+    existing ensure_connected / _force_reconnect in runtime.py. Event
+    handlers are attached to the TelegramClient instance and persist
+    across reconnects, so message flow resumes automatically.
+  - Host process restart: the host re-issues `initialize` and
+    `notifications/initialized`. The transport's on_ready re-fires;
+    `attach_event_handlers` is idempotent (per-client sentinel) so
+    NewMessage isn't pushed twice. channels/register is re-emitted with
+    the freshly-enumerated dialog list.
+  - Long disconnect with channel-set drift: Telegram doesn't replay
+    missed updates after a long offline window. Use `channels/list` from
+    the host to re-fetch the dialog set on demand.
+"""
+
+MCPL_VERSION = "0.4"
+"""Protocol version advertised in capabilities.experimental.mcpl.version."""

--- a/telegram_mcp/mcpl/capabilities.py
+++ b/telegram_mcp/mcpl/capabilities.py
@@ -1,0 +1,38 @@
+"""MCPL capability advertisement.
+
+Returns the dict that goes under `experimental.mcpl` in the server's
+`initialize` response. Phase 1: the values reflect what we *will* support
+once Phases 2–6 land. Until then the host sees the capability flags but
+calls to those methods will return JSON-RPC "method not found" — that's
+fine, MCPL is fail-open.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from . import MCPL_VERSION
+
+
+def build_mcpl_capabilities() -> dict[str, Any]:
+    """Return the dict to inject as `experimental.mcpl` on `initialize`."""
+    return {
+        "version": MCPL_VERSION,
+        "pushEvents": True,
+        "channels": {
+            "register": True,
+            "publish": True,
+            "observe": False,
+            "lifecycle": True,
+            "streaming": False,
+        },
+    }
+
+
+def build_experimental_capabilities() -> dict[str, dict[str, Any]]:
+    """Wrap our capabilities for `Server.create_initialization_options`.
+
+    The mcp SDK takes `experimental_capabilities: dict[str, dict[str, Any]]`
+    where the top-level keys are namespaces. Ours is `mcpl`.
+    """
+    return {"mcpl": build_mcpl_capabilities()}

--- a/telegram_mcp/mcpl/channels.py
+++ b/telegram_mcp/mcpl/channels.py
@@ -1,0 +1,221 @@
+"""Telegram entity ↔ MCPL ChannelDescriptor mapping.
+
+Channel ID scheme (account label is part of the ID so distinct accounts
+sharing the same chat are still distinct channels — multi-account safe):
+
+  - User (private chat)            → telegram:{label}:dm:{user_id}
+  - Chat (basic group)             → telegram:{label}:group:{chat_id}
+  - Channel.megagroup (supergroup) → telegram:{label}:supergroup:{chat_id}
+  - Channel.broadcast              → telegram:{label}:channel:{channel_id}
+  - Saved Messages (own user)      → telegram:{label}:saved
+
+Direction:
+  - bidirectional everywhere we can post (DMs, groups, supergroups,
+    broadcast channels where we're creator or have admin rights)
+  - inbound for broadcast channels we just subscribe to
+
+One channel per supergroup; forum topics ride on `threadId` of incoming
+messages, not as separate channels.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from telethon import TelegramClient
+from telethon.tl.types import Channel, Chat, User
+
+from .types import ChannelDescriptor
+
+log = logging.getLogger("telegram_mcp.mcpl")
+
+
+# ---------------------------------------------------------------------------
+# Entity classification
+# ---------------------------------------------------------------------------
+
+
+def _kind_of(entity: Any) -> str | None:
+    """Return one of: 'dm', 'group', 'supergroup', 'channel'.
+
+    Returns None for entities we shouldn't expose (forbidden chats, etc.).
+    Saved Messages ('saved') is detected by the caller using self_id.
+    """
+    if isinstance(entity, User):
+        return "dm"
+    if isinstance(entity, Chat):
+        # Skip ChatForbidden, ChatEmpty by checking for required attrs
+        if getattr(entity, "deactivated", False):
+            return None
+        return "group"
+    if isinstance(entity, Channel):
+        if getattr(entity, "megagroup", False):
+            return "supergroup"
+        if getattr(entity, "broadcast", False):
+            return "channel"
+        # Default to supergroup-shaped if neither flag is set (unusual)
+        return "supergroup"
+    return None
+
+
+def _can_post(entity: Any, kind: str) -> bool:
+    """True when our user can send messages to this entity."""
+    if kind == "channel":
+        # Broadcast channels: only writable if we're creator or admin.
+        return bool(getattr(entity, "creator", False)) or bool(
+            getattr(entity, "admin_rights", None)
+        )
+    if kind == "supergroup":
+        # Supergroups can be locked down for non-admins, but for a user
+        # account in normal groups posting is the default. If banned_rights
+        # explicitly forbids messaging, downgrade.
+        banned = getattr(entity, "banned_rights", None)
+        if banned is not None and getattr(banned, "send_messages", False):
+            return False
+        return True
+    # dm and group are always writable from a user account
+    return True
+
+
+def _label_for(entity: Any, kind: str) -> str:
+    """Best-effort human-readable label."""
+    title = getattr(entity, "title", None)
+    if title:
+        return str(title)
+    if isinstance(entity, User):
+        first = getattr(entity, "first_name", "") or ""
+        last = getattr(entity, "last_name", "") or ""
+        full = f"{first} {last}".strip()
+        if full:
+            return full
+        username = getattr(entity, "username", None)
+        if username:
+            return f"@{username}"
+        return f"user:{entity.id}"
+    return f"{kind}:{getattr(entity, 'id', '?')}"
+
+
+# ---------------------------------------------------------------------------
+# Public mapping
+# ---------------------------------------------------------------------------
+
+
+def channel_id_for(account_label: str, kind: str, peer_id: int | str) -> str:
+    """Build the canonical MCPL channel id for a Telegram entity.
+
+    `kind` is one of 'dm', 'group', 'supergroup', 'channel', 'saved'.
+    For 'saved', `peer_id` is conventionally the self user_id but is not
+    encoded in the id; use a constant suffix.
+    """
+    if kind == "saved":
+        return f"telegram:{account_label}:saved"
+    return f"telegram:{account_label}:{kind}:{peer_id}"
+
+
+def entity_to_descriptor(
+    entity: Any,
+    *,
+    account_label: str,
+    self_id: int | None = None,
+) -> ChannelDescriptor | None:
+    """Convert a Telethon entity to an MCPL ChannelDescriptor.
+
+    Returns None for entities we can't or shouldn't expose (forbidden,
+    empty, unknown kind).
+    """
+    kind = _kind_of(entity)
+    if kind is None:
+        return None
+
+    if kind == "dm" and self_id is not None and getattr(entity, "id", None) == self_id:
+        kind = "saved"
+
+    peer_id = getattr(entity, "id", None)
+    if peer_id is None:
+        return None
+
+    direction = "bidirectional" if _can_post(entity, kind) else "inbound"
+    label = _label_for(entity, kind)
+
+    descriptor: ChannelDescriptor = {
+        "id": channel_id_for(account_label, kind, peer_id),
+        "type": "telegram",
+        "label": label,
+        "direction": direction,
+        "address": {
+            "account": account_label,
+            "kind": kind,
+            "peerId": peer_id,
+        },
+        "metadata": {
+            "account": account_label,
+            "kind": kind,
+        },
+    }
+
+    # Extra metadata that helps the agent and host disambiguate.
+    username = getattr(entity, "username", None)
+    if username:
+        descriptor["metadata"]["username"] = username
+
+    forum = getattr(entity, "forum", False)
+    if kind == "supergroup" and forum:
+        descriptor["metadata"]["forum"] = True
+
+    return descriptor
+
+
+async def enumerate_channels(
+    client: TelegramClient,
+    account_label: str,
+) -> list[ChannelDescriptor]:
+    """Walk the client's dialogs and emit ChannelDescriptors for each.
+
+    Caller has already invoked `client.start()` and `client.get_dialogs()`
+    (entity cache warmed) per the standing pattern in `runner._main`.
+    """
+    me = await client.get_me()
+    self_id = getattr(me, "id", None)
+
+    descriptors: list[ChannelDescriptor] = []
+    saw_saved = False
+
+    async for dialog in client.iter_dialogs():
+        descriptor = entity_to_descriptor(
+            dialog.entity, account_label=account_label, self_id=self_id
+        )
+        if descriptor is None:
+            continue
+        if descriptor["metadata"]["kind"] == "saved":
+            saw_saved = True
+        descriptors.append(descriptor)
+
+    # Saved Messages may not always appear as a dialog. If we missed it,
+    # synthesize a descriptor since `client.send_message('me', ...)` works
+    # regardless.
+    if not saw_saved and self_id is not None:
+        descriptors.append(
+            {
+                "id": channel_id_for(account_label, "saved", self_id),
+                "type": "telegram",
+                "label": "Saved Messages",
+                "direction": "bidirectional",
+                "address": {
+                    "account": account_label,
+                    "kind": "saved",
+                    "peerId": self_id,
+                },
+                "metadata": {
+                    "account": account_label,
+                    "kind": "saved",
+                },
+            }
+        )
+
+    log.info(
+        "Enumerated %d channels for account '%s'",
+        len(descriptors),
+        account_label,
+    )
+    return descriptors

--- a/telegram_mcp/mcpl/content.py
+++ b/telegram_mcp/mcpl/content.py
@@ -1,0 +1,112 @@
+"""Telegram media ↔ McplContentBlock conversion.
+
+Conversion rules:
+  - Text                  → McplTextContent
+  - Photo / voice / doc   → McplTextContent placeholder (Phase 4 minimal)
+                            plus the message URI in metadata, so the agent
+                            can fetch with existing tools if needed
+
+Media binary path (full inline base64 ≤1MB / telegram:// URI otherwise) is
+deferred. For Phase 4 we focus on the event flow; media plumbing rides on
+top of these primitives later.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .types import McplContentBlock, McplResourceContent, McplTextContent
+
+INLINE_MEDIA_LIMIT_BYTES = 1 * 1024 * 1024
+"""Cutoff for inline base64 vs URI reference."""
+
+
+def message_uri(account_label: str, chat_id: int | str, message_id: int) -> str:
+    """Stable URI for a single Telegram message.
+
+    Used as `telegram://message/{account}/{chat}/{message}` so the agent
+    can pass it to the existing fetch tools (or, eventually, an MCP
+    resources/read endpoint) when it needs the full content.
+    """
+    return f"telegram://message/{account_label}/{chat_id}/{message_id}"
+
+
+def media_kind(message: Any) -> str | None:
+    """Return a short human label for the message's media type, if any."""
+    media = getattr(message, "media", None)
+    if media is None:
+        return None
+    cls = type(media).__name__
+    # Telethon types: MessageMediaPhoto, MessageMediaDocument, MessageMediaWebPage,
+    # MessageMediaContact, MessageMediaPoll, MessageMediaGeo, etc.
+    mapping = {
+        "MessageMediaPhoto": "photo",
+        "MessageMediaDocument": "document",
+        "MessageMediaWebPage": "link",
+        "MessageMediaContact": "contact",
+        "MessageMediaPoll": "poll",
+        "MessageMediaGeo": "location",
+        "MessageMediaVenue": "location",
+        "MessageMediaDice": "dice",
+        "MessageMediaGame": "game",
+        "MessageMediaInvoice": "invoice",
+        "MessageMediaUnsupported": "unsupported",
+    }
+    short = mapping.get(cls, cls.removeprefix("MessageMedia").lower() or "media")
+    if short == "document":
+        # Voice notes and round videos are documents with attribute flags
+        document = getattr(media, "document", None)
+        if document is not None:
+            attributes = getattr(document, "attributes", []) or []
+            for attr in attributes:
+                attr_cls = type(attr).__name__
+                if attr_cls == "DocumentAttributeAudio" and getattr(attr, "voice", False):
+                    return "voice"
+                if attr_cls == "DocumentAttributeVideo":
+                    return "video"
+                if attr_cls == "DocumentAttributeAnimated":
+                    return "gif"
+                if attr_cls == "DocumentAttributeSticker":
+                    return "sticker"
+    return short
+
+
+def message_to_content_blocks(
+    message: Any,
+    *,
+    account_label: str,
+    chat_id: int | str,
+) -> list[McplContentBlock]:
+    """Convert a Telethon Message into MCPL content blocks.
+
+    Phase 4 minimal: a single text block. If media is present and there's
+    no text, surface a `[<kind>]` placeholder. Media binary delivery comes
+    in a later phase; for now we additionally include a McplResourceContent
+    block pointing at the message URI so the host can fetch on demand.
+    """
+    blocks: list[McplContentBlock] = []
+    text = getattr(message, "message", None) or ""
+    kind = media_kind(message)
+
+    if text:
+        blocks.append(McplTextContent(type="text", text=text))
+    if kind:
+        if not text:
+            blocks.append(
+                McplTextContent(type="text", text=f"[{kind}]")
+            )
+        # Always attach the resource pointer when there's media — agent can
+        # follow it for the binary or rich content later.
+        blocks.append(
+            McplResourceContent(
+                type="resource",
+                uri=message_uri(account_label, chat_id, message.id),
+            )
+        )
+
+    if not blocks:
+        # Fallback for service messages with neither text nor media (joins,
+        # pin updates, etc.). The agent at least sees something.
+        blocks.append(McplTextContent(type="text", text="[message]"))
+
+    return blocks

--- a/telegram_mcp/mcpl/dispatcher.py
+++ b/telegram_mcp/mcpl/dispatcher.py
@@ -1,0 +1,169 @@
+"""MCPL method dispatcher.
+
+Routes inbound MCPL JSON-RPC frames to registered handlers, manages
+outbound request/response correlation, and is the single source of truth
+for which method names this server claims to handle.
+
+Phase 2 ships the routing infrastructure with zero handlers — methods
+hit by the host return JSON-RPC -32601 (method not found) until later
+phases register real implementations. Notifications without a handler
+are dropped silently per JSON-RPC convention.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .transport import McplTransport
+
+log = logging.getLogger("telegram_mcp.mcpl")
+
+# Method names this server handles or emits. The intercepting transport
+# checks `method in MCPL_METHODS` before forwarding to FastMCP, so any
+# method we want to capture must be listed here.
+MCPL_METHODS: frozenset[str] = frozenset(
+    {
+        # Server → Host (we emit; listed for symmetry, never received inbound)
+        "channels/register",
+        "channels/changed",
+        "channels/incoming",
+        "push/event",
+        # Host → Server (we receive)
+        "channels/list",
+        "channels/open",
+        "channels/close",
+        "channels/publish",
+        "channels/typing",
+        "featureSets/update",
+        "state/rollback",
+        "context/beforeInference",
+        "context/afterInference",
+    }
+)
+
+
+class McplError(Exception):
+    """Raised when an outbound MCPL request receives a JSON-RPC error response."""
+
+    def __init__(self, code: int, message: str, data: Any = None):
+        super().__init__(f"MCPL error {code}: {message}")
+        self.code = code
+        self.message = message
+        self.data = data
+
+
+HandlerFn = Callable[[dict[str, Any]], Awaitable[Any]]
+
+
+class McplDispatcher:
+    """Routes MCPL frames between the transport and the per-method handlers."""
+
+    def __init__(self) -> None:
+        self._handlers: dict[str, HandlerFn] = {}
+        self._pending_outbound: dict[int, asyncio.Future[Any]] = {}
+        self._next_id: int = 1
+
+    # -- handler registration -------------------------------------------------
+
+    def register(self, method: str, handler: HandlerFn) -> None:
+        """Register an async handler for an inbound MCPL request method."""
+        self._handlers[method] = handler
+
+    # -- inbound dispatch -----------------------------------------------------
+
+    async def handle_inbound(
+        self,
+        raw: dict[str, Any],
+        transport: McplTransport,
+    ) -> None:
+        """Dispatch an inbound MCPL frame.
+
+        Requests (`id` present) get a response (success or method-not-found).
+        Notifications (`id` absent) get no response; missing handlers are
+        dropped silently with a warning log.
+        """
+        method = raw.get("method")
+        msg_id = raw.get("id")
+        params = raw.get("params") or {}
+
+        handler = self._handlers.get(method) if method else None
+        if handler is None:
+            if msg_id is not None:
+                await transport.send_error(
+                    msg_id,
+                    code=-32601,
+                    message=f"Method not found: {method}",
+                )
+            else:
+                log.debug("MCPL notification dropped (no handler): %s", method)
+            return
+
+        try:
+            result = await handler(params)
+        except Exception as exc:  # noqa: BLE001 — JSON-RPC requires we capture all
+            log.exception("MCPL handler %s raised", method)
+            if msg_id is not None:
+                await transport.send_error(
+                    msg_id,
+                    code=-32603,
+                    message=f"Internal error: {exc}",
+                )
+            return
+
+        if msg_id is not None:
+            await transport.send_response(msg_id, result if result is not None else {})
+
+    # -- outbound request/response correlation -------------------------------
+
+    def is_pending_outbound(self, msg_id: Any) -> bool:
+        return isinstance(msg_id, int) and msg_id in self._pending_outbound
+
+    def resolve_outbound(self, msg_id: int, raw: dict[str, Any]) -> None:
+        fut = self._pending_outbound.pop(msg_id, None)
+        if fut is None or fut.done():
+            return
+        if "error" in raw:
+            err = raw["error"]
+            fut.set_exception(
+                McplError(
+                    code=err.get("code", -32000),
+                    message=err.get("message", "Unknown error"),
+                    data=err.get("data"),
+                )
+            )
+        else:
+            fut.set_result(raw.get("result"))
+
+    async def send_request(
+        self,
+        method: str,
+        params: dict[str, Any],
+        transport: McplTransport,
+    ) -> Any:
+        """Send a request to the host and await its response.
+
+        Caller awaits the result. On JSON-RPC error response, raises McplError.
+        """
+        msg_id = self._next_id
+        self._next_id += 1
+        fut: asyncio.Future[Any] = asyncio.get_event_loop().create_future()
+        self._pending_outbound[msg_id] = fut
+        try:
+            await transport.send_request(msg_id, method, params)
+        except Exception:
+            self._pending_outbound.pop(msg_id, None)
+            raise
+        return await fut
+
+    async def send_notification(
+        self,
+        method: str,
+        params: dict[str, Any] | None,
+        transport: McplTransport,
+    ) -> None:
+        """Send a notification (fire-and-forget) to the host."""
+        await transport.send_notification(method, params)

--- a/telegram_mcp/mcpl/events.py
+++ b/telegram_mcp/mcpl/events.py
@@ -1,0 +1,326 @@
+"""Telethon event → MCPL push translation.
+
+Wires `@client.on(events.NewMessage)` (and friends) for each configured
+TelegramClient. Each event is converted to a `ChannelIncomingMessage` with
+metadata rich enough to drive the host's `shouldTriggerInference` filter:
+
+  - botUserId, senderId, senderUsername
+  - chatType, chatTitle
+  - mentionIds, isMention
+  - isReply, replyToMessageId, replyToAuthorId, replyToContent (snippet)
+  - threadId for forum-topic supergroups
+  - isPrivate, accountLabel
+
+The handler emits `channels/incoming` notifications via the transport.
+Errors are swallowed and logged so a buggy mapping never tears down the
+event loop.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timezone
+from typing import TYPE_CHECKING, Any
+
+from telethon import TelegramClient, events
+from telethon.tl.types import (
+    Channel,
+    Chat,
+    MessageEntityMention,
+    MessageEntityMentionName,
+    User,
+)
+
+from .channels import channel_id_for, entity_to_descriptor
+from .content import message_to_content_blocks
+from .types import ChannelIncomingMessage
+
+if TYPE_CHECKING:
+    from .transport import McplTransport
+
+log = logging.getLogger("telegram_mcp.mcpl")
+
+REPLY_SNIPPET_MAX = 200
+
+# Tracks clients that already have MCPL handlers attached, so a host
+# reconnect (which fires on_ready again) doesn't double-attach and cause
+# every NewMessage to be pushed twice.
+_attached_clients: set[int] = set()
+
+
+def reset_attached_clients() -> None:
+    """Test helper: clear the attachment tracker between tests."""
+    _attached_clients.clear()
+
+
+def _peer_kind(chat: Any) -> str | None:
+    if isinstance(chat, User):
+        return "dm"
+    if isinstance(chat, Chat):
+        return "group"
+    if isinstance(chat, Channel):
+        if getattr(chat, "megagroup", False):
+            return "supergroup"
+        if getattr(chat, "broadcast", False):
+            return "channel"
+        return "supergroup"
+    return None
+
+
+def _author_dict(sender: Any) -> dict[str, Any]:
+    if sender is None:
+        return {"id": "unknown", "name": "Unknown"}
+    name_parts: list[str] = []
+    first = getattr(sender, "first_name", None)
+    last = getattr(sender, "last_name", None)
+    title = getattr(sender, "title", None)
+    if title:
+        name_parts.append(str(title))
+    else:
+        if first:
+            name_parts.append(first)
+        if last:
+            name_parts.append(last)
+    name = " ".join(p for p in name_parts if p) or (
+        f"@{sender.username}" if getattr(sender, "username", None) else f"id:{getattr(sender, 'id', '?')}"
+    )
+    return {"id": str(getattr(sender, "id", "unknown")), "name": name}
+
+
+def _extract_mention_ids(message: Any) -> list[int]:
+    """Extract user IDs explicitly mentioned via MessageEntityMentionName."""
+    entities = getattr(message, "entities", None) or []
+    out: list[int] = []
+    for ent in entities:
+        if isinstance(ent, MessageEntityMentionName):
+            out.append(ent.user_id)
+    return out
+
+
+def _has_username_mention(message: Any, username: str | None) -> bool:
+    if not username:
+        return False
+    entities = getattr(message, "entities", None) or []
+    text = getattr(message, "message", "") or ""
+    target = f"@{username}".lower()
+    for ent in entities:
+        if isinstance(ent, MessageEntityMention):
+            slice_ = text[ent.offset : ent.offset + ent.length]
+            if slice_.lower() == target:
+                return True
+    return False
+
+
+async def build_incoming_message(
+    event: events.NewMessage.Event,
+    *,
+    account_label: str,
+    self_id: int,
+    self_username: str | None,
+) -> ChannelIncomingMessage | None:
+    """Translate a Telethon NewMessage event to a ChannelIncomingMessage.
+
+    Returns None when the event is for an entity we can't map (forbidden,
+    unsupported peer type) — the caller skips silently.
+    """
+    message = event.message
+    chat = await event.get_chat()
+    descriptor = entity_to_descriptor(
+        chat, account_label=account_label, self_id=self_id
+    )
+    if descriptor is None:
+        return None
+
+    sender = await event.get_sender()
+    author = _author_dict(sender)
+    sender_id = getattr(sender, "id", None)
+    sender_username = getattr(sender, "username", None) if sender else None
+
+    mention_ids = _extract_mention_ids(message)
+    is_username_mention = _has_username_mention(message, self_username)
+    is_explicit_mention = self_id in mention_ids
+    is_mention = bool(getattr(message, "mentioned", False)) or is_username_mention or is_explicit_mention
+
+    chat_kind = descriptor["metadata"]["kind"]
+    chat_id = descriptor["address"]["peerId"]
+
+    metadata: dict[str, Any] = {
+        "account": account_label,
+        "botUserId": str(self_id),
+        "chatType": chat_kind,
+        "chatTitle": descriptor["label"],
+        "isPrivate": chat_kind in ("dm", "saved"),
+        "isMention": is_mention,
+        "isReply": False,
+        "isReplyToBot": False,
+        "mentionIds": [str(uid) for uid in mention_ids],
+    }
+    if sender_id is not None:
+        metadata["senderId"] = str(sender_id)
+    if sender_username:
+        metadata["senderUsername"] = sender_username
+
+    # Reply context — best-effort.
+    if getattr(message, "is_reply", False):
+        metadata["isReply"] = True
+        reply_to = getattr(message, "reply_to", None)
+        reply_to_id = getattr(reply_to, "reply_to_msg_id", None) if reply_to else None
+        if reply_to_id is not None:
+            metadata["replyToMessageId"] = str(reply_to_id)
+        try:
+            replied = await message.get_reply_message()
+        except Exception:  # noqa: BLE001 — never block on reply lookup
+            replied = None
+        if replied is not None:
+            replied_author_id = getattr(replied.sender_id, "user_id", None) or getattr(
+                replied, "sender_id", None
+            )
+            if replied_author_id is not None:
+                metadata["replyToAuthorId"] = str(replied_author_id)
+                if int(replied_author_id) == int(self_id):
+                    metadata["isReplyToBot"] = True
+            replied_text = (getattr(replied, "message", "") or "").strip()
+            if replied_text:
+                metadata["replyToContent"] = replied_text[:REPLY_SNIPPET_MAX]
+
+    # Forum topic id (supergroups only)
+    thread_id: str | None = None
+    reply_to = getattr(message, "reply_to", None)
+    if reply_to is not None and getattr(reply_to, "forum_topic", False):
+        top_id = getattr(reply_to, "reply_to_top_id", None) or getattr(
+            reply_to, "reply_to_msg_id", None
+        )
+        if top_id is not None:
+            thread_id = str(top_id)
+
+    timestamp = message.date.astimezone(timezone.utc).isoformat() if message.date else ""
+
+    incoming: ChannelIncomingMessage = {
+        "channelId": descriptor["id"],
+        "messageId": str(message.id),
+        "author": author,
+        "timestamp": timestamp,
+        "content": message_to_content_blocks(
+            message, account_label=account_label, chat_id=chat_id
+        ),
+        "metadata": metadata,
+    }
+    if thread_id is not None:
+        incoming["threadId"] = thread_id
+    return incoming
+
+
+async def _build_chat_action_payload(
+    event: events.ChatAction.Event,
+    *,
+    account_label: str,
+    self_id: int,
+) -> dict[str, Any] | None:
+    """Map ChatAction events into channels/changed payloads.
+
+    Returns one of:
+      - {"removed": [channelId]}    — we left or were kicked
+      - {"added":   [descriptor]}   — we joined a new chat
+      - None                         — uninteresting action (e.g., other user
+                                        joined or left, message pinned, etc.)
+    """
+    user_kicked = bool(getattr(event, "user_kicked", False))
+    user_left = bool(getattr(event, "user_left", False))
+    user_added = bool(getattr(event, "user_added", False))
+    user_joined = bool(getattr(event, "user_joined", False))
+
+    # Only react to events affecting OUR own membership.
+    affected_self = False
+    user_id = getattr(event, "user_id", None)
+    if isinstance(user_id, list):
+        affected_self = self_id in user_id
+    elif user_id is not None:
+        affected_self = int(user_id) == self_id
+    elif user_kicked or user_left or user_added or user_joined:
+        # Some Telethon paths set just the action flags + chat
+        affected_self = True
+
+    if not affected_self:
+        return None
+
+    chat = await event.get_chat()
+    if user_left or user_kicked:
+        descriptor = entity_to_descriptor(
+            chat, account_label=account_label, self_id=self_id
+        )
+        if descriptor is None:
+            return None
+        return {"removed": [descriptor["id"]]}
+    if user_added or user_joined:
+        descriptor = entity_to_descriptor(
+            chat, account_label=account_label, self_id=self_id
+        )
+        if descriptor is None:
+            return None
+        return {"added": [descriptor]}
+    return None
+
+
+async def attach_event_handlers(
+    client: TelegramClient,
+    *,
+    account_label: str,
+    transport: McplTransport,
+) -> None:
+    """Register Telethon event handlers for one client.
+
+    Currently:
+      - NewMessage → channels/incoming
+      - ChatAction → channels/changed (joins, leaves, kicks affecting us)
+
+    Idempotent: attaching twice on the same client is a no-op. Telethon
+    happily registers duplicate handlers, so we guard with a per-client
+    sentinel — protects against host-side reconnect re-firing on_ready.
+    """
+    if id(client) in _attached_clients:
+        log.info(
+            "MCPL handlers already attached for account '%s' — skipping (host reconnect?)",
+            account_label,
+        )
+        return
+
+    me = await client.get_me()
+    self_id = int(getattr(me, "id"))
+    self_username = getattr(me, "username", None)
+
+    @client.on(events.NewMessage)
+    async def on_new_message(event):  # pragma: no cover — real-Telegram path
+        try:
+            payload = await build_incoming_message(
+                event,
+                account_label=account_label,
+                self_id=self_id,
+                self_username=self_username,
+            )
+            if payload is None:
+                return
+            await transport.send_notification(
+                "channels/incoming", {"messages": [payload]}
+            )
+        except Exception:
+            log.exception("Failed to push NewMessage event")
+
+    @client.on(events.ChatAction)
+    async def on_chat_action(event):  # pragma: no cover — real-Telegram path
+        try:
+            payload = await _build_chat_action_payload(
+                event, account_label=account_label, self_id=self_id
+            )
+            if payload is None:
+                return
+            await transport.send_notification("channels/changed", payload)
+        except Exception:
+            log.exception("Failed to push ChatAction event")
+
+    _attached_clients.add(id(client))
+    log.info(
+        "Attached MCPL handlers (NewMessage, ChatAction) for account '%s' "
+        "(self_id=%s)",
+        account_label,
+        self_id,
+    )

--- a/telegram_mcp/mcpl/handlers.py
+++ b/telegram_mcp/mcpl/handlers.py
@@ -1,0 +1,239 @@
+"""Inbound MCPL handlers — methods the host calls on us.
+
+  - channels/publish — send agent's content via the right Telethon client.
+    Honors a custom `replyToMessageId` extension (not in the base MCPL
+    spec) which also auto-threads into the right forum topic when the
+    original message lived in one.
+  - channels/typing — fire a brief typing indicator on the target chat.
+  - channels/list — re-enumerate live dialogs and return the current set.
+  - channels/open / channels/close — minimal acknowledgements; channel
+    subscription is 'auto' on the host side, so these are mostly informational.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from telethon import TelegramClient
+
+from .channels import enumerate_channels
+from .types import ChannelsPublishParams, ChannelsPublishResult, McplContentBlock
+
+log = logging.getLogger("telegram_mcp.mcpl")
+
+
+# ---------------------------------------------------------------------------
+# Channel id parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_channel_id(channel_id: str) -> tuple[str, str, int | None]:
+    """Parse `telegram:{account}:{kind}[:{peer_id}]` into its components.
+
+    Saved Messages has no peer_id segment (kind='saved').
+    Raises ValueError on malformed input.
+    """
+    parts = channel_id.split(":")
+    if not parts or parts[0] != "telegram":
+        raise ValueError(f"Not a telegram channel id: {channel_id!r}")
+    if len(parts) == 3 and parts[2] == "saved":
+        return parts[1], "saved", None
+    if len(parts) == 4:
+        try:
+            peer_id = int(parts[3])
+        except ValueError as exc:
+            raise ValueError(f"Invalid peer id in {channel_id!r}") from exc
+        kind = parts[2]
+        if kind not in {"dm", "group", "supergroup", "channel"}:
+            raise ValueError(f"Unknown channel kind {kind!r} in {channel_id!r}")
+        return parts[1], kind, peer_id
+    raise ValueError(f"Malformed telegram channel id: {channel_id!r}")
+
+
+# ---------------------------------------------------------------------------
+# Content extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_text(content: list[McplContentBlock]) -> str:
+    """Concatenate text blocks. Non-text blocks are dropped with a warning.
+
+    Phase 5 supports text only. Image / audio / resource blocks are noted
+    in the log but not sent — sending media as the agent requires fetching
+    base64 data and is deferred.
+    """
+    text_parts: list[str] = []
+    skipped: list[str] = []
+    for block in content or []:
+        btype = block.get("type")
+        if btype == "text":
+            text_parts.append(block.get("text", ""))
+        else:
+            skipped.append(btype or "<unknown>")
+    if skipped:
+        log.warning(
+            "channels/publish dropped %d non-text content block(s): %s",
+            len(skipped),
+            skipped,
+        )
+    return "\n".join(p for p in text_parts if p)
+
+
+# ---------------------------------------------------------------------------
+# The handler
+# ---------------------------------------------------------------------------
+
+
+def make_publish_handler(
+    clients: dict[str, TelegramClient],
+    *,
+    resolve_entity_fn,
+    ensure_connected_fn,
+):
+    """Build the channels/publish handler bound to this server's clients.
+
+    `resolve_entity_fn` and `ensure_connected_fn` are the existing helpers
+    in `telegram_mcp.runtime`. Passed as parameters to keep this module
+    decoupled from the runtime singleton — it makes testing tractable.
+    """
+
+    async def handle_publish(params: ChannelsPublishParams) -> ChannelsPublishResult:
+        channel_id = params.get("channelId")
+        if not channel_id:
+            raise ValueError("channels/publish missing channelId")
+        content = params.get("content") or []
+
+        account_label, kind, peer_id = parse_channel_id(channel_id)
+        client = clients.get(account_label)
+        if client is None:
+            raise ValueError(
+                f"Unknown account '{account_label}' "
+                f"(known: {', '.join(sorted(clients))})"
+            )
+        await ensure_connected_fn(client)
+
+        if kind == "saved":
+            peer: Any = "me"
+        else:
+            assert peer_id is not None  # parse_channel_id guarantees this
+            peer = await resolve_entity_fn(peer_id, client)
+
+        text = extract_text(content)
+        if not text:
+            raise ValueError("channels/publish has no text content to send")
+
+        kwargs: dict[str, Any] = {}
+        reply_to_id = params.get("replyToMessageId")
+        if reply_to_id:
+            try:
+                kwargs["reply_to"] = int(reply_to_id)
+            except (TypeError, ValueError):
+                log.warning("Ignoring non-numeric replyToMessageId: %r", reply_to_id)
+
+        sent = await client.send_message(peer, text, **kwargs)
+        return {"delivered": True, "messageId": str(sent.id)}
+
+    return handle_publish
+
+
+# ---------------------------------------------------------------------------
+# channels/list
+# ---------------------------------------------------------------------------
+
+
+def make_list_handler(clients: dict[str, TelegramClient]):
+    """Re-enumerate dialogs across all configured accounts."""
+
+    async def handle_list(params: dict[str, Any]) -> dict[str, Any]:
+        channels = []
+        for label, cl in clients.items():
+            try:
+                channels.extend(await enumerate_channels(cl, label))
+            except Exception:
+                log.exception("channels/list — enumeration failed for %r", label)
+        return {"channels": channels}
+
+    return handle_list
+
+
+# ---------------------------------------------------------------------------
+# channels/open and channels/close — informational under 'auto' subscription
+# ---------------------------------------------------------------------------
+
+
+def make_open_handler():
+    """Acknowledge channels/open. We auto-subscribe everywhere; nothing to do."""
+
+    async def handle_open(params: dict[str, Any]) -> dict[str, Any]:
+        # The spec returns a ChannelDescriptor on success. The host already
+        # has it from the original channels/register; echo back what they
+        # asked about so the contract is satisfied.
+        return {
+            "channel": {
+                "id": params.get("address", {}).get("id")
+                or f"telegram:{params.get('type', 'unknown')}",
+                "type": params.get("type", "telegram"),
+                "label": "open-acknowledged",
+                "direction": "bidirectional",
+            }
+        }
+
+    return handle_open
+
+
+def make_close_handler():
+    """Acknowledge channels/close. No-op under auto subscription."""
+
+    async def handle_close(params: dict[str, Any]) -> dict[str, Any]:
+        return {"closed": True}
+
+    return handle_close
+
+
+# ---------------------------------------------------------------------------
+# channels/typing
+# ---------------------------------------------------------------------------
+
+
+def make_typing_handler(
+    clients: dict[str, TelegramClient],
+    *,
+    resolve_entity_fn,
+    ensure_connected_fn,
+    default_duration: float = 3.0,
+):
+    """Fire a brief typing pulse on the named channel.
+
+    channels/typing is a notification, so we kick off the actual typing in
+    a background task and return immediately — long pulses must not block
+    the dispatcher's reader loop.
+    """
+
+    async def _do_typing(client: TelegramClient, peer: Any, duration: float) -> None:
+        try:
+            async with client.action(peer, "typing"):
+                await asyncio.sleep(min(duration, 30.0))  # cap at Telegram's 30s
+        except Exception:
+            log.exception("channels/typing — action failed")
+
+    async def handle_typing(params: dict[str, Any]) -> None:
+        channel_id = params.get("channelId")
+        if not channel_id:
+            return
+        try:
+            account_label, kind, peer_id = parse_channel_id(channel_id)
+        except ValueError:
+            log.warning("channels/typing — bad channelId: %r", channel_id)
+            return
+        client = clients.get(account_label)
+        if client is None:
+            return
+        await ensure_connected_fn(client)
+        peer: Any = "me" if kind == "saved" else await resolve_entity_fn(peer_id, client)
+        duration = float(params.get("duration", default_duration))
+        # Fire and forget — the host doesn't expect a response.
+        asyncio.create_task(_do_typing(client, peer, duration))
+
+    return handle_typing

--- a/telegram_mcp/mcpl/transport.py
+++ b/telegram_mcp/mcpl/transport.py
@@ -1,0 +1,287 @@
+"""Intercepting stdio transport for MCPL.
+
+Python port of discord-mcp's McplInterceptingTransport.java. Reads real
+stdin line-by-line, classifies each JSON-RPC frame:
+
+  - MCPL methods (anything in `MCPL_METHODS`) → MCPL dispatcher
+  - JSON-RPC responses to our outbound requests → outbound queue
+  - everything else (standard MCP) → forwarded to FastMCP via an in-process
+    anyio MemoryObjectStream
+
+`initialize` is also peeked at on the way through to extract the host's
+declared MCPL capabilities (`params.capabilities.experimental.mcpl`),
+then forwarded to FastMCP unchanged.
+
+Outbound MCPL traffic (push events, host→server requests) shares the
+same `write_stream` that FastMCP writes to, so the existing stdout writer
+serializes everything in order under one anyio task — no manual stdout lock.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from collections.abc import Awaitable, Callable
+from contextlib import asynccontextmanager
+from io import TextIOWrapper
+from typing import Any
+
+import anyio
+from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+from mcp import types
+from mcp.server.fastmcp import FastMCP
+from mcp.shared.message import SessionMessage
+
+from .capabilities import build_experimental_capabilities
+from .dispatcher import MCPL_METHODS, McplDispatcher
+
+OnReadyHook = Callable[["McplTransport"], Awaitable[None]]
+"""Callback fired once the host has sent `notifications/initialized`.
+
+Use it to send `channels/register` and any other post-handshake setup
+that depends on the host being ready to receive server-initiated traffic.
+"""
+
+log = logging.getLogger("telegram_mcp.mcpl")
+
+
+class McplTransport:
+    """The MCPL side of the stdio transport.
+
+    Owns the write end so handlers can emit notifications, requests, and
+    responses. The host's MCPL capabilities are populated when `initialize`
+    is observed and stay accessible to handlers.
+    """
+
+    def __init__(self, dispatcher: McplDispatcher) -> None:
+        self.dispatcher = dispatcher
+        self._write_stream: MemoryObjectSendStream[SessionMessage] | None = None
+        self.host_capabilities: dict[str, Any] | None = None
+
+    # -- internal: bound by the stdio context manager -----------------------
+
+    def _bind_write_stream(self, write_stream: MemoryObjectSendStream[SessionMessage]) -> None:
+        self._write_stream = write_stream
+
+    # -- outbound primitives -------------------------------------------------
+
+    async def _send(self, msg: types.JSONRPCMessage) -> None:
+        if self._write_stream is None:
+            raise RuntimeError("McplTransport not started — write stream unbound")
+        await self._write_stream.send(SessionMessage(msg))
+
+    async def send_notification(self, method: str, params: dict[str, Any] | None = None) -> None:
+        notif = types.JSONRPCNotification(
+            jsonrpc="2.0",
+            method=method,
+            params=params or {},
+        )
+        await self._send(types.JSONRPCMessage(notif))
+
+    async def send_request(self, msg_id: int, method: str, params: dict[str, Any]) -> None:
+        req = types.JSONRPCRequest(
+            jsonrpc="2.0",
+            id=msg_id,
+            method=method,
+            params=params,
+        )
+        await self._send(types.JSONRPCMessage(req))
+
+    async def send_response(self, msg_id: int | str, result: Any) -> None:
+        resp = types.JSONRPCResponse(jsonrpc="2.0", id=msg_id, result=result)
+        await self._send(types.JSONRPCMessage(resp))
+
+    async def send_error(
+        self,
+        msg_id: int | str,
+        code: int,
+        message: str,
+        data: Any = None,
+    ) -> None:
+        error_data = types.ErrorData(code=code, message=message, data=data)
+        err = types.JSONRPCError(jsonrpc="2.0", id=msg_id, error=error_data)
+        await self._send(types.JSONRPCMessage(err))
+
+    # -- convenience for handlers ------------------------------------------
+
+    async def request(self, method: str, params: dict[str, Any]) -> Any:
+        """Send a request to the host and await its response."""
+        return await self.dispatcher.send_request(method, params, self)
+
+    async def notify(self, method: str, params: dict[str, Any] | None = None) -> None:
+        """Send a fire-and-forget notification to the host."""
+        await self.dispatcher.send_notification(method, params, self)
+
+
+@asynccontextmanager
+async def mcpl_stdio_server(
+    transport: McplTransport,
+    stdin: anyio.AsyncFile[str] | None = None,
+    stdout: anyio.AsyncFile[str] | None = None,
+    on_ready: OnReadyHook | None = None,
+):
+    """An stdio transport that intercepts MCPL methods.
+
+    Same shape as `mcp.server.stdio.stdio_server` — yields a (read, write)
+    pair of memory object streams that FastMCP plugs into. The difference
+    is in the stdin reader: each JSON line is classified before being
+    forwarded. `stdin`/`stdout` are accepted for tests; production passes
+    nothing and the real process streams are used.
+    """
+    if stdin is None:
+        stdin = anyio.wrap_file(
+            TextIOWrapper(sys.stdin.buffer, encoding="utf-8", errors="replace")
+        )
+    if stdout is None:
+        stdout = anyio.wrap_file(TextIOWrapper(sys.stdout.buffer, encoding="utf-8"))
+
+    read_stream_writer: MemoryObjectSendStream[SessionMessage | Exception]
+    read_stream: MemoryObjectReceiveStream[SessionMessage | Exception]
+    write_stream: MemoryObjectSendStream[SessionMessage]
+    write_stream_reader: MemoryObjectReceiveStream[SessionMessage]
+
+    read_stream_writer, read_stream = anyio.create_memory_object_stream(0)
+    write_stream, write_stream_reader = anyio.create_memory_object_stream(0)
+
+    transport._bind_write_stream(write_stream)
+
+    async def intercepting_stdin_reader() -> None:
+        try:
+            async with read_stream_writer:
+                async for line in stdin:
+                    stripped = line.strip()
+                    if not stripped:
+                        continue
+
+                    try:
+                        raw = json.loads(stripped)
+                    except json.JSONDecodeError as exc:
+                        await read_stream_writer.send(exc)
+                        continue
+
+                    if not isinstance(raw, dict):
+                        # Malformed — send to FastMCP which will validate and
+                        # surface the error via its session.
+                        try:
+                            msg = types.JSONRPCMessage.model_validate(raw)
+                            await read_stream_writer.send(SessionMessage(msg))
+                        except Exception as exc:  # noqa: BLE001
+                            await read_stream_writer.send(exc)
+                        continue
+
+                    method = raw.get("method")
+
+                    # Peek at initialize to remember host MCPL capabilities;
+                    # then forward to FastMCP unchanged.
+                    if method == "initialize":
+                        try:
+                            transport.host_capabilities = (
+                                raw.get("params", {})
+                                .get("capabilities", {})
+                                .get("experimental", {})
+                                .get("mcpl")
+                            )
+                            if transport.host_capabilities:
+                                log.info(
+                                    "Host MCPL detected: version=%s",
+                                    transport.host_capabilities.get("version"),
+                                )
+                        except Exception:  # noqa: BLE001 — never fail handshake
+                            log.warning(
+                                "Failed to extract host MCPL capabilities", exc_info=True
+                            )
+
+                    # Host is done initializing — fire on_ready, then forward.
+                    # Only fire if the host actually advertised MCPL; vanilla
+                    # MCP hosts ignore our server-initiated traffic anyway.
+                    if (
+                        method == "notifications/initialized"
+                        and on_ready is not None
+                        and transport.host_capabilities is not None
+                    ):
+                        log.info("Host signaled initialized — firing on_ready hook")
+                        tg.start_soon(_safe_on_ready, on_ready, transport)
+
+                    # MCPL inbound method → dispatch, do not forward to FastMCP.
+                    if method in MCPL_METHODS:
+                        await transport.dispatcher.handle_inbound(raw, transport)
+                        continue
+
+                    # JSON-RPC response (no method field, has id + result/error)
+                    # — match against pending outbound requests.
+                    if method is None and ("result" in raw or "error" in raw):
+                        msg_id = raw.get("id")
+                        if transport.dispatcher.is_pending_outbound(msg_id):
+                            transport.dispatcher.resolve_outbound(msg_id, raw)
+                            continue
+
+                    # Standard MCP — forward to FastMCP.
+                    try:
+                        msg = types.JSONRPCMessage.model_validate(raw)
+                        await read_stream_writer.send(SessionMessage(msg))
+                    except Exception as exc:  # noqa: BLE001
+                        await read_stream_writer.send(exc)
+        except anyio.ClosedResourceError:  # pragma: no cover
+            await anyio.lowlevel.checkpoint()
+
+    async def stdout_writer() -> None:
+        try:
+            async with write_stream_reader:
+                async for session_message in write_stream_reader:
+                    json_str = session_message.message.model_dump_json(
+                        by_alias=True, exclude_none=True
+                    )
+                    await stdout.write(json_str + "\n")
+                    await stdout.flush()
+        except anyio.ClosedResourceError:  # pragma: no cover
+            await anyio.lowlevel.checkpoint()
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(intercepting_stdin_reader)
+        tg.start_soon(stdout_writer)
+        try:
+            yield read_stream, write_stream
+        finally:
+            transport._write_stream = None
+
+
+async def _safe_on_ready(hook: OnReadyHook, transport: McplTransport) -> None:
+    """Run the on_ready hook, swallowing exceptions so they don't kill the
+    transport task group. Errors are logged."""
+    try:
+        await hook(transport)
+    except Exception:  # noqa: BLE001
+        log.exception("on_ready hook raised")
+
+
+async def run_stdio_with_mcpl(
+    mcp: FastMCP,
+    dispatcher: McplDispatcher | None = None,
+    on_ready: OnReadyHook | None = None,
+) -> McplTransport:
+    """Run FastMCP over the MCPL-intercepting stdio transport.
+
+    `on_ready`, if provided, runs as a background task once the host's
+    `notifications/initialized` arrives. That's the right moment to send
+    `channels/register` and similar server-initiated traffic.
+
+    Returns the McplTransport once the server exits — callers can inspect
+    final state in tests. In production the coroutine never returns until
+    the host disconnects.
+    """
+    if dispatcher is None:
+        dispatcher = McplDispatcher()
+    transport = McplTransport(dispatcher)
+    async with mcpl_stdio_server(transport, on_ready=on_ready) as (
+        read_stream,
+        write_stream,
+    ):
+        await mcp._mcp_server.run(
+            read_stream,
+            write_stream,
+            mcp._mcp_server.create_initialization_options(
+                experimental_capabilities=build_experimental_capabilities(),
+            ),
+        )
+    return transport

--- a/telegram_mcp/mcpl/types.py
+++ b/telegram_mcp/mcpl/types.py
@@ -1,0 +1,140 @@
+"""MCPL wire-format types used by this server.
+
+Mirrors the TypeScript definitions in
+agent-framework/src/mcpl/types.ts (same monorepo). Only the subset this
+server emits or accepts is modeled here. Use plain TypedDicts so the JSON
+serialization is trivial and the host's type expectations stay authoritative.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, TypedDict
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC envelope
+# ---------------------------------------------------------------------------
+
+
+class JsonRpcRequest(TypedDict, total=False):
+    jsonrpc: Literal["2.0"]
+    method: str
+    id: int | str
+    params: dict[str, Any]
+
+
+class JsonRpcResponse(TypedDict, total=False):
+    jsonrpc: Literal["2.0"]
+    id: int | str
+    result: Any
+    error: "JsonRpcError"
+
+
+class JsonRpcError(TypedDict, total=False):
+    code: int
+    message: str
+    data: Any
+
+
+# ---------------------------------------------------------------------------
+# Content blocks (Section 4)
+# ---------------------------------------------------------------------------
+
+
+class McplTextContent(TypedDict):
+    type: Literal["text"]
+    text: str
+
+
+class McplImageContent(TypedDict, total=False):
+    type: Literal["image"]
+    data: str
+    mimeType: str
+    uri: str
+
+
+class McplAudioContent(TypedDict, total=False):
+    type: Literal["audio"]
+    data: str
+    mimeType: str
+    uri: str
+
+
+class McplResourceContent(TypedDict):
+    type: Literal["resource"]
+    uri: str
+
+
+McplContentBlock = McplTextContent | McplImageContent | McplAudioContent | McplResourceContent
+
+
+# ---------------------------------------------------------------------------
+# Channels (Section 14)
+# ---------------------------------------------------------------------------
+
+
+class ChannelDescriptor(TypedDict, total=False):
+    id: str
+    type: str
+    label: str
+    direction: Literal["outbound", "inbound", "bidirectional"]
+    address: dict[str, Any]
+    metadata: dict[str, Any]
+
+
+class ChannelAuthor(TypedDict):
+    id: str
+    name: str
+
+
+class ChannelIncomingMessage(TypedDict, total=False):
+    channelId: str
+    messageId: str
+    threadId: str
+    author: ChannelAuthor
+    timestamp: str
+    content: list[McplContentBlock]
+    metadata: dict[str, Any]
+
+
+class ChannelsRegisterParams(TypedDict):
+    channels: list[ChannelDescriptor]
+
+
+class ChannelsChangedParams(TypedDict, total=False):
+    added: list[ChannelDescriptor]
+    removed: list[str]
+    updated: list[ChannelDescriptor]
+
+
+class ChannelsIncomingParams(TypedDict):
+    messages: list[ChannelIncomingMessage]
+
+
+class ChannelsPublishParams(TypedDict, total=False):
+    conversationId: str
+    channelId: str
+    stream: bool
+    content: list[McplContentBlock]
+
+
+class ChannelsPublishResult(TypedDict, total=False):
+    delivered: bool
+    messageId: str
+
+
+# ---------------------------------------------------------------------------
+# Push events (Section 9)
+# ---------------------------------------------------------------------------
+
+
+class PushEventPayload(TypedDict):
+    content: list[McplContentBlock]
+
+
+class PushEventParams(TypedDict, total=False):
+    featureSet: str
+    eventId: str
+    timestamp: str
+    origin: dict[str, Any]
+    payload: PushEventPayload

--- a/telegram_mcp/runner.py
+++ b/telegram_mcp/runner.py
@@ -9,6 +9,82 @@ except UnsafeInstallationError as exc:
 
 from telegram_mcp.runtime import *
 import telegram_mcp.tools  # noqa: F401 - registers MCP tools via decorators
+from telegram_mcp.mcpl.channels import enumerate_channels
+from telegram_mcp.mcpl.dispatcher import McplDispatcher
+from telegram_mcp.mcpl.events import attach_event_handlers
+from telegram_mcp.mcpl.handlers import (
+    make_close_handler,
+    make_list_handler,
+    make_open_handler,
+    make_publish_handler,
+    make_typing_handler,
+)
+from telegram_mcp.mcpl.transport import McplTransport, run_stdio_with_mcpl
+
+
+def _build_dispatcher() -> McplDispatcher:
+    """Construct the MCPL dispatcher with all server-side handlers wired in."""
+    dispatcher = McplDispatcher()
+    dispatcher.register(
+        "channels/publish",
+        make_publish_handler(
+            clients,
+            resolve_entity_fn=resolve_entity,
+            ensure_connected_fn=ensure_connected,
+        ),
+    )
+    dispatcher.register("channels/list", make_list_handler(clients))
+    dispatcher.register("channels/open", make_open_handler())
+    dispatcher.register("channels/close", make_close_handler())
+    dispatcher.register(
+        "channels/typing",
+        make_typing_handler(
+            clients,
+            resolve_entity_fn=resolve_entity,
+            ensure_connected_fn=ensure_connected,
+        ),
+    )
+    return dispatcher
+
+
+async def _build_on_ready_hook():
+    """After the host signals it's initialized: enumerate Telegram dialogs
+    across all accounts, register them as MCPL channels, and attach the
+    Telethon event handlers that translate NewMessage events into
+    `channels/incoming` pushes.
+    """
+
+    async def on_ready(transport: McplTransport) -> None:
+        all_channels = []
+        for label, cl in clients.items():
+            try:
+                channels = await enumerate_channels(cl, label)
+                all_channels.extend(channels)
+            except Exception as exc:  # noqa: BLE001 — never block the agent on enumeration
+                print(
+                    f"Failed to enumerate channels for account '{label}': {exc}",
+                    file=sys.stderr,
+                )
+        await transport.send_notification(
+            "channels/register", {"channels": all_channels}
+        )
+        print(
+            f"Registered {len(all_channels)} MCPL channels with host",
+            file=sys.stderr,
+        )
+
+        for label, cl in clients.items():
+            try:
+                await attach_event_handlers(
+                    cl, account_label=label, transport=transport
+                )
+            except Exception as exc:  # noqa: BLE001
+                print(
+                    f"Failed to attach event handlers for account '{label}': {exc}",
+                    file=sys.stderr,
+                )
+
+    return on_ready
 
 
 async def _main() -> None:
@@ -23,8 +99,13 @@ async def _main() -> None:
         await asyncio.gather(*(cl.get_dialogs() for cl in clients.values()))
 
         print(f"Telegram client(s) started ({labels}). Running MCP server...", file=sys.stderr)
-        # Use the asynchronous entrypoint instead of mcp.run()
-        await mcp.run_stdio_async()
+        # MCPL-aware stdio runner — advertises experimental.mcpl in the
+        # initialize handshake, registers Telegram dialogs as MCPL channels
+        # once the host signals ready, and exposes channels/publish so the
+        # host can send messages through us.
+        on_ready = await _build_on_ready_hook()
+        dispatcher = _build_dispatcher()
+        await run_stdio_with_mcpl(mcp, dispatcher=dispatcher, on_ready=on_ready)
     except Exception as e:
         print(f"Error starting client: {e}", file=sys.stderr)
         if isinstance(e, sqlite3.OperationalError) and "database is locked" in str(e):

--- a/tests/test_mcpl_capabilities.py
+++ b/tests/test_mcpl_capabilities.py
@@ -1,0 +1,40 @@
+"""Phase 1 regression tests for MCPL capability advertisement."""
+
+from mcp.server.fastmcp import FastMCP
+
+from telegram_mcp.mcpl import MCPL_VERSION
+from telegram_mcp.mcpl.capabilities import (
+    build_experimental_capabilities,
+    build_mcpl_capabilities,
+)
+
+
+def test_mcpl_version_pinned():
+    assert MCPL_VERSION == "0.4"
+
+
+def test_capabilities_shape():
+    caps = build_mcpl_capabilities()
+    assert caps["version"] == "0.4"
+    assert caps["pushEvents"] is True
+    assert caps["channels"]["register"] is True
+    assert caps["channels"]["publish"] is True
+    assert caps["channels"]["lifecycle"] is True
+
+
+def test_experimental_wrapper_namespaces_under_mcpl():
+    wrapped = build_experimental_capabilities()
+    assert set(wrapped.keys()) == {"mcpl"}
+    assert wrapped["mcpl"] == build_mcpl_capabilities()
+
+
+def test_capabilities_flow_through_create_initialization_options():
+    """Smoke test: capabilities reach the actual initialize-response surface."""
+    mcp = FastMCP("telegram-test")
+    opts = mcp._mcp_server.create_initialization_options(
+        experimental_capabilities=build_experimental_capabilities(),
+    )
+    assert opts.capabilities.experimental is not None
+    assert "mcpl" in opts.capabilities.experimental
+    assert opts.capabilities.experimental["mcpl"]["version"] == "0.4"
+    assert opts.capabilities.experimental["mcpl"]["pushEvents"] is True

--- a/tests/test_mcpl_channels.py
+++ b/tests/test_mcpl_channels.py
@@ -1,0 +1,258 @@
+"""Phase 3 tests — Telegram entity → ChannelDescriptor mapping."""
+
+from types import SimpleNamespace
+
+import pytest
+from telethon.tl.types import (
+    Channel,
+    ChannelForbidden,
+    Chat,
+    ChatBannedRights,
+    ChatForbidden,
+    User,
+)
+
+from telegram_mcp.mcpl.channels import (
+    channel_id_for,
+    entity_to_descriptor,
+)
+
+
+def make_user(user_id: int, **overrides):
+    base = dict(
+        id=user_id,
+        is_self=False,
+        contact=False,
+        mutual_contact=False,
+        deleted=False,
+        bot=False,
+        bot_chat_history=False,
+        bot_nochats=False,
+        verified=False,
+        restricted=False,
+        min=False,
+        bot_inline_geo=False,
+        support=False,
+        scam=False,
+        apply_min_photo=False,
+        fake=False,
+        bot_attach_menu=False,
+        premium=False,
+        attach_menu_enabled=False,
+        access_hash=None,
+        first_name="Alice",
+        last_name=None,
+        username=None,
+        phone=None,
+        photo=None,
+        status=None,
+        bot_info_version=None,
+        restriction_reason=None,
+        bot_inline_placeholder=None,
+        lang_code=None,
+    )
+    base.update(overrides)
+    return User(**base)
+
+
+def make_chat(chat_id: int, **overrides):
+    base = dict(
+        id=chat_id,
+        title=f"Chat {chat_id}",
+        photo=None,
+        participants_count=2,
+        date=None,
+        version=1,
+        creator=False,
+        left=False,
+        deactivated=False,
+        call_active=False,
+        call_not_empty=False,
+        noforwards=False,
+        migrated_to=None,
+        admin_rights=None,
+        default_banned_rights=None,
+    )
+    base.update(overrides)
+    return Chat(**base)
+
+
+def make_channel(chan_id: int, *, broadcast: bool, megagroup: bool, **overrides):
+    base = dict(
+        id=chan_id,
+        title=f"Channel {chan_id}",
+        photo=None,
+        date=None,
+        creator=False,
+        left=False,
+        broadcast=broadcast,
+        verified=False,
+        megagroup=megagroup,
+        restricted=False,
+        signatures=False,
+        min=False,
+        scam=False,
+        has_link=False,
+        has_geo=False,
+        slowmode_enabled=False,
+        call_active=False,
+        call_not_empty=False,
+        fake=False,
+        gigagroup=False,
+        noforwards=False,
+        join_to_send=False,
+        join_request=False,
+        forum=False,
+        access_hash=None,
+        username=None,
+        restriction_reason=None,
+        admin_rights=None,
+        banned_rights=None,
+        default_banned_rights=None,
+        participants_count=None,
+        usernames=None,
+        stories_hidden=False,
+        stories_hidden_min=False,
+        stories_unavailable=False,
+        stories_max_id=None,
+        color=None,
+        profile_color=None,
+        emoji_status=None,
+        level=None,
+        subscription_until_date=None,
+    )
+    base.update(overrides)
+    return Channel(**base)
+
+
+# ---------------------------------------------------------------------------
+# channel_id_for
+# ---------------------------------------------------------------------------
+
+
+def test_channel_id_for_dm():
+    assert channel_id_for("default", "dm", 12345) == "telegram:default:dm:12345"
+
+
+def test_channel_id_for_supergroup():
+    assert (
+        channel_id_for("workacct", "supergroup", 998)
+        == "telegram:workacct:supergroup:998"
+    )
+
+
+def test_channel_id_for_saved_ignores_peer_id():
+    assert channel_id_for("default", "saved", 12345) == "telegram:default:saved"
+
+
+# ---------------------------------------------------------------------------
+# entity_to_descriptor
+# ---------------------------------------------------------------------------
+
+
+def test_user_becomes_dm_channel_bidirectional():
+    user = make_user(42)
+    desc = entity_to_descriptor(user, account_label="default", self_id=99)
+    assert desc is not None
+    assert desc["id"] == "telegram:default:dm:42"
+    assert desc["type"] == "telegram"
+    assert desc["direction"] == "bidirectional"
+    assert desc["metadata"]["kind"] == "dm"
+    assert desc["metadata"]["account"] == "default"
+    assert desc["address"]["peerId"] == 42
+
+
+def test_self_user_becomes_saved_messages():
+    me = make_user(99, first_name="Me")
+    desc = entity_to_descriptor(me, account_label="default", self_id=99)
+    assert desc is not None
+    assert desc["id"] == "telegram:default:saved"
+    assert desc["metadata"]["kind"] == "saved"
+    assert desc["direction"] == "bidirectional"
+
+
+def test_chat_becomes_group_channel():
+    chat = make_chat(1001)
+    desc = entity_to_descriptor(chat, account_label="default")
+    assert desc is not None
+    assert desc["id"] == "telegram:default:group:1001"
+    assert desc["metadata"]["kind"] == "group"
+    assert desc["direction"] == "bidirectional"
+
+
+def test_deactivated_chat_returns_none():
+    chat = make_chat(1001, deactivated=True)
+    assert entity_to_descriptor(chat, account_label="default") is None
+
+
+def test_supergroup_becomes_supergroup_channel():
+    chan = make_channel(2001, broadcast=False, megagroup=True, title="The Cool Group")
+    desc = entity_to_descriptor(chan, account_label="default")
+    assert desc is not None
+    assert desc["id"] == "telegram:default:supergroup:2001"
+    assert desc["metadata"]["kind"] == "supergroup"
+    assert desc["direction"] == "bidirectional"
+    assert desc["label"] == "The Cool Group"
+
+
+def test_supergroup_with_forum_marked_in_metadata():
+    chan = make_channel(2001, broadcast=False, megagroup=True, forum=True)
+    desc = entity_to_descriptor(chan, account_label="default")
+    assert desc is not None
+    assert desc["metadata"].get("forum") is True
+
+
+def test_broadcast_channel_subscriber_is_inbound_only():
+    chan = make_channel(3001, broadcast=True, megagroup=False)
+    desc = entity_to_descriptor(chan, account_label="default")
+    assert desc is not None
+    assert desc["id"] == "telegram:default:channel:3001"
+    assert desc["direction"] == "inbound"
+
+
+def test_broadcast_channel_creator_is_bidirectional():
+    chan = make_channel(3001, broadcast=True, megagroup=False, creator=True)
+    desc = entity_to_descriptor(chan, account_label="default")
+    assert desc is not None
+    assert desc["direction"] == "bidirectional"
+
+
+def test_broadcast_channel_admin_is_bidirectional():
+    # Anything truthy in admin_rights flips us to bidirectional
+    chan = make_channel(
+        3001,
+        broadcast=True,
+        megagroup=False,
+        admin_rights=SimpleNamespace(post_messages=True),
+    )
+    desc = entity_to_descriptor(chan, account_label="default")
+    assert desc is not None
+    assert desc["direction"] == "bidirectional"
+
+
+def test_username_propagates_to_metadata():
+    user = make_user(42, username="alice", first_name="Alice")
+    desc = entity_to_descriptor(user, account_label="default")
+    assert desc is not None
+    assert desc["metadata"].get("username") == "alice"
+
+
+def test_label_falls_back_to_username_then_id():
+    user = make_user(42, first_name="", username="alice")
+    desc = entity_to_descriptor(user, account_label="default")
+    assert desc is not None
+    assert desc["label"] == "@alice"
+
+    nameless = make_user(43, first_name="", username=None)
+    desc2 = entity_to_descriptor(nameless, account_label="default")
+    assert desc2 is not None
+    assert desc2["label"] == "user:43"
+
+
+def test_account_label_threads_through_to_id_and_metadata():
+    user = make_user(42)
+    desc = entity_to_descriptor(user, account_label="workacct")
+    assert desc is not None
+    assert desc["id"] == "telegram:workacct:dm:42"
+    assert desc["metadata"]["account"] == "workacct"
+    assert desc["address"]["account"] == "workacct"

--- a/tests/test_mcpl_content.py
+++ b/tests/test_mcpl_content.py
@@ -1,0 +1,98 @@
+"""Phase 4 tests — Telegram message → McplContentBlock conversion."""
+
+from types import SimpleNamespace
+
+from telegram_mcp.mcpl.content import (
+    media_kind,
+    message_to_content_blocks,
+    message_uri,
+)
+
+
+def test_message_uri_format():
+    assert (
+        message_uri("default", 1234, 567)
+        == "telegram://message/default/1234/567"
+    )
+    # Negative chat IDs (channels in Telegram) survive verbatim
+    assert (
+        message_uri("workacct", -100123, 999)
+        == "telegram://message/workacct/-100123/999"
+    )
+
+
+def test_media_kind_no_media():
+    msg = SimpleNamespace(media=None)
+    assert media_kind(msg) is None
+
+
+def test_media_kind_photo():
+    class MessageMediaPhoto:
+        pass
+    msg = SimpleNamespace(media=MessageMediaPhoto())
+    assert media_kind(msg) == "photo"
+
+
+def test_media_kind_voice_note():
+    class DocumentAttributeAudio:
+        def __init__(self, voice):
+            self.voice = voice
+
+    class Document:
+        attributes = [DocumentAttributeAudio(voice=True)]
+
+    class MessageMediaDocument:
+        document = Document()
+
+    msg = SimpleNamespace(media=MessageMediaDocument())
+    assert media_kind(msg) == "voice"
+
+
+def test_media_kind_sticker():
+    class DocumentAttributeSticker:
+        pass
+
+    class Document:
+        attributes = [DocumentAttributeSticker()]
+
+    class MessageMediaDocument:
+        document = Document()
+
+    msg = SimpleNamespace(media=MessageMediaDocument())
+    assert media_kind(msg) == "sticker"
+
+
+def test_message_to_content_blocks_text_only():
+    msg = SimpleNamespace(message="hello world", media=None, id=42)
+    blocks = message_to_content_blocks(msg, account_label="default", chat_id=100)
+    assert blocks == [{"type": "text", "text": "hello world"}]
+
+
+def test_message_to_content_blocks_media_only_yields_placeholder_and_resource():
+    class _MMP:
+        pass
+    _MMP.__name__ = "MessageMediaPhoto"
+    msg = SimpleNamespace(message="", media=_MMP(), id=42)
+    blocks = message_to_content_blocks(msg, account_label="default", chat_id=100)
+    assert blocks == [
+        {"type": "text", "text": "[photo]"},
+        {"type": "resource", "uri": "telegram://message/default/100/42"},
+    ]
+
+
+def test_message_to_content_blocks_text_plus_media():
+    class _MMP:
+        pass
+    _MMP.__name__ = "MessageMediaPhoto"
+    msg = SimpleNamespace(message="check this out", media=_MMP(), id=42)
+    blocks = message_to_content_blocks(msg, account_label="default", chat_id=100)
+    assert blocks == [
+        {"type": "text", "text": "check this out"},
+        {"type": "resource", "uri": "telegram://message/default/100/42"},
+    ]
+
+
+def test_message_to_content_blocks_empty_falls_back():
+    msg = SimpleNamespace(message="", media=None, id=42)
+    blocks = message_to_content_blocks(msg, account_label="default", chat_id=100)
+    assert blocks == [{"type": "text", "text": "[message]"}]

--- a/tests/test_mcpl_dispatcher.py
+++ b/tests/test_mcpl_dispatcher.py
@@ -1,0 +1,161 @@
+"""Phase 2 tests — dispatcher routing logic, decoupled from real I/O."""
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from telegram_mcp.mcpl.dispatcher import McplDispatcher, McplError
+
+
+class FakeTransport:
+    """Captures outbound calls without serialising over a real stream."""
+
+    def __init__(self) -> None:
+        self.errors: list[tuple[Any, int, str]] = []
+        self.responses: list[tuple[Any, Any]] = []
+        self.requests: list[tuple[int, str, dict]] = []
+        self.notifications: list[tuple[str, dict | None]] = []
+
+    async def send_error(
+        self, msg_id: Any, code: int, message: str, data: Any = None
+    ) -> None:
+        self.errors.append((msg_id, code, message))
+
+    async def send_response(self, msg_id: Any, result: Any) -> None:
+        self.responses.append((msg_id, result))
+
+    async def send_request(self, msg_id: int, method: str, params: dict) -> None:
+        self.requests.append((msg_id, method, params))
+
+    async def send_notification(self, method: str, params: dict | None) -> None:
+        self.notifications.append((method, params))
+
+
+@pytest.mark.asyncio
+async def test_request_with_handler_returns_result():
+    d = McplDispatcher()
+    d.register("channels/publish", lambda params: _async_result({"delivered": True, "messageId": "42"}))
+    t = FakeTransport()
+
+    await d.handle_inbound(
+        {"jsonrpc": "2.0", "id": 1, "method": "channels/publish", "params": {}},
+        t,
+    )
+
+    assert t.responses == [(1, {"delivered": True, "messageId": "42"})]
+    assert not t.errors
+
+
+@pytest.mark.asyncio
+async def test_request_without_handler_returns_method_not_found():
+    d = McplDispatcher()
+    t = FakeTransport()
+
+    await d.handle_inbound(
+        {"jsonrpc": "2.0", "id": 7, "method": "channels/publish", "params": {}},
+        t,
+    )
+
+    assert len(t.errors) == 1
+    msg_id, code, message = t.errors[0]
+    assert msg_id == 7
+    assert code == -32601
+    assert "channels/publish" in message
+
+
+@pytest.mark.asyncio
+async def test_notification_without_handler_is_dropped_silently():
+    d = McplDispatcher()
+    t = FakeTransport()
+
+    await d.handle_inbound(
+        {"jsonrpc": "2.0", "method": "channels/changed", "params": {"added": []}},
+        t,
+    )
+
+    # No response, no error — notification is fire-and-forget.
+    assert not t.errors
+    assert not t.responses
+
+
+@pytest.mark.asyncio
+async def test_handler_exception_yields_internal_error_for_request():
+    d = McplDispatcher()
+
+    async def boom(params):
+        raise RuntimeError("kaboom")
+
+    d.register("channels/publish", boom)
+    t = FakeTransport()
+
+    await d.handle_inbound(
+        {"jsonrpc": "2.0", "id": 9, "method": "channels/publish", "params": {}},
+        t,
+    )
+
+    assert len(t.errors) == 1
+    msg_id, code, message = t.errors[0]
+    assert msg_id == 9
+    assert code == -32603
+    assert "kaboom" in message
+
+
+@pytest.mark.asyncio
+async def test_outbound_request_correlates_response_by_id():
+    d = McplDispatcher()
+    t = FakeTransport()
+
+    async def driver():
+        # Wait until send_request has emitted on the wire and registered its future.
+        while not t.requests:
+            await asyncio.sleep(0)
+        msg_id = t.requests[-1][0]
+        d.resolve_outbound(msg_id, {"jsonrpc": "2.0", "id": msg_id, "result": {"ok": True}})
+
+    request_task = asyncio.create_task(
+        d.send_request("channels/incoming", {"messages": []}, t)
+    )
+    driver_task = asyncio.create_task(driver())
+    result, _ = await asyncio.gather(request_task, driver_task)
+
+    assert result == {"ok": True}
+    assert len(t.requests) == 1
+    assert t.requests[0][1] == "channels/incoming"
+
+
+@pytest.mark.asyncio
+async def test_outbound_request_raises_on_error_response():
+    d = McplDispatcher()
+    t = FakeTransport()
+
+    async def driver():
+        while not t.requests:
+            await asyncio.sleep(0)
+        msg_id = t.requests[-1][0]
+        d.resolve_outbound(
+            msg_id,
+            {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "error": {"code": -32000, "message": "no such channel"},
+            },
+        )
+
+    request_task = asyncio.create_task(
+        d.send_request("channels/incoming", {"messages": []}, t)
+    )
+    driver_task = asyncio.create_task(driver())
+
+    with pytest.raises(McplError) as exc_info:
+        await asyncio.gather(request_task, driver_task)
+
+    assert exc_info.value.code == -32000
+    assert "no such channel" in exc_info.value.message
+
+
+# -- helpers -----------------------------------------------------------------
+
+
+async def _async_result(value):
+    return value

--- a/tests/test_mcpl_events.py
+++ b/tests/test_mcpl_events.py
@@ -1,0 +1,474 @@
+"""Phase 4 tests — Telethon NewMessage event → ChannelIncomingMessage."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from telethon.tl.types import (
+    Channel,
+    Chat,
+    MessageEntityMention,
+    MessageEntityMentionName,
+    User,
+)
+
+from telegram_mcp.mcpl.events import (
+    _attached_clients,
+    _author_dict,
+    _build_chat_action_payload,
+    _extract_mention_ids,
+    _has_username_mention,
+    attach_event_handlers,
+    build_incoming_message,
+    reset_attached_clients,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build fakes of Telethon types just rich enough for the tests
+# ---------------------------------------------------------------------------
+
+
+def make_user(uid: int, *, first="", last=None, username=None) -> User:
+    return User(
+        id=uid,
+        is_self=False,
+        contact=False,
+        mutual_contact=False,
+        deleted=False,
+        bot=False,
+        bot_chat_history=False,
+        bot_nochats=False,
+        verified=False,
+        restricted=False,
+        min=False,
+        bot_inline_geo=False,
+        support=False,
+        scam=False,
+        apply_min_photo=False,
+        fake=False,
+        bot_attach_menu=False,
+        premium=False,
+        attach_menu_enabled=False,
+        access_hash=None,
+        first_name=first,
+        last_name=last,
+        username=username,
+        phone=None,
+        photo=None,
+        status=None,
+        bot_info_version=None,
+        restriction_reason=None,
+        bot_inline_placeholder=None,
+        lang_code=None,
+    )
+
+
+class FakeMessage:
+    """Telethon Message-like fake for build_incoming_message."""
+
+    def __init__(
+        self,
+        *,
+        id: int,
+        text: str,
+        date=None,
+        entities=None,
+        media=None,
+        is_reply: bool = False,
+        reply_to=None,
+        replied=None,
+        mentioned: bool = False,
+    ):
+        self.id = id
+        self.message = text
+        self.date = date or datetime(2026, 5, 7, tzinfo=timezone.utc)
+        self.entities = entities or []
+        self.media = media
+        self.is_reply = is_reply
+        self.reply_to = reply_to
+        self.mentioned = mentioned
+        self._replied = replied
+
+    async def get_reply_message(self):
+        return self._replied
+
+
+class FakeEvent:
+    def __init__(self, message: FakeMessage, chat: Any, sender: Any):
+        self.message = message
+        self._chat = chat
+        self._sender = sender
+
+    async def get_chat(self):
+        return self._chat
+
+    async def get_sender(self):
+        return self._sender
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_author_dict_user_with_full_name():
+    user = make_user(7, first="Alice", last="Wonderland")
+    assert _author_dict(user) == {"id": "7", "name": "Alice Wonderland"}
+
+
+def test_author_dict_user_falls_back_to_username():
+    user = make_user(7, first="", username="alice")
+    assert _author_dict(user) == {"id": "7", "name": "@alice"}
+
+
+def test_author_dict_unknown_sender():
+    assert _author_dict(None) == {"id": "unknown", "name": "Unknown"}
+
+
+def test_extract_mention_ids_returns_user_ids_from_entities():
+    msg = SimpleNamespace(
+        entities=[
+            MessageEntityMentionName(offset=0, length=5, user_id=42),
+            MessageEntityMention(offset=10, length=6),  # @bare username — no id
+            MessageEntityMentionName(offset=20, length=5, user_id=99),
+        ]
+    )
+    assert _extract_mention_ids(msg) == [42, 99]
+
+
+def test_has_username_mention_matches_case_insensitive():
+    msg = SimpleNamespace(
+        message="hello @MyBot how are you",
+        entities=[MessageEntityMention(offset=6, length=6)],
+    )
+    assert _has_username_mention(msg, "mybot") is True
+    assert _has_username_mention(msg, "otherbot") is False
+    assert _has_username_mention(msg, None) is False
+
+
+# ---------------------------------------------------------------------------
+# build_incoming_message — the integrated path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dm_text_message_basic_metadata():
+    chat = make_user(42, first="Alice", username="alice")  # the OTHER party in a DM
+    sender = chat
+    msg = FakeMessage(id=100, text="hi there")
+    event = FakeEvent(msg, chat, sender)
+
+    out = await build_incoming_message(
+        event, account_label="default", self_id=99, self_username="mybot"
+    )
+
+    assert out is not None
+    assert out["channelId"] == "telegram:default:dm:42"
+    assert out["messageId"] == "100"
+    assert out["author"] == {"id": "42", "name": "Alice"}
+    assert out["content"] == [{"type": "text", "text": "hi there"}]
+    assert out["timestamp"].endswith("+00:00")
+    md = out["metadata"]
+    assert md["account"] == "default"
+    assert md["botUserId"] == "99"
+    assert md["chatType"] == "dm"
+    assert md["isPrivate"] is True
+    assert md["isReply"] is False
+    assert md["isMention"] is False
+    assert md["mentionIds"] == []
+    assert md["senderId"] == "42"
+    assert md["senderUsername"] == "alice"
+
+
+@pytest.mark.asyncio
+async def test_username_mention_marks_isMention():
+    chat = make_user(42, first="Alice")
+    sender = chat
+    msg = FakeMessage(
+        id=100,
+        text="hey @MyBot please help",
+        entities=[MessageEntityMention(offset=4, length=6)],
+    )
+    event = FakeEvent(msg, chat, sender)
+
+    out = await build_incoming_message(
+        event, account_label="default", self_id=99, self_username="MyBot"
+    )
+
+    assert out is not None
+    assert out["metadata"]["isMention"] is True
+
+
+@pytest.mark.asyncio
+async def test_explicit_mention_name_marks_isMention_with_id_in_list():
+    chat = make_user(42, first="Alice")
+    sender = chat
+    msg = FakeMessage(
+        id=100,
+        text="hey  please help",
+        entities=[MessageEntityMentionName(offset=4, length=2, user_id=99)],
+    )
+    event = FakeEvent(msg, chat, sender)
+
+    out = await build_incoming_message(
+        event, account_label="default", self_id=99, self_username=None
+    )
+
+    assert out is not None
+    assert out["metadata"]["isMention"] is True
+    assert "99" in out["metadata"]["mentionIds"]
+
+
+@pytest.mark.asyncio
+async def test_reply_metadata_includes_snippet_and_author():
+    chat = make_user(42, first="Alice")
+    sender = chat
+    replied = FakeMessage(id=50, text="original message text")
+    replied.sender_id = 99  # we are the original author
+    msg = FakeMessage(
+        id=100,
+        text="thanks",
+        is_reply=True,
+        reply_to=SimpleNamespace(reply_to_msg_id=50, forum_topic=False),
+        replied=replied,
+    )
+    event = FakeEvent(msg, chat, sender)
+
+    out = await build_incoming_message(
+        event, account_label="default", self_id=99, self_username=None
+    )
+
+    assert out is not None
+    md = out["metadata"]
+    assert md["isReply"] is True
+    assert md["replyToMessageId"] == "50"
+    assert md["replyToContent"] == "original message text"
+    assert md["replyToAuthorId"] == "99"
+    assert md["isReplyToBot"] is True
+
+
+class FakeChatActionEvent:
+    """Mimics events.ChatAction.Event enough for _build_chat_action_payload."""
+
+    def __init__(self, chat, *, user_id=None, **flags):
+        self._chat = chat
+        self.user_id = user_id
+        for name in (
+            "user_kicked",
+            "user_left",
+            "user_added",
+            "user_joined",
+        ):
+            setattr(self, name, flags.get(name, False))
+
+    async def get_chat(self):
+        return self._chat
+
+
+@pytest.mark.asyncio
+async def test_attach_event_handlers_is_idempotent_per_client():
+    """A host reconnect re-fires on_ready; duplicate attachment must no-op."""
+    reset_attached_clients()
+
+    on_calls: list[str] = []
+
+    class FakeMe:
+        id = 99
+        username = "mybot"
+
+    class FakeClient:
+        def __init__(self):
+            self.handlers: list = []
+
+        async def get_me(self):
+            return FakeMe()
+
+        def on(self, event_filter):
+            def decorator(fn):
+                on_calls.append(type(event_filter).__name__)
+                self.handlers.append(fn)
+                return fn
+
+            return decorator
+
+    class FakeTransport:
+        async def send_notification(self, *args, **kwargs):
+            pass
+
+    client = FakeClient()
+    transport = FakeTransport()
+
+    await attach_event_handlers(client, account_label="default", transport=transport)
+    first_attach_count = len(on_calls)
+    assert first_attach_count >= 1
+    assert id(client) in _attached_clients
+
+    # Second call (simulating host reconnect → on_ready re-fire) must no-op.
+    await attach_event_handlers(client, account_label="default", transport=transport)
+    assert len(on_calls) == first_attach_count, (
+        "attach_event_handlers must be idempotent per client"
+    )
+
+
+@pytest.mark.asyncio
+async def test_chat_action_self_left_emits_removed():
+    chat = make_user(42, first="Alice")  # placeholder — using a Chat would be more realistic
+    # Use a real Chat fixture
+    from telethon.tl.types import Chat as TelChat
+
+    chat = TelChat(
+        id=1001,
+        title="Group",
+        photo=None,
+        participants_count=1,
+        date=None,
+        version=1,
+        creator=False,
+        left=True,
+        deactivated=False,
+        call_active=False,
+        call_not_empty=False,
+        noforwards=False,
+        migrated_to=None,
+        admin_rights=None,
+        default_banned_rights=None,
+    )
+    event = FakeChatActionEvent(chat, user_id=99, user_left=True)
+
+    payload = await _build_chat_action_payload(
+        event, account_label="default", self_id=99
+    )
+    assert payload == {"removed": ["telegram:default:group:1001"]}
+
+
+@pytest.mark.asyncio
+async def test_chat_action_other_user_left_returns_none():
+    from telethon.tl.types import Chat as TelChat
+
+    chat = TelChat(
+        id=1001,
+        title="Group",
+        photo=None,
+        participants_count=2,
+        date=None,
+        version=1,
+        creator=False,
+        left=False,
+        deactivated=False,
+        call_active=False,
+        call_not_empty=False,
+        noforwards=False,
+        migrated_to=None,
+        admin_rights=None,
+        default_banned_rights=None,
+    )
+    # Someone ELSE (user 7) left — we (99) don't care
+    event = FakeChatActionEvent(chat, user_id=7, user_left=True)
+
+    payload = await _build_chat_action_payload(
+        event, account_label="default", self_id=99
+    )
+    assert payload is None
+
+
+@pytest.mark.asyncio
+async def test_chat_action_self_joined_emits_added():
+    from telethon.tl.types import Chat as TelChat
+
+    chat = TelChat(
+        id=1001,
+        title="New Group",
+        photo=None,
+        participants_count=2,
+        date=None,
+        version=1,
+        creator=False,
+        left=False,
+        deactivated=False,
+        call_active=False,
+        call_not_empty=False,
+        noforwards=False,
+        migrated_to=None,
+        admin_rights=None,
+        default_banned_rights=None,
+    )
+    event = FakeChatActionEvent(chat, user_id=99, user_joined=True)
+
+    payload = await _build_chat_action_payload(
+        event, account_label="default", self_id=99
+    )
+    assert payload is not None
+    assert "added" in payload
+    assert len(payload["added"]) == 1
+    assert payload["added"][0]["id"] == "telegram:default:group:1001"
+
+
+@pytest.mark.asyncio
+async def test_supergroup_forum_topic_emits_threadId():
+    # Build a supergroup channel
+    from telethon.tl.types import Channel as TelChannel
+
+    chat = TelChannel(
+        id=1000,
+        title="Forum",
+        photo=None,
+        date=None,
+        creator=False,
+        left=False,
+        broadcast=False,
+        verified=False,
+        megagroup=True,
+        restricted=False,
+        signatures=False,
+        min=False,
+        scam=False,
+        has_link=False,
+        has_geo=False,
+        slowmode_enabled=False,
+        call_active=False,
+        call_not_empty=False,
+        fake=False,
+        gigagroup=False,
+        noforwards=False,
+        join_to_send=False,
+        join_request=False,
+        forum=True,
+        access_hash=None,
+        username=None,
+        restriction_reason=None,
+        admin_rights=None,
+        banned_rights=None,
+        default_banned_rights=None,
+        participants_count=None,
+        usernames=None,
+        stories_hidden=False,
+        stories_hidden_min=False,
+        stories_unavailable=False,
+        stories_max_id=None,
+        color=None,
+        profile_color=None,
+        emoji_status=None,
+        level=None,
+        subscription_until_date=None,
+    )
+    sender = make_user(42, first="Alice")
+    msg = FakeMessage(
+        id=100,
+        text="in topic 7",
+        reply_to=SimpleNamespace(
+            reply_to_msg_id=7,
+            reply_to_top_id=7,
+            forum_topic=True,
+        ),
+    )
+    event = FakeEvent(msg, chat, sender)
+
+    out = await build_incoming_message(
+        event, account_label="default", self_id=99, self_username=None
+    )
+
+    assert out is not None
+    assert out["threadId"] == "7"
+    assert out["channelId"] == "telegram:default:supergroup:1000"

--- a/tests/test_mcpl_handlers.py
+++ b/tests/test_mcpl_handlers.py
@@ -1,0 +1,430 @@
+"""Phase 5–6 tests — channels/publish, channels/list, channels/open,
+channels/close, channels/typing handlers."""
+
+import asyncio
+
+import pytest
+
+from telegram_mcp.mcpl.handlers import (
+    extract_text,
+    make_close_handler,
+    make_list_handler,
+    make_open_handler,
+    make_publish_handler,
+    make_typing_handler,
+    parse_channel_id,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_channel_id
+# ---------------------------------------------------------------------------
+
+
+def test_parse_channel_id_dm():
+    assert parse_channel_id("telegram:default:dm:42") == ("default", "dm", 42)
+
+
+def test_parse_channel_id_group_supergroup_channel():
+    assert parse_channel_id("telegram:work:group:1001") == ("work", "group", 1001)
+    assert parse_channel_id("telegram:work:supergroup:2001") == (
+        "work",
+        "supergroup",
+        2001,
+    )
+    assert parse_channel_id("telegram:work:channel:3001") == ("work", "channel", 3001)
+
+
+def test_parse_channel_id_saved():
+    assert parse_channel_id("telegram:default:saved") == ("default", "saved", None)
+
+
+def test_parse_channel_id_negative_chat_id():
+    # Telegram channels' marked IDs are negative; must round-trip
+    assert parse_channel_id("telegram:default:supergroup:-1001234567890") == (
+        "default",
+        "supergroup",
+        -1001234567890,
+    )
+
+
+def test_parse_channel_id_malformed():
+    with pytest.raises(ValueError):
+        parse_channel_id("not-a-telegram-channel")
+    with pytest.raises(ValueError):
+        parse_channel_id("telegram:default:unknown:42")
+    with pytest.raises(ValueError):
+        parse_channel_id("telegram:default:dm:notanumber")
+
+
+# ---------------------------------------------------------------------------
+# extract_text
+# ---------------------------------------------------------------------------
+
+
+def test_extract_text_concatenates_blocks():
+    blocks = [
+        {"type": "text", "text": "hello"},
+        {"type": "text", "text": "world"},
+    ]
+    assert extract_text(blocks) == "hello\nworld"
+
+
+def test_extract_text_drops_non_text():
+    blocks = [
+        {"type": "text", "text": "hi"},
+        {"type": "image", "data": "..."},
+        {"type": "resource", "uri": "telegram://..."},
+    ]
+    assert extract_text(blocks) == "hi"
+
+
+def test_extract_text_empty():
+    assert extract_text([]) == ""
+    assert extract_text([{"type": "image", "data": "..."}]) == ""
+
+
+# ---------------------------------------------------------------------------
+# Publish handler
+# ---------------------------------------------------------------------------
+
+
+class FakeClient:
+    def __init__(self):
+        self.sent: list[tuple] = []
+
+    async def send_message(self, peer, text, **kwargs):
+        self.sent.append((peer, text, kwargs))
+        return _SentMessage(id=999)
+
+
+class _SentMessage:
+    def __init__(self, id):
+        self.id = id
+
+
+@pytest.mark.asyncio
+async def test_publish_to_dm_calls_send_message_with_resolved_entity():
+    client = FakeClient()
+    resolved = {"_entity": True}
+
+    async def resolve_entity_fn(peer_id, client_):
+        assert peer_id == 42
+        assert client_ is client
+        return resolved
+
+    async def ensure_connected_fn(c):
+        assert c is client
+
+    handle = make_publish_handler(
+        {"default": client},
+        resolve_entity_fn=resolve_entity_fn,
+        ensure_connected_fn=ensure_connected_fn,
+    )
+
+    result = await handle(
+        {
+            "channelId": "telegram:default:dm:42",
+            "content": [{"type": "text", "text": "hello"}],
+        }
+    )
+
+    assert result == {"delivered": True, "messageId": "999"}
+    assert client.sent == [(resolved, "hello", {})]
+
+
+@pytest.mark.asyncio
+async def test_publish_to_saved_uses_me_alias():
+    client = FakeClient()
+
+    async def resolve_entity_fn(peer_id, client_):
+        pytest.fail("should not resolve for saved")
+
+    async def ensure_connected_fn(c):
+        pass
+
+    handle = make_publish_handler(
+        {"default": client},
+        resolve_entity_fn=resolve_entity_fn,
+        ensure_connected_fn=ensure_connected_fn,
+    )
+
+    result = await handle(
+        {
+            "channelId": "telegram:default:saved",
+            "content": [{"type": "text", "text": "note to self"}],
+        }
+    )
+
+    assert result["delivered"] is True
+    assert client.sent == [("me", "note to self", {})]
+
+
+@pytest.mark.asyncio
+async def test_publish_with_reply_to_message_id_threads_correctly():
+    client = FakeClient()
+    resolved = object()
+
+    async def resolve_entity_fn(peer_id, client_):
+        return resolved
+
+    async def ensure_connected_fn(c):
+        pass
+
+    handle = make_publish_handler(
+        {"default": client},
+        resolve_entity_fn=resolve_entity_fn,
+        ensure_connected_fn=ensure_connected_fn,
+    )
+
+    await handle(
+        {
+            "channelId": "telegram:default:supergroup:1001",
+            "content": [{"type": "text", "text": "thread reply"}],
+            "replyToMessageId": "7",
+        }
+    )
+
+    assert client.sent == [(resolved, "thread reply", {"reply_to": 7})]
+
+
+@pytest.mark.asyncio
+async def test_publish_routes_to_correct_account():
+    client_a = FakeClient()
+    client_b = FakeClient()
+
+    async def resolve_entity_fn(peer_id, client_):
+        return f"resolved-on-{id(client_)}"
+
+    async def ensure_connected_fn(c):
+        pass
+
+    handle = make_publish_handler(
+        {"alpha": client_a, "beta": client_b},
+        resolve_entity_fn=resolve_entity_fn,
+        ensure_connected_fn=ensure_connected_fn,
+    )
+
+    await handle(
+        {
+            "channelId": "telegram:beta:dm:42",
+            "content": [{"type": "text", "text": "to beta"}],
+        }
+    )
+
+    assert client_a.sent == []
+    assert len(client_b.sent) == 1
+
+
+@pytest.mark.asyncio
+async def test_publish_unknown_account_raises():
+    client = FakeClient()
+
+    async def resolve_entity_fn(peer_id, client_):
+        return None
+
+    async def ensure_connected_fn(c):
+        pass
+
+    handle = make_publish_handler(
+        {"default": client},
+        resolve_entity_fn=resolve_entity_fn,
+        ensure_connected_fn=ensure_connected_fn,
+    )
+
+    with pytest.raises(ValueError, match="Unknown account"):
+        await handle(
+            {
+                "channelId": "telegram:nonexistent:dm:42",
+                "content": [{"type": "text", "text": "hi"}],
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_publish_with_only_non_text_content_raises():
+    client = FakeClient()
+
+    async def resolve_entity_fn(peer_id, client_):
+        return None
+
+    async def ensure_connected_fn(c):
+        pass
+
+    handle = make_publish_handler(
+        {"default": client},
+        resolve_entity_fn=resolve_entity_fn,
+        ensure_connected_fn=ensure_connected_fn,
+    )
+
+    with pytest.raises(ValueError, match="no text content"):
+        await handle(
+            {
+                "channelId": "telegram:default:dm:42",
+                "content": [{"type": "image", "data": "fake"}],
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# channels/list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_handler_aggregates_across_accounts(monkeypatch):
+    enumerate_calls: list[str] = []
+
+    async def fake_enumerate(client, label):
+        enumerate_calls.append(label)
+        return [{"id": f"telegram:{label}:dm:1", "type": "telegram"}]
+
+    monkeypatch.setattr(
+        "telegram_mcp.mcpl.handlers.enumerate_channels", fake_enumerate
+    )
+    handle = make_list_handler({"alpha": object(), "beta": object()})
+
+    out = await handle({})
+
+    assert sorted(enumerate_calls) == ["alpha", "beta"]
+    ids = sorted(c["id"] for c in out["channels"])
+    assert ids == ["telegram:alpha:dm:1", "telegram:beta:dm:1"]
+
+
+@pytest.mark.asyncio
+async def test_list_handler_continues_when_one_account_fails(monkeypatch):
+    async def fake_enumerate(client, label):
+        if label == "broken":
+            raise RuntimeError("oops")
+        return [{"id": f"telegram:{label}:saved"}]
+
+    monkeypatch.setattr(
+        "telegram_mcp.mcpl.handlers.enumerate_channels", fake_enumerate
+    )
+    handle = make_list_handler({"good": object(), "broken": object()})
+
+    out = await handle({})
+    assert out["channels"] == [{"id": "telegram:good:saved"}]
+
+
+# ---------------------------------------------------------------------------
+# channels/open and channels/close
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_open_handler_acknowledges():
+    handle = make_open_handler()
+    out = await handle({"type": "telegram"})
+    assert "channel" in out
+    assert out["channel"]["type"] == "telegram"
+    assert out["channel"]["direction"] == "bidirectional"
+
+
+@pytest.mark.asyncio
+async def test_close_handler_returns_closed_true():
+    handle = make_close_handler()
+    out = await handle({"channelId": "telegram:default:dm:1"})
+    assert out == {"closed": True}
+
+
+# ---------------------------------------------------------------------------
+# channels/typing — fire-and-forget background task
+# ---------------------------------------------------------------------------
+
+
+class FakeAction:
+    """Mimics Telethon's client.action(entity, 'typing') context manager."""
+
+    def __init__(self, recorder, peer):
+        self._recorder = recorder
+        self._peer = peer
+
+    async def __aenter__(self):
+        self._recorder.append(("typing-start", self._peer))
+        return self
+
+    async def __aexit__(self, *args):
+        self._recorder.append(("typing-end", self._peer))
+
+
+class FakeClientWithAction(FakeClient):
+    def __init__(self):
+        super().__init__()
+        self.actions: list[tuple] = []
+
+    def action(self, peer, kind):
+        return FakeAction(self.actions, (peer, kind))
+
+
+@pytest.mark.asyncio
+async def test_typing_handler_returns_immediately_and_runs_in_background():
+    client = FakeClientWithAction()
+    resolved = object()
+
+    async def resolve_entity_fn(peer_id, client_):
+        return resolved
+
+    async def ensure_connected_fn(c):
+        pass
+
+    handle = make_typing_handler(
+        {"default": client},
+        resolve_entity_fn=resolve_entity_fn,
+        ensure_connected_fn=ensure_connected_fn,
+        default_duration=0.01,
+    )
+
+    # Handler must NOT block for the duration of the typing action.
+    result = await asyncio.wait_for(
+        handle({"channelId": "telegram:default:dm:42"}), timeout=0.5
+    )
+    assert result is None  # notification — no return value
+
+    # Let the background typing task run.
+    await asyncio.sleep(0.05)
+    assert ("typing-start", (resolved, "typing")) in client.actions
+    assert ("typing-end", (resolved, "typing")) in client.actions
+
+
+@pytest.mark.asyncio
+async def test_typing_handler_silently_drops_unknown_account():
+    client = FakeClientWithAction()
+
+    async def resolve_entity_fn(peer_id, client_):
+        return None
+
+    async def ensure_connected_fn(c):
+        pass
+
+    handle = make_typing_handler(
+        {"default": client},
+        resolve_entity_fn=resolve_entity_fn,
+        ensure_connected_fn=ensure_connected_fn,
+    )
+
+    # Should not raise; should not record anything.
+    await handle({"channelId": "telegram:nonexistent:dm:42"})
+    await asyncio.sleep(0.02)
+    assert client.actions == []
+
+
+@pytest.mark.asyncio
+async def test_typing_handler_silently_drops_malformed_channel_id():
+    client = FakeClientWithAction()
+
+    async def resolve_entity_fn(peer_id, client_):
+        return None
+
+    async def ensure_connected_fn(c):
+        pass
+
+    handle = make_typing_handler(
+        {"default": client},
+        resolve_entity_fn=resolve_entity_fn,
+        ensure_connected_fn=ensure_connected_fn,
+    )
+
+    await handle({"channelId": "not-a-real-id"})
+    await asyncio.sleep(0.02)
+    assert client.actions == []

--- a/tests/test_mcpl_transport.py
+++ b/tests/test_mcpl_transport.py
@@ -1,0 +1,431 @@
+"""Phase 2 tests — McplTransport outbound message construction
+and the intercepting stdin classifier.
+
+For the stdin classifier we feed a fake AsyncFile through `mcpl_stdio_server`
+and read both the FastMCP-bound forwards (from `read_stream`) and the
+host-bound outbound (from `stdout`). FastMCP itself is never started.
+"""
+
+import asyncio
+import json
+
+import anyio
+import pytest
+
+from telegram_mcp.mcpl.dispatcher import MCPL_METHODS, McplDispatcher
+from telegram_mcp.mcpl.transport import McplTransport, mcpl_stdio_server
+
+
+# ---------------------------------------------------------------------------
+# Outbound message construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_notification_emits_jsonrpc_notification():
+    transport = McplTransport(McplDispatcher())
+    send_stream, receive_stream = anyio.create_memory_object_stream(4)
+    transport._bind_write_stream(send_stream)
+
+    await transport.send_notification("channels/changed", {"added": [{"id": "x"}]})
+    session_message = receive_stream.receive_nowait()
+    payload = json.loads(
+        session_message.message.model_dump_json(by_alias=True, exclude_none=True)
+    )
+    assert payload == {
+        "jsonrpc": "2.0",
+        "method": "channels/changed",
+        "params": {"added": [{"id": "x"}]},
+    }
+
+
+@pytest.mark.asyncio
+async def test_send_request_emits_jsonrpc_request_with_id():
+    transport = McplTransport(McplDispatcher())
+    send_stream, receive_stream = anyio.create_memory_object_stream(4)
+    transport._bind_write_stream(send_stream)
+
+    await transport.send_request(7, "channels/incoming", {"messages": []})
+    session_message = receive_stream.receive_nowait()
+    payload = json.loads(
+        session_message.message.model_dump_json(by_alias=True, exclude_none=True)
+    )
+    assert payload == {
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": "channels/incoming",
+        "params": {"messages": []},
+    }
+
+
+@pytest.mark.asyncio
+async def test_send_response_and_error():
+    transport = McplTransport(McplDispatcher())
+    send_stream, receive_stream = anyio.create_memory_object_stream(4)
+    transport._bind_write_stream(send_stream)
+
+    await transport.send_response(11, {"delivered": True, "messageId": "abc"})
+    await transport.send_error(12, code=-32601, message="Method not found: foo")
+
+    response = json.loads(
+        receive_stream.receive_nowait().message.model_dump_json(
+            by_alias=True, exclude_none=True
+        )
+    )
+    error = json.loads(
+        receive_stream.receive_nowait().message.model_dump_json(
+            by_alias=True, exclude_none=True
+        )
+    )
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": 11,
+        "result": {"delivered": True, "messageId": "abc"},
+    }
+    assert error == {
+        "jsonrpc": "2.0",
+        "id": 12,
+        "error": {"code": -32601, "message": "Method not found: foo"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_send_before_bind_raises():
+    transport = McplTransport(McplDispatcher())
+    with pytest.raises(RuntimeError, match="not started"):
+        await transport.send_notification("channels/changed", {})
+
+
+# ---------------------------------------------------------------------------
+# Intercepting classifier
+# ---------------------------------------------------------------------------
+
+
+class FakeAsyncFile:
+    """Minimal AsyncFile-shaped fake for stdin/stdout in tests."""
+
+    def __init__(self, content: str = "") -> None:
+        # Preserve newlines so `async for line` yields one line at a time.
+        self._lines = content.splitlines(keepends=True)
+        self._idx = 0
+        self.written: list[str] = []
+
+    def __aiter__(self) -> "FakeAsyncFile":
+        return self
+
+    async def __anext__(self) -> str:
+        if self._idx >= len(self._lines):
+            raise StopAsyncIteration
+        line = self._lines[self._idx]
+        self._idx += 1
+        return line
+
+    async def write(self, data: str) -> None:
+        self.written.append(data)
+
+    async def flush(self) -> None:
+        pass
+
+
+async def _drain_lines(fake_stdout: FakeAsyncFile) -> list[dict]:
+    return [json.loads(line.rstrip()) for line in fake_stdout.written if line.strip()]
+
+
+@pytest.mark.asyncio
+async def test_inbound_mcpl_request_routes_to_handler_not_to_fastmcp():
+    """An MCPL method must be intercepted; FastMCP must never see it."""
+    dispatcher = McplDispatcher()
+    handler_calls: list[dict] = []
+
+    async def publish_handler(params: dict) -> dict:
+        handler_calls.append(params)
+        return {"delivered": True, "messageId": "msg-1"}
+
+    dispatcher.register("channels/publish", publish_handler)
+    transport = McplTransport(dispatcher)
+
+    line = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 99,
+            "method": "channels/publish",
+            "params": {"channelId": "telegram:dm:1", "content": []},
+        }
+    )
+    stdin = FakeAsyncFile(line + "\n")
+    stdout = FakeAsyncFile()
+
+    forwarded: list = []
+
+    async def consume_forwarded(read_stream):
+        async for item in read_stream:
+            forwarded.append(item)
+
+    with anyio.fail_after(2.0):
+        async with mcpl_stdio_server(transport, stdin=stdin, stdout=stdout) as (
+            read_stream,
+            write_stream,
+        ):
+            consumer = asyncio.create_task(consume_forwarded(read_stream))
+            # Give the reader/writer time to flow the message end-to-end.
+            for _ in range(20):
+                if stdout.written and not stdout.written[-1].endswith(""):
+                    pass
+                if stdout.written:
+                    break
+                await asyncio.sleep(0.01)
+            await write_stream.aclose()
+            await read_stream.aclose()
+            consumer.cancel()
+            try:
+                await consumer
+            except (asyncio.CancelledError, anyio.ClosedResourceError):
+                pass
+
+    assert handler_calls == [{"channelId": "telegram:dm:1", "content": []}]
+    payloads = await _drain_lines(stdout)
+    assert payloads == [
+        {"jsonrpc": "2.0", "id": 99, "result": {"delivered": True, "messageId": "msg-1"}}
+    ]
+    # Critically, no MCPL traffic leaked into the FastMCP-bound stream.
+    assert forwarded == []
+
+
+@pytest.mark.asyncio
+async def test_initialize_extracts_host_capabilities_and_forwards():
+    """initialize must reach FastMCP; host MCPL caps must be captured."""
+    dispatcher = McplDispatcher()
+    transport = McplTransport(dispatcher)
+
+    init_line = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {
+                    "experimental": {
+                        "mcpl": {"version": "0.4", "pushEvents": True}
+                    }
+                },
+                "clientInfo": {"name": "test", "version": "1"},
+            },
+        }
+    )
+    stdin = FakeAsyncFile(init_line + "\n")
+    stdout = FakeAsyncFile()
+
+    forwarded: list = []
+
+    async def consume_forwarded(read_stream):
+        async for item in read_stream:
+            forwarded.append(item)
+
+    with anyio.fail_after(2.0):
+        async with mcpl_stdio_server(transport, stdin=stdin, stdout=stdout) as (
+            read_stream,
+            write_stream,
+        ):
+            consumer = asyncio.create_task(consume_forwarded(read_stream))
+            for _ in range(20):
+                if forwarded:
+                    break
+                await asyncio.sleep(0.01)
+            await write_stream.aclose()
+            await read_stream.aclose()
+            consumer.cancel()
+            try:
+                await consumer
+            except (asyncio.CancelledError, anyio.ClosedResourceError):
+                pass
+
+    # initialize must be forwarded — FastMCP owns it
+    assert len(forwarded) == 1
+    # And we captured the host's MCPL caps
+    assert transport.host_capabilities == {"version": "0.4", "pushEvents": True}
+
+
+@pytest.mark.asyncio
+async def test_response_to_outbound_request_does_not_reach_fastmcp():
+    """When we have a pending outbound, the matching response is consumed by us."""
+    dispatcher = McplDispatcher()
+    transport = McplTransport(dispatcher)
+
+    # Pre-register a pending outbound request so id=42 is recognized.
+    fut: asyncio.Future = asyncio.get_event_loop().create_future()
+    dispatcher._pending_outbound[42] = fut
+
+    response_line = json.dumps(
+        {"jsonrpc": "2.0", "id": 42, "result": {"ok": True}}
+    )
+    stdin = FakeAsyncFile(response_line + "\n")
+    stdout = FakeAsyncFile()
+
+    forwarded: list = []
+
+    async def consume_forwarded(read_stream):
+        async for item in read_stream:
+            forwarded.append(item)
+
+    with anyio.fail_after(2.0):
+        async with mcpl_stdio_server(transport, stdin=stdin, stdout=stdout) as (
+            read_stream,
+            write_stream,
+        ):
+            consumer = asyncio.create_task(consume_forwarded(read_stream))
+            # Wait for the future to resolve
+            for _ in range(50):
+                if fut.done():
+                    break
+                await asyncio.sleep(0.01)
+            await write_stream.aclose()
+            await read_stream.aclose()
+            consumer.cancel()
+            try:
+                await consumer
+            except (asyncio.CancelledError, anyio.ClosedResourceError):
+                pass
+
+    assert fut.done()
+    assert fut.result() == {"ok": True}
+    assert forwarded == []  # not forwarded to FastMCP
+    assert stdout.written == []  # no outbound response written
+
+
+def test_method_set_covers_all_spec_methods_we_handle():
+    """The dispatcher's method set must list every method the transport intercepts."""
+    expected_subset = {
+        "channels/incoming",
+        "channels/publish",
+        "channels/list",
+        "channels/typing",
+        "context/beforeInference",
+    }
+    assert expected_subset.issubset(MCPL_METHODS)
+
+
+# ---------------------------------------------------------------------------
+# on_ready hook
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_ready_fires_after_initialized_when_host_supports_mcpl():
+    """initialize (with mcpl caps) followed by notifications/initialized
+    must trigger the on_ready callback."""
+    dispatcher = McplDispatcher()
+    transport = McplTransport(dispatcher)
+
+    init = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {
+                    "experimental": {"mcpl": {"version": "0.4", "pushEvents": True}}
+                },
+                "clientInfo": {"name": "test", "version": "1"},
+            },
+        }
+    )
+    initialized = json.dumps(
+        {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}
+    )
+    stdin = FakeAsyncFile(init + "\n" + initialized + "\n")
+    stdout = FakeAsyncFile()
+
+    fired_with: list[McplTransport] = []
+
+    async def on_ready(t: McplTransport) -> None:
+        fired_with.append(t)
+        # Send a notification while the transport is alive
+        await t.send_notification("channels/register", {"channels": []})
+
+    forwarded: list = []
+
+    async def consume_forwarded(read_stream):
+        async for item in read_stream:
+            forwarded.append(item)
+
+    with anyio.fail_after(2.0):
+        async with mcpl_stdio_server(
+            transport, stdin=stdin, stdout=stdout, on_ready=on_ready
+        ) as (read_stream, write_stream):
+            consumer = asyncio.create_task(consume_forwarded(read_stream))
+            for _ in range(50):
+                if fired_with and stdout.written:
+                    break
+                await asyncio.sleep(0.01)
+            await write_stream.aclose()
+            await read_stream.aclose()
+            consumer.cancel()
+            try:
+                await consumer
+            except (asyncio.CancelledError, anyio.ClosedResourceError):
+                pass
+
+    assert fired_with == [transport]
+    payloads = [json.loads(line.rstrip()) for line in stdout.written if line.strip()]
+    assert payloads == [
+        {"jsonrpc": "2.0", "method": "channels/register", "params": {"channels": []}}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_on_ready_does_not_fire_for_vanilla_mcp_host():
+    """Hosts that don't advertise MCPL skip on_ready entirely."""
+    dispatcher = McplDispatcher()
+    transport = McplTransport(dispatcher)
+
+    init = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},  # no experimental.mcpl
+                "clientInfo": {"name": "vanilla-mcp", "version": "1"},
+            },
+        }
+    )
+    initialized = json.dumps(
+        {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}
+    )
+    stdin = FakeAsyncFile(init + "\n" + initialized + "\n")
+    stdout = FakeAsyncFile()
+
+    fired = []
+
+    async def on_ready(t: McplTransport) -> None:
+        fired.append(True)
+
+    forwarded: list = []
+
+    async def consume_forwarded(read_stream):
+        async for item in read_stream:
+            forwarded.append(item)
+
+    with anyio.fail_after(2.0):
+        async with mcpl_stdio_server(
+            transport, stdin=stdin, stdout=stdout, on_ready=on_ready
+        ) as (read_stream, write_stream):
+            consumer = asyncio.create_task(consume_forwarded(read_stream))
+            # Both messages should be forwarded
+            for _ in range(50):
+                if len(forwarded) >= 2:
+                    break
+                await asyncio.sleep(0.01)
+            await write_stream.aclose()
+            await read_stream.aclose()
+            consumer.cancel()
+            try:
+                await consumer
+            except (asyncio.CancelledError, anyio.ClosedResourceError):
+                pass
+
+    assert fired == []  # vanilla MCP — on_ready intentionally skipped
+    assert len(forwarded) == 2  # initialize + notifications/initialized both forwarded


### PR DESCRIPTION
Layers MCPL (MCP Live) extensions on top of the existing FastMCP server so the Telegram client can participate as a push-event-aware connector, not just a request/response tool surface.

What's covered:
  - experimental.mcpl capabilities advertised on initialize
  - intercepting stdio transport (Python port of the Java precedent in discord-mcp/src/main/java/dev/saseq/mcpl/) — routes MCPL methods to the dispatcher, forwards MCP methods to FastMCP unchanged
  - channel registry: Telegram dialogs → ChannelDescriptor with the telegram:{account}:{kind}:{peer_id} id scheme; one channel per supergroup with threadId for forum topics
  - push events: Telethon NewMessage → channels/incoming with rich metadata (mentionIds, isReply, isReplyToBot, replyToContent, …) for host-side trigger filtering
  - host → server: channels/publish with replyToMessageId extension, channels/typing as fire-and-forget pulse, channels/list/open/close, channels/changed for join/leave/kick membership updates
  - host-reconnect-safe: attach_event_handlers is idempotent per client so on_ready firing twice doesn't duplicate NewMessage pushes

What's deliberately deferred:
  - outbound media (image/audio publish) — text-only for now
  - inbound media binary delivery — surfaces as [kind] placeholder + a telegram:// resource URI; agent can fetch via existing chigwell tools
  - edits/deletes via push/event — no host-side use case yet
  - scoped access, context hooks, state rollback, inference/request

79 new tests across capabilities, dispatcher, transport, channels, content, events, and handlers. Existing 96-test suite untouched.