### PR TITLE
fix(roots): recover Cursor bare-path MCP Roots; opt-in fallback on list_roots errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,10 +30,11 @@ TELEGRAM_SESSION_NAME=telegram_session
 # TELEGRAM_EXPOSED_TOOLS=read-only
 
 # --- File-path tools / allowed roots (optional) ---
-# When the MCP client implements Roots but advertises an empty list, file-path
-# tools (download_media, send_file, ...) are disabled (deny-all) even if server
-# CLI roots are configured. Set this to 1/true to fall back to the server CLI
-# roots in that case. Default is deny-all.
+# When the MCP client implements Roots but advertises an empty list — or when
+# list_roots fails unexpectedly and no client paths can be recovered —
+# file-path tools (download_media, send_file, ...) are disabled (deny-all) even
+# if server CLI roots are configured. Set this to 1/true to fall back to the
+# server CLI roots in those cases. Default is deny-all.
 # TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK=1
 
 # --- Proxy (optional) ---

--- a/README.md
+++ b/README.md
@@ -347,11 +347,16 @@ Allowed roots can come from:
 Security behavior:
 
 - Client MCP Roots replace server CLI roots when available.
+- Some clients (notably Cursor) return workspace roots as bare absolute paths
+  instead of `file://` URIs. That breaks MCP SDK validation of `list_roots`;
+  the server recovers those absolute paths from the validation error so
+  file-path tools keep working.
 - Empty client Roots are treated as deny-all by default. Some clients implement
   the Roots capability but advertise an empty list, which disables file tools
   even when server CLI roots are configured. Set
   `TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK=1` to fall back to the server CLI roots
-  in that case (opt-in; the default stays deny-all).
+  in that case (opt-in; the default stays deny-all). The same opt-in also applies
+  when `list_roots` fails unexpectedly and no client paths could be recovered.
 - Paths are resolved through real paths and must stay inside an allowed root.
 - Traversal, wildcard-like, shell-like, and null-byte path patterns are rejected.
 - Relative paths resolve under the first allowed root.

--- a/telegram_mcp/runtime.py
+++ b/telegram_mcp/runtime.py
@@ -984,10 +984,49 @@ def _is_roots_unsupported_error(error: Exception) -> bool:
     return False
 
 
+def _coerce_paths_from_list_roots_validation_error(error: Exception) -> List[Path]:
+    """Recover absolute filesystem roots when a client sends bare paths.
+
+    Some MCP clients (notably Cursor) return workspace roots as plain absolute
+    paths instead of ``file://`` URIs. The MCP SDK then fails pydantic validation
+    of ``ListRootsResult`` even though the roots themselves are usable. Extract
+    those paths from the validation error payload so file-path tools keep working.
+    """
+    errors_fn = getattr(error, "errors", None)
+    if not callable(errors_fn):
+        return []
+
+    try:
+        details = errors_fn()
+    except Exception:
+        return []
+
+    recovered: List[Path] = []
+    for item in details:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") != "url_parsing":
+            continue
+        value = item.get("input")
+        if not isinstance(value, str):
+            continue
+        candidate = value.strip()
+        if not (candidate.startswith("/") or (len(candidate) > 2 and candidate[1] == ":")):
+            # Unix absolute path, or Windows drive path like C:\...
+            continue
+        try:
+            recovered.append(Path(candidate).expanduser().resolve())
+        except Exception:
+            continue
+    return _dedupe_paths(recovered)
+
+
 def _server_roots_fallback_enabled(value: Optional[str] = None) -> bool:
-    """Whether an empty client roots list should fall back to server CLI roots.
+    """Whether server CLI roots may replace unusable/empty client Roots.
 
     Opt-in via the ``TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK`` environment variable.
+    Applies when the client returns an empty roots list, or when ``list_roots``
+    fails with an unexpected error (after any recoverable client paths are tried).
     Defaults to ``False`` to preserve the safe deny-all behavior.
     """
     raw_value = os.getenv("TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK") if value is None else value
@@ -1006,10 +1045,26 @@ async def _get_effective_allowed_roots_with_status(
     try:
         list_roots_result = await ctx.session.list_roots()
     except Exception as error:
+        recovered_roots = _coerce_paths_from_list_roots_validation_error(error)
+        if recovered_roots:
+            logger.warning(
+                "MCP client returned non-URI roots; recovered %d path(s) from validation error.",
+                len(recovered_roots),
+            )
+            return recovered_roots, ROOTS_STATUS_READY
         if _is_roots_unsupported_error(error):
             if fallback_roots:
                 return fallback_roots, ROOTS_STATUS_UNSUPPORTED_FALLBACK
             return [], ROOTS_STATUS_NOT_CONFIGURED
+        # Unexpected list_roots failures (e.g. malformed client payloads that we
+        # could not recover). Match empty-list behavior: opt-in server fallback.
+        if fallback_roots and _server_roots_fallback_enabled():
+            logger.warning(
+                "MCP roots request failed; falling back to server CLI roots "
+                "(TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK).",
+                exc_info=True,
+            )
+            return fallback_roots, ROOTS_STATUS_SERVER_FALLBACK
         logger.error(
             "MCP roots request failed; disabling file-path tools for safety.", exc_info=True
         )

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -802,3 +802,95 @@ async def test_empty_client_roots_fallback_noop_without_server_roots(monkeypatch
     roots, status = await runtime._get_effective_allowed_roots_with_status(_ctx_with_roots([]))
     assert roots == []
     assert status == runtime.ROOTS_STATUS_CLIENT_DENY_ALL
+
+
+class _FailingRootsSession:
+    def __init__(self, error: Exception):
+        self._error = error
+
+    async def list_roots(self):
+        raise self._error
+
+
+def _ctx_with_list_roots_error(error: Exception):
+    return SimpleNamespace(session=_FailingRootsSession(error))
+
+
+def test_coerce_paths_from_list_roots_validation_error_recovers_bare_paths(tmp_path):
+    """Cursor-style bare absolute paths appear as pydantic url_parsing inputs."""
+    from pydantic import ValidationError
+    from mcp.types import ListRootsResult
+
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    root_a.mkdir()
+    root_b.mkdir()
+
+    with pytest.raises(ValidationError) as exc_info:
+        ListRootsResult.model_validate(
+            {
+                "roots": [
+                    {"uri": str(root_a)},
+                    {"uri": str(root_b)},
+                    {"uri": "not-a-path"},
+                ]
+            }
+        )
+
+    recovered = runtime._coerce_paths_from_list_roots_validation_error(exc_info.value)
+    assert root_a.resolve() in recovered
+    assert root_b.resolve() in recovered
+
+
+@pytest.mark.asyncio
+async def test_list_roots_validation_error_recovers_client_paths(tmp_path, monkeypatch):
+    from pydantic import ValidationError
+    from mcp.types import ListRootsResult
+
+    root = tmp_path / "workspace"
+    root.mkdir()
+    monkeypatch.setattr(runtime, "SERVER_ALLOWED_ROOTS", [])
+    monkeypatch.delenv("TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK", raising=False)
+
+    with pytest.raises(ValidationError) as exc_info:
+        ListRootsResult.model_validate({"roots": [{"uri": str(root)}]})
+
+    roots, status = await runtime._get_effective_allowed_roots_with_status(
+        _ctx_with_list_roots_error(exc_info.value)
+    )
+    assert status == runtime.ROOTS_STATUS_READY
+    assert roots == [root.resolve()]
+
+    resolved, error = await runtime._ensure_allowed_roots(
+        _ctx_with_list_roots_error(exc_info.value), "download_media"
+    )
+    assert error is None
+    assert resolved == [root.resolve()]
+
+
+@pytest.mark.asyncio
+async def test_list_roots_unexpected_error_falls_back_when_opt_in(tmp_path, monkeypatch):
+    root = tmp_path / "root"
+    root.mkdir()
+    monkeypatch.setattr(runtime, "SERVER_ALLOWED_ROOTS", [root.resolve()])
+    monkeypatch.setenv("TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK", "1")
+
+    roots, status = await runtime._get_effective_allowed_roots_with_status(
+        _ctx_with_list_roots_error(RuntimeError("boom"))
+    )
+    assert status == runtime.ROOTS_STATUS_SERVER_FALLBACK
+    assert roots == [root.resolve()]
+
+
+@pytest.mark.asyncio
+async def test_list_roots_unexpected_error_denies_without_opt_in(tmp_path, monkeypatch):
+    root = tmp_path / "root"
+    root.mkdir()
+    monkeypatch.setattr(runtime, "SERVER_ALLOWED_ROOTS", [root.resolve()])
+    monkeypatch.delenv("TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK", raising=False)
+
+    roots, status = await runtime._get_effective_allowed_roots_with_status(
+        _ctx_with_list_roots_error(RuntimeError("boom"))
+    )
+    assert status == runtime.ROOTS_STATUS_ERROR
+    assert roots == []


### PR DESCRIPTION
## Summary
- Recover absolute workspace paths when an MCP client (notably **Cursor**) returns bare paths instead of `file://` URIs — today SDK validation fails with `url_parsing` and file tools return *"MCP Roots could not be verified safely"*.
- Align unexpected `list_roots` failures with the empty-list behavior: if `TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK=1` and CLI roots are set, fall back to server roots instead of hard deny-all.
- Docs/tests updated.

## Problem
Cursor's `roots/list` response uses values like `/Users/…/project` rather than `file:///Users/…/project`. The MCP Python SDK then raises pydantic `ValidationError` while validating `ListRootsResult`. Upstream treated that as `ROOTS_STATUS_ERROR` and disabled `download_media` / `send_file` even though the paths were valid.

Related: #141 (empty-list opt-in). Closed (unmerged) #149 covered unexpected-error fallback; this PR keeps that opt-in gated and adds client-path recovery for Cursor.

## Test plan
- [x] `uv run pytest tests/test_runtime.py -k 'roots or coerce or list_roots'`
- [ ] On Cursor: `download_media` for a DM attachment


Made with [Cursor](https://cursor.com)