### PR TITLE
fix: hide 2fa password input in session generator

### DIFF
--- a/session_string_generator.py
+++ b/session_string_generator.py
@@ -22,6 +22,7 @@ and usernames (e.g., "@mychannel").
 
 import argparse
 import asyncio
+import getpass
 import io
 import os
 import sys
@@ -88,7 +89,7 @@ def _qr_login(client: TelegramClient) -> None:
         client.disconnect()
         sys.exit(1)
     except errors.SessionPasswordNeededError:
-        pw = input("\nTwo-factor authentication enabled. Please enter your password: ")
+        pw = getpass.getpass("\nTwo-factor authentication enabled. Please enter your password: ")
         client.sign_in(password=pw)
 
 
@@ -114,7 +115,7 @@ def _phone_login(client: TelegramClient) -> None:
     try:
         client.sign_in(phone, code)
     except errors.SessionPasswordNeededError:
-        pw = input("Two-factor authentication enabled. Please enter your password: ")
+        pw = getpass.getpass("Two-factor authentication enabled. Please enter your password: ")
         client.sign_in(password=pw)
 
 

--- a/tests/test_session_string_generator.py
+++ b/tests/test_session_string_generator.py
@@ -3,6 +3,91 @@ import pytest
 import session_string_generator
 
 
+def test_qr_login_uses_hidden_password_prompt_for_2fa(monkeypatch):
+    class _Loop:
+        def run_until_complete(self, awaitable):
+            awaitable.close()
+            raise session_string_generator.errors.SessionPasswordNeededError(request=None)
+
+    class _Client:
+        def __init__(self):
+            self.loop = _Loop()
+            self.sign_in_calls = []
+
+        def qr_login(self):
+            class _Qr:
+                url = "https://example.test/qr"
+
+                class _Expiry:
+                    def strftime(self, _fmt):
+                        return "00:00:00"
+
+                expires = _Expiry()
+
+                async def wait(self, timeout=120):
+                    return None
+
+            return _Qr()
+
+        def sign_in(self, password=None):
+            self.sign_in_calls.append(password)
+
+    class _FakeQrCode:
+        def __init__(self, border=1):
+            self.border = border
+
+        def add_data(self, _data):
+            return None
+
+        def make(self, fit=True):
+            return None
+
+        def print_ascii(self, out, invert=True):
+            out.write("qr")
+
+    client = _Client()
+    prompted = []
+
+    monkeypatch.setattr("getpass.getpass", lambda prompt: prompted.append(prompt) or "secret")
+    monkeypatch.setattr("qrcode.QRCode", _FakeQrCode)
+
+    session_string_generator._qr_login(client)
+
+    assert prompted == ["\nTwo-factor authentication enabled. Please enter your password: "]
+    assert client.sign_in_calls == ["secret"]
+
+
+def test_phone_login_uses_hidden_password_prompt_for_2fa(monkeypatch):
+    class _Client:
+        def __init__(self):
+            self.sign_in_calls = []
+
+        def send_code_request(self, phone):
+            self.phone = phone
+
+        def disconnect(self):
+            return None
+
+        def sign_in(self, *args, **kwargs):
+            if kwargs.get("password") is not None:
+                self.sign_in_calls.append(kwargs["password"])
+                return None
+            raise session_string_generator.errors.SessionPasswordNeededError(request=None)
+
+    client = _Client()
+    prompted = []
+    entered = iter(["+10000000000", "12345"])
+
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(entered))
+    monkeypatch.setattr("getpass.getpass", lambda prompt: prompted.append(prompt) or "secret")
+
+    session_string_generator._phone_login(client)
+
+    assert client.phone == "+10000000000"
+    assert prompted == ["Two-factor authentication enabled. Please enter your password: "]
+    assert client.sign_in_calls == ["secret"]
+
+
 def test_parse_args_qr_selects_qr_login(monkeypatch):
     monkeypatch.setattr("sys.argv", ["session_string_generator.py", "--qr"])
 


### PR DESCRIPTION
## Summary

This changes the Telegram session string generator to use `getpass.getpass()` for two-factor authentication password prompts instead of plain `input()`.

## Why

When 2FA is required during QR or phone login, the current generator echoes the password into the terminal. That exposes the password in terminal scrollback even though it is not intended to be displayed.

## Changes

- use `getpass.getpass()` in the QR login 2FA path
- use `getpass.getpass()` in the phone login 2FA path
- add regression tests for both flows

## Verification

- `uv run pytest tests/test_session_string_generator.py`
