### PR TITLE
feat(messages): forward batches and auto-preserve albums

### DIFF
--- a/telegram_mcp/tools/messages.py
+++ b/telegram_mcp/tools/messages.py
@@ -576,6 +576,9 @@ async def list_messages(
                 "date": msg.date,
                 "text": sanitize_user_content(msg.message),
             }
+            grouped_id = getattr(msg, "grouped_id", None)
+            if grouped_id is not None:
+                record["grouped_id"] = grouped_id
             reply_to_id = getattr(msg.reply_to, "reply_to_msg_id", None) if msg.reply_to else None
             if reply_to_id:
                 record["reply_to"] = reply_to_id
@@ -639,6 +642,9 @@ async def get_message_context(
                 "is_target": msg.id == message_id,
                 "text": sanitize_user_content(msg.message),
             }
+            grouped_id = getattr(msg, "grouped_id", None)
+            if grouped_id is not None:
+                record["grouped_id"] = grouped_id
 
             # Check if this message is a reply and get the replied message
             if msg.reply_to and msg.reply_to.reply_to_msg_id:
@@ -683,19 +689,26 @@ async def get_message_context(
 @validate_id("from_chat_id", "to_chat_id")
 async def forward_message(
     from_chat_id: Union[int, str],
-    message_id: int,
+    message_id: Union[int, List[int]],
     to_chat_id: Union[int, str],
     account: str = None,
 ) -> str:
     """
-    Forward a message from one chat to another.
+    Forward one or more messages from one chat to another.
+
+    Pass a list of message IDs to forward multiple messages in a single call.
+    Messages that share a Telegram album (same grouped_id) are preserved as a
+    grouped album in the destination when forwarded together in one list.
     """
     try:
         cl = get_client(account)
         from_entity = await resolve_entity(from_chat_id, cl)
         to_entity = await resolve_entity(to_chat_id, cl)
         await cl.forward_messages(to_entity, message_id, from_entity)
-        return f"Message {message_id} forwarded from {from_chat_id} to {to_chat_id}."
+        count = len(message_id) if isinstance(message_id, list) else 1
+        if count == 1:
+            return f"Message {message_id} forwarded from {from_chat_id} to {to_chat_id}."
+        return f"{count} messages forwarded from {from_chat_id} to {to_chat_id}."
     except Exception as e:
         return log_and_format_error(
             "forward_message",

--- a/telegram_mcp/tools/messages.py
+++ b/telegram_mcp/tools/messages.py
@@ -694,11 +694,24 @@ async def forward_message(
     account: str = None,
 ) -> str:
     """
-    Forward one or more messages from one chat to another.
+    Forward one or more messages from a source chat to a destination chat.
 
-    Pass a list of message IDs to forward multiple messages in a single call.
-    Messages that share a Telegram album (same grouped_id) are preserved as a
-    grouped album in the destination when forwarded together in one list.
+    To forward MULTIPLE messages, pass `message_id` as a list of integers in
+    a SINGLE call (e.g. message_id=[12345, 12346, 12347]). Do NOT call this
+    tool repeatedly with single ints to forward several messages — the list
+    form is faster, atomic, and preserves Telegram album grouping (messages
+    sharing a `grouped_id` arrive as one grouped album in the destination).
+
+    Pass a single int only when forwarding exactly one message and you do
+    not need album grouping. See also: forward_messages (plural) — same
+    behavior with a list-only signature.
+
+    Args:
+        from_chat_id: Source chat (id or @username).
+        message_id: A single message id (int) OR a list of message ids
+            (e.g. [12345, 12346]). USE A LIST WHENEVER FORWARDING >1 MESSAGE.
+        to_chat_id: Destination chat (id or @username).
+        account: Optional account label for multi-account mode.
     """
     try:
         cl = get_client(account)
@@ -715,6 +728,61 @@ async def forward_message(
             e,
             from_chat_id=from_chat_id,
             message_id=message_id,
+            to_chat_id=to_chat_id,
+        )
+
+
+@mcp.tool(
+    annotations=ToolAnnotations(
+        title="Forward Messages (batch)", openWorldHint=True, destructiveHint=True
+    )
+)
+@with_account(readonly=False)
+@validate_id("from_chat_id", "to_chat_id")
+async def forward_messages(
+    from_chat_id: Union[int, str],
+    message_ids: List[int],
+    to_chat_id: Union[int, str],
+    account: str = None,
+) -> str:
+    """
+    Forward a BATCH of messages from a source chat to a destination chat in
+    a single atomic call.
+
+    Use this whenever you need to forward more than one message. Pass all
+    message ids as a list (e.g. message_ids=[12345, 12346, 12347]). Calling
+    this once with a list is strictly better than calling forward_message
+    multiple times: it preserves Telegram album grouping (siblings sharing
+    `grouped_id` arrive as one grouped album), is atomic, and counts as a
+    single forward op for Telegram rate limits.
+
+    For exactly one message, you may use either this tool with a one-item
+    list or `forward_message` with an int.
+
+    Args:
+        from_chat_id: Source chat (id or @username).
+        message_ids: List of message ids to forward, in any order
+            (e.g. [12345, 12346]). Must contain at least one id.
+        to_chat_id: Destination chat (id or @username).
+        account: Optional account label for multi-account mode.
+    """
+    try:
+        if not message_ids:
+            return "Error: message_ids must contain at least one id."
+        cl = get_client(account)
+        from_entity = await resolve_entity(from_chat_id, cl)
+        to_entity = await resolve_entity(to_chat_id, cl)
+        await cl.forward_messages(to_entity, list(message_ids), from_entity)
+        return (
+            f"{len(message_ids)} messages forwarded from "
+            f"{from_chat_id} to {to_chat_id}."
+        )
+    except Exception as e:
+        return log_and_format_error(
+            "forward_messages",
+            e,
+            from_chat_id=from_chat_id,
+            message_ids=message_ids,
             to_chat_id=to_chat_id,
         )
 

--- a/telegram_mcp/tools/messages.py
+++ b/telegram_mcp/tools/messages.py
@@ -692,35 +692,69 @@ async def forward_message(
     message_id: Union[int, List[int]],
     to_chat_id: Union[int, str],
     account: str = None,
+    expand_album: bool = True,
 ) -> str:
     """
-    Forward one or more messages from a source chat to a destination chat.
+    Forward a message (or several) from a source chat to a destination chat.
 
-    To forward MULTIPLE messages, pass `message_id` as a list of integers in
-    a SINGLE call (e.g. message_id=[12345, 12346, 12347]). Do NOT call this
-    tool repeatedly with single ints to forward several messages — the list
-    form is faster, atomic, and preserves Telegram album grouping (messages
-    sharing a `grouped_id` arrive as one grouped album in the destination).
+    When forwarding a single int message_id, the server automatically detects
+    Telegram albums (multi-photo/video posts sharing a `grouped_id`) and
+    forwards the ENTIRE album as one grouped batch — so the destination
+    receives the album intact with "Forwarded from <source>", not a single
+    detached photo. This is the desired behavior in almost all cases.
 
-    Pass a single int only when forwarding exactly one message and you do
-    not need album grouping. See also: forward_messages (plural) — same
-    behavior with a list-only signature.
+    Set expand_album=False to forward only the exact message you specified
+    (useful if you really want one photo out of an album).
+
+    To forward a specific set of unrelated messages, pass a list of ints.
+    Album expansion is not applied to list inputs — the list is treated as
+    the explicit batch.
 
     Args:
         from_chat_id: Source chat (id or @username).
-        message_id: A single message id (int) OR a list of message ids
-            (e.g. [12345, 12346]). USE A LIST WHENEVER FORWARDING >1 MESSAGE.
+        message_id: A single message id (int) OR a list of ids. Single ints
+            are auto-expanded to the full album when applicable.
         to_chat_id: Destination chat (id or @username).
         account: Optional account label for multi-account mode.
+        expand_album: If True (default) and message_id is a single int, the
+            server expands albums automatically. No effect on list inputs.
     """
     try:
         cl = get_client(account)
         from_entity = await resolve_entity(from_chat_id, cl)
         to_entity = await resolve_entity(to_chat_id, cl)
-        await cl.forward_messages(to_entity, message_id, from_entity)
-        count = len(message_id) if isinstance(message_id, list) else 1
+
+        ids_to_forward = message_id
+        expanded_from_album = False
+        if expand_album and isinstance(message_id, int):
+            anchor = await cl.get_messages(from_entity, ids=message_id)
+            grouped_id = getattr(anchor, "grouped_id", None) if anchor else None
+            if grouped_id is not None:
+                # Album ids are allocated contiguously by Telegram; a small
+                # window around the anchor reliably captures all siblings.
+                window = list(range(message_id - 9, message_id + 10))
+                neighbors = await cl.get_messages(from_entity, ids=window)
+                sibling_ids = sorted(
+                    {
+                        m.id
+                        for m in neighbors
+                        if m is not None
+                        and getattr(m, "grouped_id", None) == grouped_id
+                    }
+                )
+                if len(sibling_ids) > 1:
+                    ids_to_forward = sibling_ids
+                    expanded_from_album = True
+
+        await cl.forward_messages(to_entity, ids_to_forward, from_entity)
+        count = len(ids_to_forward) if isinstance(ids_to_forward, list) else 1
         if count == 1:
             return f"Message {message_id} forwarded from {from_chat_id} to {to_chat_id}."
+        if expanded_from_album:
+            return (
+                f"Album of {count} messages forwarded from {from_chat_id} "
+                f"to {to_chat_id} (auto-expanded from message {message_id})."
+            )
         return f"{count} messages forwarded from {from_chat_id} to {to_chat_id}."
     except Exception as e:
         return log_and_format_error(

--- a/telegram_mcp/tools/messages.py
+++ b/telegram_mcp/tools/messages.py
@@ -738,8 +738,7 @@ async def forward_message(
                     {
                         m.id
                         for m in neighbors
-                        if m is not None
-                        and getattr(m, "grouped_id", None) == grouped_id
+                        if m is not None and getattr(m, "grouped_id", None) == grouped_id
                     }
                 )
                 if len(sibling_ids) > 1:
@@ -807,10 +806,7 @@ async def forward_messages(
         from_entity = await resolve_entity(from_chat_id, cl)
         to_entity = await resolve_entity(to_chat_id, cl)
         await cl.forward_messages(to_entity, list(message_ids), from_entity)
-        return (
-            f"{len(message_ids)} messages forwarded from "
-            f"{from_chat_id} to {to_chat_id}."
-        )
+        return f"{len(message_ids)} messages forwarded from " f"{from_chat_id} to {to_chat_id}."
     except Exception as e:
         return log_and_format_error(
             "forward_messages",


### PR DESCRIPTION
## Summary

Three related changes to make forwarding work well in agent / MCP-client use:

1. **`forward_message` accepts `Union[int, List[int]]`.** Passing a list of ids in a single call lets Telethon's `forward_messages` preserve Telegram album grouping (messages sharing `grouped_id` arrive as one grouped album, not detached items).

2. **`list_messages` and `get_message_context` include `grouped_id`** in each record when the message is part of an album. Callers can detect album membership programmatically (it was not exposed before).

3. **New `forward_messages` tool (plural)** with a pure `List[int]` signature, plus **server-side album auto-expansion in `forward_message`**: when called with a single int and the target message has a `grouped_id`, the server now fetches a small contiguous window of neighbour ids, filters siblings sharing the same `grouped_id`, and forwards them all in one Telethon call. An `expand_album: bool = True` flag lets callers opt out for the rare case of forwarding one specific item out of an album.

## Motivation

When driven by a small MCP-client model (e.g. `gpt-oss-20b` in LM Studio), the upstream behavior reliably broke for multi-photo channel posts: the model would call `forward_message` with the album's anchor id only and the destination received one detached photo. Tool-description directives and skill prompts did not move the needle.

The two failure modes addressed:

- **No way to express "forward N items as a group"** — the single-int signature forced loops, which break atomicity, defeat album grouping, and trip flood-wait limits.
- **No way for the agent to detect an album** — without `grouped_id` exposure, a client cannot tell that a message is part of a group, so it cannot construct the list even if the tool accepted one.

The server-side auto-expand path (3) means the most common case ("forward this post") works correctly without any client intelligence at all.

## Backward compatibility

- `forward_message(message_id=<int>, ...)` — same call signature, but now expands albums by default. Opt out with `expand_album=False` to restore the previous one-message behavior.
- `forward_message(message_id=<list>, ...)` — new capability, no behavior change for any existing caller.
- `forward_messages` is new; no conflict.
- `grouped_id` in `list_messages` / `get_message_context` is an additive field that only appears when non-null; existing consumers ignoring unknown keys are unaffected.

## Commits

- `aaa4f28` feat(messages): forward list of ids and expose grouped_id
- `095d00b` feat(messages): add forward_messages (batch) tool and strengthen guidance
- `85a8f39` feat(forward_message): auto-expand albums on single-int forwards

## Testing notes

Verified end-to-end against a real personal account: forwarding a 3-photo post from a public channel via the auto-expand path delivers one grouped album with the original "Forwarded from \<source>" header to the destination, matching the result of forwarding the same post manually from the Telegram client.

Happy to split into separate PRs or rework the API surface if that fits the project direction better.