### PR TITLE
fix(roots): honor server roots on list_roots error; ship writable /data in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,9 @@ COPY main.py sanitize.py ./
 COPY telegram_mcp ./telegram_mcp
 # COPY session_string_generator.py . # Optional: if needed within the container, otherwise can be run outside
 
-# Create a non-root user and switch to it
-RUN adduser --disabled-password --gecos "" appuser && chown -R appuser:appuser /app
+RUN adduser --disabled-password --gecos "" appuser \
+    && mkdir -p /data \
+    && chown -R appuser:appuser /app /data
 USER appuser
 
 # Define environment variables needed by the application
@@ -40,9 +41,10 @@ ENV TELEGRAM_API_HASH=""
 ENV TELEGRAM_SESSION_NAME="telegram_mcp_session"
 # Or provide the session string directly
 ENV TELEGRAM_SESSION_STRING=""
+ENV TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK="true"
 
 # Expose any ports if the application were a web server (not needed for stdio MCP)
 # EXPOSE 8000
 
-# Define the command to run the application
-CMD ["python", "main.py"]
+# /data = allowed root for file tools; mount a volume there to persist downloads
+CMD ["python", "main.py", "/data"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,15 @@ services:
     # The endpoint is unauthenticated — publish on localhost only.
     ports:
       - "127.0.0.1:8765:8765"
+    # Persist downloaded media (download_media writes into /data)
+    volumes:
+      - telegram_downloads:/data
     # Optional: Uncomment the following lines to mount a local directory
     # for persisting the Telegram session file if NOT using TELEGRAM_SESSION_STRING.
     # Replace './telegram_sessions' with your desired host path.
     # volumes:
     #   - ./telegram_sessions:/app
     restart: unless-stopped
+
+volumes:
+  telegram_downloads:

--- a/telegram_mcp/runtime.py
+++ b/telegram_mcp/runtime.py
@@ -1011,8 +1011,11 @@ async def _get_effective_allowed_roots_with_status(
                 return fallback_roots, ROOTS_STATUS_UNSUPPORTED_FALLBACK
             return [], ROOTS_STATUS_NOT_CONFIGURED
         logger.error(
-            "MCP roots request failed; disabling file-path tools for safety.", exc_info=True
+            "MCP roots request failed; falling back to server roots if opted in.",
+            exc_info=True,
         )
+        if fallback_roots and _server_roots_fallback_enabled():
+            return fallback_roots, ROOTS_STATUS_SERVER_FALLBACK
         return [], ROOTS_STATUS_ERROR
 
     client_roots: List[Path] = []

--- a/tests/test_file_path_security.py
+++ b/tests/test_file_path_security.py
@@ -193,6 +193,18 @@ async def test_unexpected_roots_error_disables_file_path_tools(tmp_path, monkeyp
 
 
 @pytest.mark.asyncio
+async def test_roots_error_falls_back_to_server_roots_when_opted_in(tmp_path, monkeypatch):
+    server_root = (tmp_path / "server_root").resolve()
+    server_root.mkdir(parents=True)
+    monkeypatch.setattr(main, "SERVER_ALLOWED_ROOTS", [server_root])
+    monkeypatch.setenv("TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK", "true")
+
+    ctx = _FailingContext(RuntimeError("transport failure"))
+    roots = await main._get_effective_allowed_roots(ctx)
+    assert roots == [server_root]
+
+
+@pytest.mark.asyncio
 async def test_writable_default_path_uses_downloads_subdir(tmp_path, monkeypatch):
     root = (tmp_path / "root").resolve()
     root.mkdir(parents=True)


### PR DESCRIPTION
## Problem

File-path tools (`download_media`, `send_file`, …) are gated behind MCP Roots verification. The gate has three client-failure modes, but they're handled inconsistently in `_get_effective_allowed_roots_with_status`:

| client `list_roots()` result | server-roots fallback on opt-in? |
|---|---|
| unsupported (`method not found`) | ✅ yes |
| empty list | ✅ yes |
| **raised an unexpected exception** | ❌ **no → deny-all** |

So any MCP client that errors on `roots/list` disables the file tools entirely — even when the operator explicitly set CLI roots **and** `TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK=true`. There was no escape hatch for that path. Symptom users hit: `download_media` returns *"MCP Roots could not be verified safely"*.

The Docker image also shipped with no allowed root at all (`CMD ["python", "main.py"]`, no positional arg), so file tools were off out of the box.

## Changes

- **`runtime.py`** — the `error` branch now returns server roots when the operator opted in, matching the empty-list and unsupported branches. Fail-closed only when no server roots / no opt-in.
- **`Dockerfile`** — create a writable `/data`, launch with it as the allowed root, and default `TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK=true`.
- **`docker-compose.yml`** — persist `/data` via a named volume (a bind-mount would override the image's `chown` and break writes for the non-root `appuser`).
- **tests** — added `error + opt-in → server roots`; existing `error + no opt-in → deny-all` still passes.

## Verification

- `pytest tests/test_file_path_security.py` → 12 passed.
- `docker build` + `docker run` confirm `/data` exists and is writable by `appuser`, via both a fresh container and a named volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)