### PR TITLE
feat: surface reply quotes (quote_text + offset) in message reads

### DIFF
--- a/telegram_mcp/tools/messages.py
+++ b/telegram_mcp/tools/messages.py
@@ -87,6 +87,29 @@ def _link_urls(msg):
     return out
 
 
+def get_reply_quote(msg) -> Optional[dict]:
+    """Quoted fragment when a reply targets only *part* of the replied-to message.
+
+    Telegram lets you select a span of another message and reply to just that
+    span. Telethon exposes it on msg.reply_to as quote_text (the selected text)
+    and quote_offset (its UTF-16 character offset inside the original message).
+    Returns {"text": ..., "offset": ...} for such a partial-quote reply, or None
+    for a plain whole-message reply (or no reply at all). Independent of
+    reply_to_msg_id so a cross-chat quote reply still surfaces its quote.
+    """
+    reply = getattr(msg, "reply_to", None)
+    if reply is None:
+        return None
+    quote_text = getattr(reply, "quote_text", None)
+    if not quote_text:
+        return None
+    quote = {"text": sanitize_user_content(quote_text)}
+    offset = getattr(reply, "quote_offset", None)
+    if offset is not None:
+        quote["offset"] = offset
+    return quote
+
+
 def message_to_dict(msg) -> dict:
     """API-complete but compact Telethon message view (omit empty fields).
 
@@ -123,6 +146,9 @@ def message_to_dict(msg) -> dict:
     )
     if reply_to_id:
         d["reply_to"] = reply_to_id
+    reply_quote = get_reply_quote(msg)
+    if reply_quote:
+        d["reply_quote"] = reply_quote  # reply to a selected span of the original
 
     fwd = getattr(msg, "fwd_from", None)
     if fwd is not None:
@@ -184,6 +210,12 @@ def format_message_line(msg) -> str:
     )
     if reply_to_id:
         parts.append(f"reply to {reply_to_id}")
+    reply_quote = get_reply_quote(msg)
+    if reply_quote:
+        preview = reply_quote["text"].replace("\n", " ")
+        if len(preview) > 60:
+            preview = preview[:60] + "…"
+        parts.append(f'quoting "{preview}"')
 
     flags = []
     media_label = get_media_label(msg)
@@ -785,6 +817,9 @@ async def list_messages(
             reply_to_id = getattr(msg.reply_to, "reply_to_msg_id", None) if msg.reply_to else None
             if reply_to_id:
                 record["reply_to"] = reply_to_id
+            reply_quote = get_reply_quote(msg)
+            if reply_quote:
+                record["reply_quote"] = reply_quote
             engagement = get_engagement_dict(msg)
             if engagement:
                 record["engagement"] = engagement
@@ -855,6 +890,9 @@ async def get_message_context(
                 record["grouped_id"] = grouped_id
 
             # Check if this message is a reply and get the replied message
+            reply_quote = get_reply_quote(msg)
+            if reply_quote:
+                record["reply_quote"] = reply_quote
             if msg.reply_to and msg.reply_to.reply_to_msg_id:
                 record["reply_to"] = msg.reply_to.reply_to_msg_id
                 try:
@@ -1319,6 +1357,9 @@ async def search_messages(
             }
             if msg.reply_to and msg.reply_to.reply_to_msg_id:
                 record["reply_to"] = msg.reply_to.reply_to_msg_id
+            reply_quote = get_reply_quote(msg)
+            if reply_quote:
+                record["reply_quote"] = reply_quote
             records.append(record)
         return format_tool_result(records)
     except Exception as e:
@@ -1435,6 +1476,9 @@ async def get_pinned_messages(chat_id: Union[int, str], account: str = None) -> 
             }
             if msg.reply_to and msg.reply_to.reply_to_msg_id:
                 record["reply_to"] = msg.reply_to.reply_to_msg_id
+            reply_quote = get_reply_quote(msg)
+            if reply_quote:
+                record["reply_quote"] = reply_quote
             records.append(record)
 
         return format_tool_result(records)

--- a/tests/test_reply_quote.py
+++ b/tests/test_reply_quote.py
@@ -1,0 +1,95 @@
+"""Tests for reply-quote extraction (reply to a selected part of a message)."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from telegram_mcp.tools.messages import (
+    get_reply_quote,
+    message_to_dict,
+    format_message_line,
+)
+
+
+def _reply(**overrides):
+    """Fake Telethon MessageReplyHeader."""
+    base = {
+        "reply_to_msg_id": 100,
+        "quote_text": None,
+        "quote_offset": None,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _msg(**overrides):
+    """Minimal fake Telethon Message; getattr defaults cover unset media/flags."""
+    base = {
+        "id": 200,
+        "sender": None,
+        "sender_id": 42,
+        "date": datetime(2024, 1, 1, tzinfo=timezone.utc),
+        "message": "the reply body",
+        "reply_to": None,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_get_reply_quote_returns_text_and_offset():
+    msg = _msg(reply_to=_reply(quote_text="the important part", quote_offset=15))
+    assert get_reply_quote(msg) == {"text": "the important part", "offset": 15}
+
+
+def test_get_reply_quote_none_for_plain_reply():
+    # A whole-message reply carries reply_to_msg_id but no quote_text.
+    msg = _msg(reply_to=_reply())
+    assert get_reply_quote(msg) is None
+
+
+def test_get_reply_quote_none_when_not_a_reply():
+    assert get_reply_quote(_msg(reply_to=None)) is None
+
+
+def test_get_reply_quote_offset_zero_is_kept():
+    # offset 0 is a valid position (quote at the very start), must not be dropped.
+    msg = _msg(reply_to=_reply(quote_text="start span", quote_offset=0))
+    assert get_reply_quote(msg) == {"text": "start span", "offset": 0}
+
+
+def test_get_reply_quote_without_offset():
+    msg = _msg(reply_to=_reply(quote_text="span", quote_offset=None))
+    assert get_reply_quote(msg) == {"text": "span"}
+
+
+def test_get_reply_quote_survives_cross_chat_reply_without_msg_id():
+    # Cross-chat quote reply: reply_to_msg_id may be absent, quote still present.
+    msg = _msg(reply_to=_reply(reply_to_msg_id=None, quote_text="from elsewhere", quote_offset=3))
+    assert get_reply_quote(msg) == {"text": "from elsewhere", "offset": 3}
+
+
+def test_message_to_dict_includes_reply_quote():
+    msg = _msg(reply_to=_reply(quote_text="quoted span", quote_offset=7))
+    d = message_to_dict(msg)
+    assert d["reply_to"] == 100
+    assert d["reply_quote"] == {"text": "quoted span", "offset": 7}
+
+
+def test_message_to_dict_omits_reply_quote_for_plain_reply():
+    d = message_to_dict(_msg(reply_to=_reply()))
+    assert d["reply_to"] == 100
+    assert "reply_quote" not in d
+
+
+def test_format_message_line_shows_quote_preview():
+    msg = _msg(reply_to=_reply(quote_text="a short quoted span", quote_offset=2))
+    line = format_message_line(msg)
+    assert "reply to 100" in line
+    assert 'quoting "a short quoted span"' in line
+
+
+def test_format_message_line_truncates_long_quote_and_flattens_newlines():
+    long_quote = "x" * 80 + "\nmore"
+    msg = _msg(reply_to=_reply(quote_text=long_quote, quote_offset=0))
+    line = format_message_line(msg)
+    assert "\n" not in line.split("quoting", 1)[1]
+    assert "…" in line


### PR DESCRIPTION
## What

When a Telegram reply targets only a **selected span** of the original message (Telegram's quote-reply), that span is now exposed in the MCP output.

Adds a `get_reply_quote()` helper that reads `quote_text` / `quote_offset` from `msg.reply_to`, and wires a new optional `reply_quote` field into every message serializer:

- `message_to_dict` (→ `get_history`)
- `format_message_line` (→ `get_messages`)
- `list_messages`
- `get_message_context`
- `search_messages`
- `get_pinned_messages`

### Output shape

```json
{
  "id": 200,
  "text": "my reply",
  "reply_to": 100,
  "reply_quote": { "text": "the selected fragment", "offset": 12 }
}
```

- The existing `reply_to` id field is **unchanged** (backward compatible).
- `reply_quote` appears **only** for partial-quote replies; a plain whole-message reply has no `reply_quote`.
- Quote text is sanitized like all user-generated content.
- `offset: 0` (quote at the very start) is preserved.
- In the human-readable `get_messages` line output, a `quoting "…"` preview is shown (truncated to 60 chars, newlines flattened).

## Testing

- New `tests/test_reply_quote.py` — 10 cases (offset 0, missing offset, plain reply, cross-chat reply, line-format truncation).
- Full suite green (155 passed).
- Verified against real Telethon `Message` + `MessageReplyHeader` objects (telethon 1.44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)