### PR TITLE
fix: support manage_topics admin right in promote/demote/edit_admin_rights

### DIFF
--- a/telegram_mcp/tools/groups.py
+++ b/telegram_mcp/tools/groups.py
@@ -487,6 +487,7 @@ async def promote_admin(
                 "add_admins": False,
                 "anonymous": False,
                 "manage_call": True,
+                "manage_topics": True,
                 "other": True,
             }
 
@@ -501,6 +502,7 @@ async def promote_admin(
             add_admins=rights.get("add_admins", False),
             anonymous=rights.get("anonymous", False),
             manage_call=rights.get("manage_call", True),
+            manage_topics=rights.get("manage_topics", True),
             other=rights.get("other", True),
         )
 
@@ -560,6 +562,7 @@ async def demote_admin(
             add_admins=False,
             anonymous=False,
             manage_call=False,
+            manage_topics=False,
             other=False,
         )
 
@@ -839,6 +842,7 @@ async def edit_admin_rights(
     add_admins: bool = False,
     anonymous: bool = False,
     manage_call: bool = False,
+    manage_topics: bool = False,
     other: bool = False,
     account: str = None,
 ) -> str:
@@ -863,6 +867,7 @@ async def edit_admin_rights(
         add_admins: can add new admins with their own rights
         anonymous: admin actions appear anonymous
         manage_call: can manage voice/video chats
+        manage_topics: can create, edit, close and reopen forum topics (forum-enabled supergroups only)
         other: reserved for future rights
     """
     try:
@@ -881,6 +886,7 @@ async def edit_admin_rights(
             add_admins=add_admins,
             anonymous=anonymous,
             manage_call=manage_call,
+            manage_topics=manage_topics,
             other=other,
         )
         await cl(


### PR DESCRIPTION
## Summary
- `promote_admin` builds `ChatAdminRights` from a fixed defaults dict that silently dropped `manage_topics` — granting topic-management rights via MCP was impossible. Bug verified live: promote with `rights={"manage_topics": true}` → Bot API `getChatMember` shows `can_manage_topics: false` → `createForumTopic` fails with "not enough rights".
- Adds `manage_topics` to `promote_admin` defaults, `demote_admin` reset, and as an explicit `edit_admin_rights` parameter.

Extracted from #126 as a focused fix (the forum-topics CRUD part overlaps #138).

## Test plan
- Full suite passes (`pytest -q`, 113 passed)
- The fix passes the parameter straight through to `ChatAdminRights`; not yet exercised against live Telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)