### PR TITLE
Optional SSE transport + sender @username/id in listings

### DIFF
--- a/telegram_mcp/runner.py
+++ b/telegram_mcp/runner.py
@@ -50,9 +50,22 @@ async def _main() -> None:
 
         warm_task = asyncio.create_task(_warm_caches())
 
-        print(f"Telegram client(s) started ({labels}). Running MCP server...", file=sys.stderr)
-        # Use the asynchronous entrypoint instead of mcp.run()
-        await mcp.run_stdio_async()
+        transport = os.getenv("MCP_TRANSPORT", "stdio").lower()
+        print(
+            f"Telegram client(s) started ({labels}). Running MCP server ({transport})...",
+            file=sys.stderr,
+        )
+        # SSE transport: one long-lived process holds a single shared Telegram
+        # connection, while multiple local MCP clients (Claude Code via mcp-remote,
+        # Claude Desktop) connect over HTTP. This avoids spawning one Telethon
+        # session per client, which Telegram throttles/flags.
+        if transport == "sse":
+            mcp.settings.host = os.getenv("MCP_HOST", "127.0.0.1")
+            mcp.settings.port = int(os.getenv("MCP_PORT", "8765"))
+            await mcp.run_sse_async()
+        else:
+            # Use the asynchronous entrypoint instead of mcp.run()
+            await mcp.run_stdio_async()
     except Exception as e:
         print(f"Error starting client: {e}", file=sys.stderr)
         if isinstance(e, sqlite3.OperationalError) and "database is locked" in str(e):

--- a/telegram_mcp/runtime.py
+++ b/telegram_mcp/runtime.py
@@ -831,6 +831,30 @@ def get_sender_name(message) -> str:
         return "Unknown"
 
 
+def get_sender_username(message) -> Optional[str]:
+    """Public @username of the message sender, if any (sanitized)."""
+    sender = getattr(message, "sender", None)
+    username = getattr(sender, "username", None) if sender else None
+    return sanitize_name(username) if username else None
+
+
+def get_sender_info(message) -> str:
+    """Sender display string: name (@username) [id=NNN].
+
+    Always exposes a numeric id (sender or from_id) so a user can be reached via
+    tg://user?id=<id> even when no public @username exists.
+    """
+    name = get_sender_name(message)
+    username = get_sender_username(message)
+    sid = getattr(message, "sender_id", None)
+    suffix = ""
+    if username:
+        suffix += f" (@{username})"
+    if sid:
+        suffix += f" [id={sid}]"
+    return f"{name}{suffix}"
+
+
 def get_engagement_info(message) -> str:
     """Helper function to get engagement metrics (views, forwards, reactions) from a message."""
     engagement_parts = []

--- a/telegram_mcp/tools/groups.py
+++ b/telegram_mcp/tools/groups.py
@@ -253,15 +253,18 @@ async def get_participants(
         if not participants:
             return format_tool_result([])
 
-        records = [
-            {
+        records = []
+        for p in participants:
+            rec = {
                 "id": p.id,
                 "name": sanitize_name(
                     f"{getattr(p, 'first_name', '')} {getattr(p, 'last_name', '')}".strip()
                 ),
             }
-            for p in participants
-        ]
+            uname = getattr(p, "username", None)
+            if uname:
+                rec["username"] = sanitize_name(uname)
+            records.append(rec)
         result = format_tool_result(records)
 
         # Append pagination metadata; has_more indicates whether a next page likely exists
@@ -920,15 +923,18 @@ async def get_admins(chat_id: Union[int, str], account: str = None) -> str:
         await ensure_connected(cl)
         # Fix: Use the correct filter type ChannelParticipantsAdmins
         participants = await cl.get_participants(chat_id, filter=ChannelParticipantsAdmins())
-        records = [
-            {
+        records = []
+        for p in participants:
+            rec = {
                 "id": p.id,
                 "name": sanitize_name(
                     f"{getattr(p, 'first_name', '')} {getattr(p, 'last_name', '')}".strip()
                 ),
             }
-            for p in participants
-        ]
+            uname = getattr(p, "username", None)
+            if uname:
+                rec["username"] = sanitize_name(uname)
+            records.append(rec)
         return format_tool_result(records) if records else "No admins found."
     except Exception as e:
         logger.exception(f"get_admins failed (chat_id={chat_id})")
@@ -951,15 +957,18 @@ async def get_banned_users(chat_id: Union[int, str], account: str = None) -> str
         await ensure_connected(cl)
         # Fix: Use the correct filter type ChannelParticipantsKicked
         participants = await cl.get_participants(chat_id, filter=ChannelParticipantsKicked(q=""))
-        records = [
-            {
+        records = []
+        for p in participants:
+            rec = {
                 "id": p.id,
                 "name": sanitize_name(
                     f"{getattr(p, 'first_name', '')} {getattr(p, 'last_name', '')}".strip()
                 ),
             }
-            for p in participants
-        ]
+            uname = getattr(p, "username", None)
+            if uname:
+                rec["username"] = sanitize_name(uname)
+            records.append(rec)
         return format_tool_result(records) if records else "No banned users found."
     except Exception as e:
         logger.exception(f"get_banned_users failed (chat_id={chat_id})")

--- a/telegram_mcp/tools/messages.py
+++ b/telegram_mcp/tools/messages.py
@@ -100,6 +100,9 @@ def message_to_dict(msg) -> dict:
     sender_id = getattr(msg, "sender_id", None)
     if sender_id is not None:
         d["sender_id"] = sender_id
+    username = get_sender_username(msg)
+    if username:
+        d["username"] = username
     if getattr(msg, "out", False):
         d["out"] = True
 
@@ -174,7 +177,7 @@ def message_to_dict(msg) -> dict:
 
 def format_message_line(msg) -> str:
     """Single-line human-readable message representation with ALL key flags."""
-    parts = [f"ID: {msg.id}", get_sender_name(msg), f"Date: {msg.date}"]
+    parts = [f"ID: {msg.id}", get_sender_info(msg), f"Date: {msg.date}"]
 
     reply_to_id = (
         getattr(msg.reply_to, "reply_to_msg_id", None) if getattr(msg, "reply_to", None) else None
@@ -772,7 +775,7 @@ async def list_messages(
         for msg in messages:
             record = {
                 "id": msg.id,
-                "sender": get_sender_name(msg),
+                "sender": get_sender_info(msg),
                 "date": msg.date,
                 "text": sanitize_user_content(msg.message),
             }
@@ -842,6 +845,11 @@ async def get_message_context(
                 "is_target": msg.id == message_id,
                 "text": sanitize_user_content(msg.message),
             }
+            if getattr(msg, "sender_id", None):
+                record["sender_id"] = msg.sender_id
+            _username = get_sender_username(msg)
+            if _username:
+                record["username"] = _username
             grouped_id = getattr(msg, "grouped_id", None)
             if grouped_id is not None:
                 record["grouped_id"] = grouped_id
@@ -852,15 +860,16 @@ async def get_message_context(
                 try:
                     replied_msg = await cl.get_messages(chat, ids=msg.reply_to.reply_to_msg_id)
                     if replied_msg:
-                        replied_sender = "Unknown"
-                        if replied_msg.sender:
-                            replied_sender = getattr(
-                                replied_msg.sender, "first_name", ""
-                            ) or getattr(replied_msg.sender, "title", "Unknown")
-                        record["replied_message"] = {
-                            "sender": sanitize_name(replied_sender),
+                        replied_record = {
+                            "sender": get_sender_name(replied_msg),
                             "text": sanitize_user_content(replied_msg.message),
                         }
+                        if getattr(replied_msg, "sender_id", None):
+                            replied_record["sender_id"] = replied_msg.sender_id
+                        _r_username = get_sender_username(replied_msg)
+                        if _r_username:
+                            replied_record["username"] = _r_username
+                        record["replied_message"] = replied_record
                 except Exception:
                     record["replied_message"] = None
 
@@ -1304,7 +1313,7 @@ async def search_messages(
         for msg in messages:
             record = {
                 "id": msg.id,
-                "sender": get_sender_name(msg),
+                "sender": get_sender_info(msg),
                 "date": msg.date,
                 "text": sanitize_user_content(msg.message),
             }
@@ -1354,7 +1363,7 @@ async def search_global(
                     "chat_name": sanitize_name(chat_name),
                     "chat_id": msg.chat_id,
                     "id": msg.id,
-                    "sender": get_sender_name(msg),
+                    "sender": get_sender_info(msg),
                     "date": msg.date,
                     "text": sanitize_user_content(msg.message),
                 }
@@ -1420,7 +1429,7 @@ async def get_pinned_messages(chat_id: Union[int, str], account: str = None) -> 
         for msg in messages:
             record = {
                 "id": msg.id,
-                "sender": get_sender_name(msg),
+                "sender": get_sender_info(msg),
                 "date": msg.date,
                 "text": sanitize_user_content(msg.message),
             }


### PR DESCRIPTION
Two small, independent additions. Happy to split into two PRs if you prefer focused review.

## 1. Optional SSE transport
`MCP_TRANSPORT=sse` runs the server over HTTP via `run_sse_async()` on `MCP_HOST:MCP_PORT` (default `127.0.0.1:8765`); **stdio stays the default**, so nothing changes for existing users.

**Why:** a single long-lived process can hold one Telegram connection while multiple local MCP clients (e.g. an editor + a desktop app) attach over HTTP — instead of each client spawning its own Telethon session, which Telegram throttles/flags.

## 2. Sender `@username` + numeric id in listings
Listings previously exposed only the display name (`sender_id` only in the dict view). This threads the sender's public `@username` through `message_to_dict`, `format_message_line`, `get_message_context` (incl. `replied_message`), search / global-search / pinned / date-range, and participant/admin/banned listings.

- New helpers `get_sender_username()` and `get_sender_info()` in `runtime.py`.
- Usernames are sanitized via `sanitize_name`, same as display names.
- Lets a caller reach a user by `@username`, and by `tg://user?id=<id>` when no public username exists.
- **No extra API calls** — the data is already on the fetched message object.

## Tests
All **131** existing tests pass (`pytest tests/`). No new dependencies.

## Notes
The two features are unrelated and self-contained; say the word and I'll resubmit as two separate PRs.