### PR TITLE
deps: bump telethon floor 1.42.0 → 1.44.0 (fixes User-constructor TypeNotFoundError on numeric-id resolve)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "python-dotenv>=1.1.0",
     "python-json-logger>=3.3.0",
     "qrcode>=8.2",
-    "telethon>=1.42.0",
+    "telethon>=1.44.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ nest-asyncio>=1.6.0
 python-dotenv>=1.1.0
 python-json-logger>=3.3.0
 qrcode>=8.2
-telethon>=1.42.0
+telethon>=1.44.0

--- a/uv.lock
+++ b/uv.lock
@@ -1362,7 +1362,7 @@ requires-dist = [
     { name = "python-json-logger", specifier = ">=3.3.0" },
     { name = "python-socks", marker = "extra == 'proxy'", specifier = ">=2.4.3" },
     { name = "qrcode", specifier = ">=8.2" },
-    { name = "telethon", specifier = ">=1.42.0" },
+    { name = "telethon", specifier = ">=1.44.0" },
 ]
 provides-extras = ["proxy"]
 
@@ -1378,15 +1378,15 @@ dev = [
 
 [[package]]
 name = "telethon"
-version = "1.42.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyaes" },
     { name = "rsa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/10/8c8c9476bfce767a856d8aaf9eae8ea1869df4e970da16f1c5b638fd1b0c/telethon-1.42.0.tar.gz", hash = "sha256:032e95511261d5ead719f75494c6c85ece2ce71816b54f3c65d6ccc371d6994d", size = 672734, upload-time = "2025-11-05T19:15:19.849Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/e2/d4137e598db0ba50e4cf9bf32f2e26d016b2c4bb0e9763e3d5a07007d780/telethon-1.44.0.tar.gz", hash = "sha256:7de1473e9e412e20bd57b102d8f50d48372712462be9ff6c003bb81c50ad7e98", size = 701463, upload-time = "2026-06-15T15:47:39.44Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/e4/8ce0ff55251381966a7c3f88bd5b34abda79b225a8e7fb51ddef3b849c94/telethon-1.42.0-py3-none-any.whl", hash = "sha256:cf361c94586bcacd6d0fc8959a2bce509d1bb37007fe6476a80c4fb4a2decc29", size = 748466, upload-time = "2025-11-05T19:15:18.241Z" },
+    { url = "https://files.pythonhosted.org/packages/82/fd/4ad621d7a4b8655dfc964ee1c1267407496ec6fd10c91901a64ea29c16c8/telethon-1.44.0-py3-none-any.whl", hash = "sha256:52fc49efb67a4916c2aedcb295ad286f4afa2aba9bf15d83ed2acdc64af0c718", size = 789786, upload-time = "2026-06-15T15:47:41.534Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
On telethon **1.42.0**, resolving a user by **numeric id** (`get_entity(<user_id>)`, as used inside `ResolveUsername`/`GetUsers` paths) can raise:

```
TypeNotFoundError: Could not find a matching Constructor ID for the TLObject
that was supposed to be read with ID 31774388 ...
```

`0x31774388` is the `User` constructor. Telegram serves `User` objects with fields that the 1.42 TL layer does not parse, so deserialization desyncs. Resolving by **@username** was unaffected, which made it look intermittent.

**telethon 1.44.0** (TL layer 227) parses these `User` objects correctly and resolves the same numeric ids cleanly.

### Change
- Bump the floor `telethon>=1.42.0 → >=1.44.0` in `pyproject.toml` and `requirements.txt`.
- Regenerate `uv.lock` (`1.42.0 → 1.44.0`).

Diff is telethon-only. `poetry.lock` is left untouched (it has not tracked deps since 2025-04 — `uv.lock`/`pyproject.toml` are the maintained pair).

### Verification
Reproduced the `TypeNotFoundError` on 1.42.0 resolving a real user by numeric id; after the bump, `get_entity(<numeric_id>)` returns the full user with no error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)