### PR TITLE
feat: support Telegram Rich Messages

### DIFF
--- a/telegram_mcp/tools/media.py
+++ b/telegram_mcp/tools/media.py
@@ -1,6 +1,45 @@
 """Media MCP tools."""
 
+from mcp.server.fastmcp import Audio, Image
+
 from telegram_mcp.runtime import *
+
+
+MAX_INLINE_MEDIA_BYTES = 20 * 1024 * 1024
+
+
+@mcp.tool(annotations=ToolAnnotations(title="Get Media", openWorldHint=True, readOnlyHint=True))
+@with_account(readonly=True)
+@validate_id("chat_id")
+async def get_media(
+    chat_id: Union[int, str], message_id: int, account: str = None
+) -> Any:
+    """Return a Telegram image or audio attachment as native MCP media content."""
+    try:
+        cl = get_client(account)
+        entity = await resolve_entity(chat_id, cl)
+        msg = await cl.get_messages(entity, ids=message_id)
+        if not msg or not msg.media:
+            return "No media found in the specified message."
+
+        mime = getattr(getattr(msg, "file", None), "mime_type", None)
+        if not mime and getattr(msg, "photo", None) is not None:
+            mime = "image/jpeg"
+        if not mime or not (mime.startswith("image/") or mime.startswith("audio/")):
+            return "Native MCP media is available for images and audio only."
+
+        data = await cl.download_media(msg, bytes)
+        if not data:
+            return f"Download failed for message {message_id}."
+        if len(data) > MAX_INLINE_MEDIA_BYTES:
+            return f"Media is too large for inline MCP delivery ({len(data)} bytes)."
+
+        media_type, media_format = mime.split("/", 1)
+        if media_type == "image":
+            return Image(data=data, format=media_format)
+        return Audio(data=data, format=media_format)
+    except Exception as e:
+        return log_and_format_error("get_media", e, chat_id=chat_id, message_id=message_id)
 
 
 @mcp.tool(annotations=ToolAnnotations(title="Send File", openWorldHint=True, destructiveHint=True))

--- a/telegram_mcp/tools/messages.py
+++ b/telegram_mcp/tools/messages.py
@@ -1,5 +1,7 @@
 """Messages MCP tools."""
 
+import secrets
+
 from telegram_mcp.runtime import *
 
 
@@ -190,6 +192,10 @@ def message_to_dict(msg) -> dict:
     if urls:
         d["link_urls"] = urls
 
+    rich_message = getattr(msg, "rich_message", None)
+    if rich_message is not None:
+        d["rich_message"] = sanitize_dict(rich_message.to_dict())
+
     action = getattr(msg, "action", None)
     if action is not None:
         d["action"] = type(action).__name__  # service message (joined/pinned/…)
@@ -272,8 +278,7 @@ async def get_messages(
         messages = await cl.get_messages(entity, limit=page_size, add_offset=offset)
         if not messages:
             return "No messages found for this page."
-        lines = [format_message_line(msg) for msg in messages]
-        return "\n".join(lines)
+        return format_tool_result([message_to_dict(msg) for msg in messages])
     except Exception as e:
         return log_and_format_error(
             "get_messages", e, chat_id=chat_id, page=page, page_size=page_size
@@ -307,6 +312,93 @@ async def send_message(
         return "Message sent successfully."
     except Exception as e:
         return log_and_format_error("send_message", e, chat_id=chat_id)
+
+
+def _build_rich_message(
+    html: Optional[str], markdown: Optional[str], is_rtl: bool, skip_entity_detection: bool
+):
+    """Build Telegram's native rich payload from exactly one supported markup form."""
+    if bool(html) == bool(markdown):
+        raise ValidationError("Provide exactly one of html or markdown.")
+    kwargs = {"rtl": is_rtl or None, "noautolink": skip_entity_detection or None}
+    if html:
+        return types.InputRichMessageHTML(html=html, **kwargs)
+    return types.InputRichMessageMarkdown(markdown=markdown, **kwargs)
+
+
+@mcp.tool(
+    annotations=ToolAnnotations(title="Send Rich Message", openWorldHint=True, destructiveHint=True)
+)
+@with_account(readonly=False)
+@validate_id("chat_id")
+async def send_rich_message(
+    chat_id: Union[int, str],
+    html: Optional[str] = None,
+    markdown: Optional[str] = None,
+    is_rtl: bool = False,
+    skip_entity_detection: bool = False,
+    account: str = None,
+) -> str:
+    """Send a native Telegram Rich Message using HTML or Markdown markup.
+
+    Rich markup supports Telegram's structured blocks, lists, tables, quotations,
+    formulas and media references; provide exactly one of ``html`` or ``markdown``.
+    """
+    try:
+        cl = get_client(account)
+        peer = await resolve_input_entity(chat_id, cl)
+        rich_message = _build_rich_message(html, markdown, is_rtl, skip_entity_detection)
+        await cl(
+            functions.messages.SendMessageRequest(
+                peer=peer,
+                message="",
+                random_id=secrets.randbits(63),
+                rich_message=rich_message,
+            )
+        )
+        return "Rich message sent successfully."
+    except Exception as e:
+        return log_and_format_error("send_rich_message", e, chat_id=chat_id)
+
+
+@mcp.tool(
+    annotations=ToolAnnotations(
+        title="Stream Rich Message Draft",
+        openWorldHint=True,
+        destructiveHint=True,
+        idempotentHint=False,
+    )
+)
+@with_account(readonly=False)
+@validate_id("chat_id")
+async def send_rich_message_draft(
+    chat_id: Union[int, str],
+    draft_id: int,
+    html: Optional[str] = None,
+    markdown: Optional[str] = None,
+    is_rtl: bool = False,
+    skip_entity_detection: bool = False,
+    account: str = None,
+) -> str:
+    """Update the native Rich Message draft identified by ``draft_id``."""
+    try:
+        if draft_id < 0:
+            raise ValidationError("draft_id must be a non-negative integer.")
+        cl = get_client(account)
+        peer = await resolve_input_entity(chat_id, cl)
+        rich_message = _build_rich_message(html, markdown, is_rtl, skip_entity_detection)
+        await cl(
+            functions.messages.SetTypingRequest(
+                peer=peer,
+                action=types.InputSendMessageRichMessageDraftAction(
+                    rich_message=rich_message,
+                    random_id=draft_id,
+                ),
+            )
+        )
+        return "Rich message draft updated successfully."
+    except Exception as e:
+        return log_and_format_error("send_rich_message_draft", e, chat_id=chat_id)
 
 
 @mcp.tool(

--- a/tests/test_media_album.py
+++ b/tests/test_media_album.py
@@ -17,6 +17,36 @@ class _DummyClient:
 
 
 @pytest.mark.asyncio
+async def test_get_media_returns_native_image_content(monkeypatch):
+    class Client:
+        async def get_messages(self, entity, ids):
+            assert (entity, ids) == ("chat", 42)
+            return type(
+                "Message",
+                (),
+                {"media": object(), "photo": object(), "file": type("File", (), {"mime_type": None})()},
+            )()
+
+        async def download_media(self, message, output):
+            assert output is bytes
+            return b"image-bytes"
+
+    client = Client()
+    monkeypatch.setattr(media, "get_client", lambda account=None: client)
+
+    async def resolve(chat_id, cl):
+        assert (chat_id, cl) == (123, client)
+        return "chat"
+
+    monkeypatch.setattr(media, "resolve_entity", resolve)
+
+    result = await media.get_media(123, 42)
+
+    assert result.data == b"image-bytes"
+    assert result._format == "jpeg"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("tool_name", ["send_album", "send_file"])
 async def test_album_mode_sends_multiple_files_as_one_media_group(
     tmp_path, monkeypatch, tool_name

--- a/tests/test_rich_messages.py
+++ b/tests/test_rich_messages.py
@@ -1,0 +1,86 @@
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from telethon.tl import functions, types
+
+from telegram_mcp.tools import messages
+
+
+class _Client:
+    def __init__(self):
+        self.request = None
+
+    async def __call__(self, request):
+        self.request = request
+
+
+@pytest.mark.asyncio
+async def test_send_rich_message_uses_native_html_payload(monkeypatch):
+    client = _Client()
+    monkeypatch.setattr(messages, "get_client", lambda account=None: client)
+
+    async def resolve(chat_id, cl):
+        assert (chat_id, cl) == (123, client)
+        return "peer"
+
+    monkeypatch.setattr(messages, "resolve_input_entity", resolve)
+
+    result = await messages.send_rich_message(123, html="<h1>Hello</h1>")
+
+    assert result == "Rich message sent successfully."
+    assert isinstance(client.request, functions.messages.SendMessageRequest)
+    assert client.request.peer == "peer"
+    assert isinstance(client.request.rich_message, types.InputRichMessageHTML)
+    assert client.request.rich_message.html == "<h1>Hello</h1>"
+
+
+@pytest.mark.asyncio
+async def test_send_rich_message_draft_uses_native_draft_action(monkeypatch):
+    client = _Client()
+    monkeypatch.setattr(messages, "get_client", lambda account=None: client)
+
+    async def resolve(*args):
+        return "peer"
+
+    monkeypatch.setattr(messages, "resolve_input_entity", resolve)
+
+    result = await messages.send_rich_message_draft(123, 42, markdown="# Hello")
+
+    assert result == "Rich message draft updated successfully."
+    assert isinstance(client.request, functions.messages.SetTypingRequest)
+    assert isinstance(client.request.action, types.InputSendMessageRichMessageDraftAction)
+    assert client.request.action.random_id == 42
+    assert client.request.action.rich_message.markdown == "# Hello"
+
+
+def test_rich_message_is_exposed_in_message_results():
+    rich = types.RichMessage(blocks=[], photos=[], documents=[])
+    message = SimpleNamespace(
+        id=1,
+        sender=None,
+        date=datetime.now(timezone.utc),
+        sender_id=None,
+        out=False,
+        message="",
+        media=None,
+        grouped_id=None,
+        reply_to=None,
+        fwd_from=None,
+        via_bot_id=None,
+        edit_date=None,
+        pinned=False,
+        reactions=None,
+        replies=None,
+        buttons=None,
+        entities=None,
+        action=None,
+        ttl_period=None,
+        rich_message=rich,
+    )
+
+    record = messages.message_to_dict(message)
+
+    assert record["rich_message"]["_"] == "RichMessage"
+    assert json.dumps(record, default=str)


### PR DESCRIPTION
Closes #159

## What changed
- add native rich-message sending through Telethon's `InputRichMessageHTML` and `InputRichMessageMarkdown` payloads;
- add rich-message draft streaming;
- include received `rich_message` structures in message results;
- return `get_messages` as structured JSON rather than lossy display lines.

## Why
Telegram Rich Messages require a native `rich_message` payload. The existing MCP exposed only plain `send_message` calls and dropped the received rich structure.

## Validation
- `pytest -q` — 155 passed
- live send → read → delete round trip and streaming-draft check against Telegram.