### PR TITLE
feat: expose birthday in get_full_user

### DIFF
--- a/telegram_mcp/tools/profile.py
+++ b/telegram_mcp/tools/profile.py
@@ -268,6 +268,23 @@ async def get_full_user(username: Union[int, str], account: str = None) -> str:
             except Exception:
                 personal_channel = str(personal_channel_id)
 
+        # Birthday is exposed in UserFull for Premium users who set it and allow
+        # contacts to see it. The `year` component is optional (often hidden).
+        # Returns ISO `YYYY-MM-DD` when year is present, else `--MM-DD` (vCard
+        # RFC 6350 style for year-less dates); None when not available.
+        birthday = getattr(full_user, "birthday", None)
+        birthday_str = None
+        if birthday is not None:
+            b_day = getattr(birthday, "day", None)
+            b_month = getattr(birthday, "month", None)
+            b_year = getattr(birthday, "year", None)
+            if b_day and b_month:
+                birthday_str = (
+                    f"{b_year:04d}-{b_month:02d}-{b_day:02d}"
+                    if b_year
+                    else f"--{b_month:02d}-{b_day:02d}"
+                )
+
         result = {
             "id": user.id if user else None,
             "first_name": sanitize_name(getattr(user, "first_name", None)) if user else None,
@@ -276,6 +293,7 @@ async def get_full_user(username: Union[int, str], account: str = None) -> str:
             "phone": getattr(user, "phone", None) if user else None,
             "bio": sanitize_user_content(full_user.about or "", max_length=1024),
             "personal_channel": personal_channel,
+            "birthday": birthday_str,
             "bot": getattr(user, "bot", False) if user else False,
             "verified": getattr(user, "verified", False) if user else False,
             "premium": getattr(user, "premium", False) if user else False,


### PR DESCRIPTION
## What

Surfaces `birthday` from `UserFull` in the `get_full_user` tool output.

## Why

Telethon's `UserFull.birthday` exposes the contact's date of birth when:
- the user has Telegram Premium,
- has set a birthday on their profile, and
- has allowed contacts to see it.

The `year` component is optional (often hidden by the user). Currently `get_full_user` does not expose this field, even though it sits right next to fields the tool already surfaces (`bio`, `personal_channel`, `verified`, `premium`, `common_chats_count`).

## How

Adds 18 lines inside `get_full_user` (`telegram_mcp/tools/profile.py`):
- reads `full_user.birthday` via `getattr` (forward-compatible if Telethon ever omits the attribute),
- formats output as ISO 8601 `YYYY-MM-DD` when the year is present,
- falls back to vCard RFC 6350 `--MM-DD` for year-less dates,
- emits `None` when birthday is unavailable.

The new field is placed next to `personal_channel` in the result dict, keeping the order logical.

## Testing

- `PYTHONPATH=. uv run pytest -q --ignore=tests/test_media_album.py` → **99/99 passed** on this branch.
- `tests/test_media_album.py` shows 6 pre-existing failures on `origin/main` (verified by stashing the patch and re-running on a clean checkout) — they are infra-related (`Error: 'account' is required`) and unrelated to this change.
- Manual verification on a Premium contact with a set birthday: confirms a non-null `birthday` field in the tool output.

## Notes

Follows the same minimal-patch style as #128 (`fix: handle MessageReplyStoryHeader without reply_to_msg_id attribute`).