### PR TITLE
fix: handle MessageReplyStoryHeader without reply_to_msg_id attribute

### DIFF
--- a/telegram_mcp/tools/messages.py
+++ b/telegram_mcp/tools/messages.py
@@ -576,8 +576,9 @@ async def list_messages(
                 "date": msg.date,
                 "text": sanitize_user_content(msg.message),
             }
-            if msg.reply_to and msg.reply_to.reply_to_msg_id:
-                record["reply_to"] = msg.reply_to.reply_to_msg_id
+            reply_to_id = getattr(msg.reply_to, "reply_to_msg_id", None) if msg.reply_to else None
+            if reply_to_id:
+                record["reply_to"] = reply_to_id
             engagement = get_engagement_dict(msg)
             if engagement:
                 record["engagement"] = engagement
@@ -1077,8 +1078,9 @@ async def get_history(chat_id: Union[int, str], limit: int = 100, account: str =
                 "date": msg.date,
                 "text": sanitize_user_content(msg.message),
             }
-            if msg.reply_to and msg.reply_to.reply_to_msg_id:
-                record["reply_to"] = msg.reply_to.reply_to_msg_id
+            reply_to_id = getattr(msg.reply_to, "reply_to_msg_id", None) if msg.reply_to else None
+            if reply_to_id:
+                record["reply_to"] = reply_to_id
             records.append(record)
         return format_tool_result(records)
     except Exception as e:


### PR DESCRIPTION
## Summary

`Message.reply_to` in Telethon can be either `MessageReplyHeader` (when the
message replies to another regular message) or `MessageReplyStoryHeader`
(when it replies to a story). Only the former carries `reply_to_msg_id`;
the latter has `story_id` + `peer` instead.

Before this fix, `get_history()` and `list_messages()` crashed with
`AttributeError` as soon as the requested range contained a
reply-to-story message:

    File "telegram_mcp/tools/messages.py", line 1080, in get_history
        if msg.reply_to and msg.reply_to.reply_to_msg_id:
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    AttributeError: 'MessageReplyStoryHeader' object has no attribute
    'reply_to_msg_id'

This made any sufficiently large history fetch unreliable for users whose
chats include story-reply messages — symptom is `GEN-ERR-971` in MCP logs.

## Fix

Use `getattr(msg.reply_to, "reply_to_msg_id", None)` to safely probe for
the attribute on whichever reply-header class is attached. Behavior for
ordinary `MessageReplyHeader` is unchanged.

## Test plan

- [x] Manually reproduced the crash with `get_history(chat_id, limit=200)`
      on a chat containing a reply-to-story message
- [x] After patch — same call returns 200 messages successfully
- [x] Replies to regular messages still populate `reply_to` field in the
      output (verified on a chat with both reply types)