### PR TITLE
fix(runner): drop nest_asyncio, which breaks startup on Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "dotenv>=0.9.9",
     "httpx>=0.28.1",
     "mcp[cli]>=1.8.0",
-    "nest-asyncio>=1.6.0",
     "python-dotenv>=1.1.0",
     "python-json-logger>=3.3.0",
     "qrcode>=8.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 dotenv>=0.9.9
 httpx>=0.28.1
 mcp[cli]>=1.8.0
-nest-asyncio>=1.6.0
 python-dotenv>=1.1.0
 python-json-logger>=3.3.0
 qrcode>=8.2

--- a/telegram_mcp/runner.py
+++ b/telegram_mcp/runner.py
@@ -98,7 +98,6 @@ async def _main() -> None:
 def main() -> None:
     _configure_allowed_roots_from_cli(sys.argv[1:])
     _runtime._apply_exposed_tools_mode()
-    nest_asyncio.apply()
     asyncio.run(_main())
 
 

--- a/telegram_mcp/runtime.py
+++ b/telegram_mcp/runtime.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from urllib.parse import unquote, urlparse
 
 # Third-party libraries
-import nest_asyncio
 from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP, Context
 from mcp.types import Annotations, TextContent, ToolAnnotations

--- a/uv.lock
+++ b/uv.lock
@@ -664,15 +664,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nest-asyncio"
-version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
-]
-
-[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1330,7 +1321,6 @@ dependencies = [
     { name = "dotenv" },
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
-    { name = "nest-asyncio" },
     { name = "python-dotenv" },
     { name = "python-json-logger" },
     { name = "qrcode" },
@@ -1357,7 +1347,6 @@ requires-dist = [
     { name = "dotenv", specifier = ">=0.9.9" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.8.0" },
-    { name = "nest-asyncio", specifier = ">=1.6.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "python-json-logger", specifier = ">=3.3.0" },
     { name = "python-socks", marker = "extra == 'proxy'", specifier = ">=2.4.3" },


### PR DESCRIPTION
Fixes #156. On Python 3.14 the server dies on startup with `RuntimeError: Timeout should be used inside a task`. `nest_asyncio.apply()` in `runner.main()` patches asyncio so that `wait_for` loses its task context, and the first `wait_for` inside Telethon `client.connect()` raises. nest_asyncio has been archived upstream since January 2024, so no fix is coming from there.

The call is vestigial, so this removes it along with the import and the dependency. Nothing under `telegram_mcp/` re-enters a running loop: the only entrypoint is `asyncio.run(_main())`, and the HTTP/SSE transports are awaited inside that same loop. `session_string_generator.py` does use `telethon.sync` and `loop.run_until_complete`, but it runs standalone and never imports `runner`, so `apply()` never applied to it. The uv.lock diff is nest-asyncio only.

One correction to the issue: it reports 3.13 as affected too, but I could not reproduce there. Both the isolated `wait_for` case and app startup are fine on 3.13.14, and the failure only appears on 3.14, so I scoped the report to 3.14.

Tested on 3.14.6: before this change `python main.py` dies at `connect()` with the error above, after it the connection completes and startup reaches the expected "not authorized" error for dummy credentials. 3.11 reaches that same point unchanged. pytest is 149 passed with 3 pre-existing failures (Windows path handling in the install-guard and list_roots tests), identical before and after. Worth noting CI only runs 3.11, which is why this went unnoticed.