### PR TITLE
type account param as Optional[str] to fix single-account tool failures

### DIFF
--- a/telegram_mcp/tools/contacts.py
+++ b/telegram_mcp/tools/contacts.py
@@ -1,13 +1,14 @@
 """Contacts MCP tools."""
 
 from telegram_mcp.runtime import *
+from typing import Optional
 
 
 @mcp.tool(
     annotations=ToolAnnotations(title="List Contacts", openWorldHint=True, readOnlyHint=True)
 )
 @with_account(readonly=True)
-async def list_contacts(account: str = None) -> str:
+async def list_contacts(account: Optional[str] = None) -> str:
     """
     List all contacts in your Telegram account.
 
@@ -43,7 +44,7 @@ async def list_contacts(account: str = None) -> str:
     annotations=ToolAnnotations(title="Search Contacts", openWorldHint=True, readOnlyHint=True)
 )
 @with_account(readonly=True)
-async def search_contacts(query: str, account: str = None) -> str:
+async def search_contacts(query: str, account: Optional[str] = None) -> str:
     """
     Search for contacts by name, username, or phone number using Telethon's SearchRequest.
     Args:
@@ -81,7 +82,7 @@ async def search_contacts(query: str, account: str = None) -> str:
     annotations=ToolAnnotations(title="Get Contact Ids", openWorldHint=True, readOnlyHint=True)
 )
 @with_account(readonly=True)
-async def get_contact_ids(account: str = None) -> str:
+async def get_contact_ids(account: Optional[str] = None) -> str:
     """
     Get all contact IDs in your Telegram account.
     """
@@ -102,7 +103,7 @@ async def get_contact_ids(account: str = None) -> str:
     )
 )
 @with_account(readonly=True)
-async def get_direct_chat_by_contact(contact_query: str, account: str = None) -> str:
+async def get_direct_chat_by_contact(contact_query: str, account: Optional[str] = None) -> str:
     """
     Find a direct chat with a specific contact by name, username, or phone.
 
@@ -168,7 +169,7 @@ async def get_direct_chat_by_contact(contact_query: str, account: str = None) ->
 )
 @with_account(readonly=True)
 @validate_id("contact_id")
-async def get_contact_chats(contact_id: Union[int, str], account: str = None) -> str:
+async def get_contact_chats(contact_id: Union[int, str], account: Optional[str] = None) -> str:
     """
     List all chats involving a specific contact.
 
@@ -237,7 +238,7 @@ async def get_contact_chats(contact_id: Union[int, str], account: str = None) ->
 )
 @with_account(readonly=True)
 @validate_id("contact_id")
-async def get_last_interaction(contact_id: Union[int, str], account: str = None) -> str:
+async def get_last_interaction(contact_id: Union[int, str], account: Optional[str] = None) -> str:
     """
     Get the most recent message with a contact.
 
@@ -291,7 +292,7 @@ async def get_last_interaction(contact_id: Union[int, str], account: str = None)
 )
 @with_account(readonly=False)
 async def add_contact(
-    account: str = None,
+    account: Optional[str] = None,
     phone: Optional[str] = None,
     first_name: str = "",
     last_name: str = "",
@@ -428,7 +429,7 @@ async def add_contact(
 )
 @with_account(readonly=False)
 @validate_id("user_id")
-async def delete_contact(user_id: Union[int, str], account: str = None) -> str:
+async def delete_contact(user_id: Union[int, str], account: Optional[str] = None) -> str:
     """
     Delete a contact by user ID.
     Args:
@@ -450,7 +451,7 @@ async def delete_contact(user_id: Union[int, str], account: str = None) -> str:
 )
 @with_account(readonly=False)
 @validate_id("user_id")
-async def block_user(user_id: Union[int, str], account: str = None) -> str:
+async def block_user(user_id: Union[int, str], account: Optional[str] = None) -> str:
     """
     Block a user by user ID.
     Args:
@@ -472,7 +473,7 @@ async def block_user(user_id: Union[int, str], account: str = None) -> str:
 )
 @with_account(readonly=False)
 @validate_id("user_id")
-async def unblock_user(user_id: Union[int, str], account: str = None) -> str:
+async def unblock_user(user_id: Union[int, str], account: Optional[str] = None) -> str:
     """
     Unblock a user by user ID.
     Args:
@@ -491,7 +492,7 @@ async def unblock_user(user_id: Union[int, str], account: str = None) -> str:
     annotations=ToolAnnotations(title="Import Contacts", openWorldHint=True, destructiveHint=True)
 )
 @with_account(readonly=False)
-async def import_contacts(contacts: list, account: str = None) -> str:
+async def import_contacts(contacts: list, account: Optional[str] = None) -> str:
     """
     Import a list of contacts. Each contact should be a dict with phone, first_name, last_name.
     """
@@ -517,7 +518,7 @@ async def import_contacts(contacts: list, account: str = None) -> str:
     annotations=ToolAnnotations(title="Export Contacts", openWorldHint=True, readOnlyHint=True)
 )
 @with_account(readonly=True)
-async def export_contacts(account: str = None) -> str:
+async def export_contacts(account: Optional[str] = None) -> str:
     """
     Export all contacts as a JSON string.
     """
@@ -535,7 +536,7 @@ async def export_contacts(account: str = None) -> str:
     annotations=ToolAnnotations(title="Get Blocked Users", openWorldHint=True, readOnlyHint=True)
 )
 @with_account(readonly=True)
-async def get_blocked_users(account: str = None) -> str:
+async def get_blocked_users(account: Optional[str] = None) -> str:
     """
     Get a list of blocked users.
     """
@@ -559,7 +560,7 @@ async def send_contact(
     first_name: str,
     last_name: str = "",
     vcard: str = "",
-    account: str = None,
+    account: Optional[str] = None,
 ) -> str:
     """
     Send a contact to a chat.


### PR DESCRIPTION
## Problem

All tool functions declare the `account` parameter as `account: str = None`.

In Pydantic v2, this generates a JSON schema that marks `account` as a required
string field — despite the `None` default. When an LLM-backed MCP client receives
this schema, it treats `account` as required and passes an empty string `""` when
it has no value to supply.

`get_client("")` then raises: ValueError: Unknown account ''. Available accounts: default


This breaks every tool call in single-account setups, which is the most common
configuration and is documented as supported.

---

## How to reproduce

Set up the server in single-account mode. Connect any LLM-backed MCP client.
Then try these two prompts back to back:

**Prompt 1 — fails:**
> "What is the last message from my contact named Alice?"

The LLM picks `list_contacts` or `get_contact_ids`, passes `account=""`, and gets
a `CONTACT-ERR-*` error. The tool never executes.

**Prompt 2 — works (same intent, split into two steps):**
> "Is there a contact named Alice in Telegram?"
> *(after it responds)* "Get her last message."

In step one, the LLM picks `search_contacts` which has a `query` param to focus
on, so it omits `account` entirely. `get_client(None)` auto-selects the only
configured account and succeeds. Step two then uses `chat_id` directly, also
bypassing the `account` problem.

Same underlying intent. Same tools available. The only difference is whether
the LLM feels obligated to fill `account`.

---

## Root cause

Pydantic v2 no longer infers `Optional` from `field: str = None`. The correct
annotation is `Optional[str]`.

```python
# Before — Pydantic v2 emits {"type": "string"} — looks required to the client
async def list_contacts(account: str = None) -> str:

# After — emits {"anyOf": [{"type": "string"}, {"type": "null"}], "default": null}
async def list_contacts(account: Optional[str] = None) -> str:
```

With the correct annotation, LLM clients see `account` as optional and omit it.
`get_client(None)` then auto-selects the single configured account, as intended.
No logic in `runtime.py` needed to change.

---

## Change

`account: str = None` → `account: Optional[str] = None` across all tool files.
No behavior change. No logic change. Purely a type annotation correction.

Files changed:
- `telegram_mcp/tools/contacts.py`

- (will change other files in the similar manner after testing and verifying that no new issues are introduced)

---

## Affected users

Anyone running single-account mode with an LLM-backed MCP client
(Claude Desktop via `langchain-mcp-adapters`, Cursor, or similar).
Direct programmatic callers are unaffected.

