### PR TITLE
feat(roots): opt-in fallback to server CLI roots on empty client Roots

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,13 @@ TELEGRAM_SESSION_NAME=telegram_session
 # inside the server process.
 # TELEGRAM_EXPOSED_TOOLS=read-only
 
+# --- File-path tools / allowed roots (optional) ---
+# When the MCP client implements Roots but advertises an empty list, file-path
+# tools (download_media, send_file, ...) are disabled (deny-all) even if server
+# CLI roots are configured. Set this to 1/true to fall back to the server CLI
+# roots in that case. Default is deny-all.
+# TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK=1
+
 # --- Proxy (optional) ---
 # Route Telegram traffic through a proxy. Set TELEGRAM_PROXY_TYPE to enable.
 # Supported types: socks5, socks4, http, mtproxy.

--- a/README.md
+++ b/README.md
@@ -286,7 +286,11 @@ Allowed roots can come from:
 Security behavior:
 
 - Client MCP Roots replace server CLI roots when available.
-- Empty client Roots are treated as deny-all.
+- Empty client Roots are treated as deny-all by default. Some clients implement
+  the Roots capability but advertise an empty list, which disables file tools
+  even when server CLI roots are configured. Set
+  `TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK=1` to fall back to the server CLI roots
+  in that case (opt-in; the default stays deny-all).
 - Paths are resolved through real paths and must stay inside an allowed root.
 - Traversal, wildcard-like, shell-like, and null-byte path patterns are rejected.
 - Relative paths resolve under the first allowed root.

--- a/telegram_mcp/runtime.py
+++ b/telegram_mcp/runtime.py
@@ -504,6 +504,7 @@ ROOTS_STATUS_READY = "ready"
 ROOTS_STATUS_NOT_CONFIGURED = "not_configured"
 ROOTS_STATUS_UNSUPPORTED_FALLBACK = "unsupported_fallback"
 ROOTS_STATUS_CLIENT_DENY_ALL = "client_deny_all"
+ROOTS_STATUS_SERVER_FALLBACK = "server_fallback"
 ROOTS_STATUS_ERROR = "error"
 
 
@@ -957,6 +958,18 @@ def _is_roots_unsupported_error(error: Exception) -> bool:
     return False
 
 
+def _server_roots_fallback_enabled(value: Optional[str] = None) -> bool:
+    """Whether an empty client roots list should fall back to server CLI roots.
+
+    Opt-in via the ``TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK`` environment variable.
+    Defaults to ``False`` to preserve the safe deny-all behavior.
+    """
+    raw_value = (
+        os.getenv("TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK") if value is None else value
+    )
+    return _parse_bool_env(raw_value, False)
+
+
 async def _get_effective_allowed_roots_with_status(
     ctx: Optional[Context],
 ) -> tuple[List[Path], str]:
@@ -989,7 +1002,13 @@ async def _get_effective_allowed_roots_with_status(
     if client_roots:
         return _dedupe_paths(client_roots), ROOTS_STATUS_READY
 
-    # Roots API succeeded; an empty roots list is treated as explicit deny-all.
+    # Roots API succeeded but returned an empty list. By default this is an
+    # explicit deny-all. Some clients (e.g. ones that implement the Roots
+    # capability but expose no roots) advertise an empty list even though the
+    # operator configured server-side CLI roots; for those, an opt-in lets the
+    # server-side roots take effect instead of disabling file tools entirely.
+    if fallback_roots and _server_roots_fallback_enabled():
+        return fallback_roots, ROOTS_STATUS_SERVER_FALLBACK
     return [], ROOTS_STATUS_CLIENT_DENY_ALL
 
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -722,3 +722,72 @@ def test_main_compatibility_wrappers_are_exported():
     assert main.send_message is not None
     assert main.validate_id is runtime.validate_id
     assert main.log_file_path.endswith("mcp_errors.log")
+
+
+class _FakeRootsSession:
+    def __init__(self, roots):
+        self._roots = roots
+
+    async def list_roots(self):
+        return SimpleNamespace(roots=list(self._roots))
+
+
+def _ctx_with_roots(roots):
+    return SimpleNamespace(session=_FakeRootsSession(roots))
+
+
+def test_server_roots_fallback_enabled_parsing(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK", raising=False)
+    assert runtime._server_roots_fallback_enabled() is False
+    assert runtime._server_roots_fallback_enabled("1") is True
+    assert runtime._server_roots_fallback_enabled("true") is True
+    assert runtime._server_roots_fallback_enabled("off") is False
+    monkeypatch.setenv("TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK", "yes")
+    assert runtime._server_roots_fallback_enabled() is True
+
+
+@pytest.mark.asyncio
+async def test_empty_client_roots_denies_by_default(tmp_path, monkeypatch):
+    root = tmp_path / "root"
+    root.mkdir()
+    monkeypatch.setattr(runtime, "SERVER_ALLOWED_ROOTS", [root.resolve()])
+    monkeypatch.delenv("TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK", raising=False)
+
+    roots, status = await runtime._get_effective_allowed_roots_with_status(
+        _ctx_with_roots([])
+    )
+    assert roots == []
+    assert status == runtime.ROOTS_STATUS_CLIENT_DENY_ALL
+
+
+@pytest.mark.asyncio
+async def test_empty_client_roots_falls_back_to_server_when_enabled(tmp_path, monkeypatch):
+    root = tmp_path / "root"
+    root.mkdir()
+    monkeypatch.setattr(runtime, "SERVER_ALLOWED_ROOTS", [root.resolve()])
+    monkeypatch.setenv("TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK", "1")
+
+    roots, status = await runtime._get_effective_allowed_roots_with_status(
+        _ctx_with_roots([])
+    )
+    assert roots == [root.resolve()]
+    assert status == runtime.ROOTS_STATUS_SERVER_FALLBACK
+
+    # _ensure_allowed_roots must accept the fallback roots without an error.
+    resolved, error = await runtime._ensure_allowed_roots(
+        _ctx_with_roots([]), "download_media"
+    )
+    assert error is None
+    assert resolved == [root.resolve()]
+
+
+@pytest.mark.asyncio
+async def test_empty_client_roots_fallback_noop_without_server_roots(monkeypatch):
+    monkeypatch.setattr(runtime, "SERVER_ALLOWED_ROOTS", [])
+    monkeypatch.setenv("TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK", "1")
+
+    roots, status = await runtime._get_effective_allowed_roots_with_status(
+        _ctx_with_roots([])
+    )
+    assert roots == []
+    assert status == runtime.ROOTS_STATUS_CLIENT_DENY_ALL


### PR DESCRIPTION
## Problem

File-path tools (`download_media`, `send_file`, `upload_file`, ...) are disabled until allowed roots are configured. Roots can come from server CLI args (fallback) or from MCP client Roots.

The current precedence in `_get_effective_allowed_roots_with_status` is:

- client implements Roots and returns a **non-empty** list → use client roots;
- client does **not** implement Roots (errors) → fall back to server CLI roots;
- client implements Roots and returns an **empty** list → **explicit deny-all**.

The last case is a real interop trap: some clients implement the Roots capability but advertise an **empty** list (e.g. a globally-registered server with no project roots). That empty list is treated as deny-all and **overrides** any server-side CLI roots, so an operator who explicitly passed allowed roots still cannot use file-path tools — with no escape hatch.

Observed verbatim error from such a client:

> `download_media is disabled because the client provided an empty MCP Roots list (deny-all).`

## Fix (opt-in, backwards compatible)

Add an env var `TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK`. When enabled **and** the client returns an empty roots list **and** server CLI roots are configured, fall back to the server roots (new status `server_fallback`) instead of deny-all.

- Default is unchanged: empty client roots → deny-all.
- No effect when server CLI roots are not configured (still deny-all).
- Security envelope is unchanged: resolved paths must still stay inside the configured roots.

## Changes

- `telegram_mcp/runtime.py`: `_server_roots_fallback_enabled()` helper + `ROOTS_STATUS_SERVER_FALLBACK`; branch in `_get_effective_allowed_roots_with_status`.
- `tests/test_runtime.py`: default deny-all, opt-in fallback (incl. `_ensure_allowed_roots` accepts them), and no-op without server roots. Env parsing test.
- `README.md` security section + `.env.example`.

## Testing

`pytest tests/test_runtime.py tests/test_file_path_security.py` → 50 passed (4 new). Run inside the project Docker image.