### PR TITLE
docs: add Autohand Code MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,12 @@ claude mcp add --transport http telegram http://127.0.0.1:8765/mcp
 
 # Codex
 codex mcp add telegram --url http://127.0.0.1:8765/mcp
+
+# Autohand Code
+autohand mcp add --transport http telegram http://127.0.0.1:8765/mcp
 ```
+
+For a project-scoped [Autohand Code](https://github.com/autohandai/code-cli/) registration, add `--scope project` after `mcp add`.
 
 For stdio-only clients, bridge with [mcp-remote](https://www.npmjs.com/package/mcp-remote):
 


### PR DESCRIPTION
## Summary

Add Autohand Code to the shared Streamable HTTP registration examples. This keeps one long-lived Telegram connection, matching the guide's recommendation for coding-agent sessions.

## Verification

- CI-parity pytest command — 136 passed, 89.43% coverage
- Black passed
- Flake8 passed
- end-of-file, trailing-whitespace, and merge-conflict hooks passed
- `git diff --check`

The Docker-based hadolint hook became unresponsive locally and was stopped after more than ten minutes. The README-only change does not touch Docker files; CI can provide the Docker-hosted check.