### PR TITLE
Allowed Hosts Configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,14 @@ TELEGRAM_SESSION_NAME=telegram_session
 # server CLI roots in those cases. Default is deny-all.
 # TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK=1
 
+# --- HTTP/SSE transport security (optional) ---
+# Only relevant when MCP_TRANSPORT=http or sse. If the server is reachable via
+# a domain (e.g. behind a reverse proxy) rather than only 127.0.0.1/localhost,
+# set MCP_ALLOWED_HOSTS to enable DNS-rebinding protection and allow that Host
+# header. Comma-separated; supports a ":*" suffix to allow any port.
+# MCP_ALLOWED_HOSTS=mcp.example.com
+# MCP_ALLOWED_ORIGINS=https://mcp.example.com
+
 # --- Proxy (optional) ---
 # Route Telegram traffic through a proxy. Set TELEGRAM_PROXY_TYPE to enable.
 # Supported types: socks5, socks4, http, mtproxy.

--- a/README.md
+++ b/README.md
@@ -214,6 +214,13 @@ For `http` and `sse`, the server binds `MCP_HOST`:`MCP_PORT` (default
 `127.0.0.1:8765`); the streamable HTTP endpoint is `/mcp`, the SSE endpoint is
 `/sse`.
 
+If the server is reachable via a domain (e.g. behind a reverse proxy) rather
+than only `127.0.0.1`/`localhost`, set `MCP_ALLOWED_HOSTS` (and optionally
+`MCP_ALLOWED_ORIGINS`) to enable DNS-rebinding protection and allow that Host
+header, e.g. `MCP_ALLOWED_HOSTS=mcp.example.com`. Comma-separated; supports a
+`:*` suffix to allow any port. Left unset, DNS-rebinding protection stays off
+(the historical default).
+
 Prefer `http` when more than one MCP client (or many coding-agent sessions)
 will use the server: a single long-lived process holds one Telegram
 connection, instead of every client spawning its own Telethon session —

--- a/telegram_mcp/runner.py
+++ b/telegram_mcp/runner.py
@@ -55,6 +55,28 @@ async def _connect_authorized_client(label, client) -> None:
     )
 
 
+def _configure_transport_security() -> None:
+    """Wire MCP_ALLOWED_HOSTS/MCP_ALLOWED_ORIGINS into FastMCP's DNS-rebinding
+    protection, e.g. when the server sits behind a reverse proxy on a public
+    domain instead of only being reached via 127.0.0.1/localhost.
+    """
+    raw_hosts = os.getenv("MCP_ALLOWED_HOSTS", "")
+    allowed_hosts = [h.strip() for h in raw_hosts.split(",") if h.strip()]
+    if not allowed_hosts:
+        return
+
+    from mcp.server.transport_security import TransportSecuritySettings
+
+    raw_origins = os.getenv("MCP_ALLOWED_ORIGINS", "")
+    allowed_origins = [o.strip() for o in raw_origins.split(",") if o.strip()]
+
+    mcp.settings.transport_security = TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=allowed_hosts,
+        allowed_origins=allowed_origins,
+    )
+
+
 async def _serve(transport: str) -> None:
     """Run the MCP server on the selected transport.
 
@@ -68,6 +90,7 @@ async def _serve(transport: str) -> None:
     if transport in ("http", "sse"):
         mcp.settings.host = os.getenv("MCP_HOST", "127.0.0.1")
         mcp.settings.port = int(os.getenv("MCP_PORT", "8765"))
+        _configure_transport_security()
         if transport == "http":
             await mcp.run_streamable_http_async()
         else:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -44,6 +44,7 @@ class _FakeSettings:
     def __init__(self):
         self.host = None
         self.port = None
+        self.transport_security = None
 
 
 class _FakeMcp:
@@ -99,3 +100,30 @@ async def test_serve_http_uses_default_host_and_port(monkeypatch):
     assert fake.ran == "http"
     assert fake.settings.host == "127.0.0.1"
     assert fake.settings.port == 8765
+
+
+@pytest.mark.asyncio
+async def test_serve_http_leaves_transport_security_unset_by_default(monkeypatch):
+    fake = _FakeMcp()
+    monkeypatch.setattr(runner, "mcp", fake)
+    monkeypatch.delenv("MCP_ALLOWED_HOSTS", raising=False)
+    monkeypatch.delenv("MCP_ALLOWED_ORIGINS", raising=False)
+
+    await runner._serve("http")
+
+    assert fake.settings.transport_security is None
+
+
+@pytest.mark.asyncio
+async def test_serve_http_configures_allowed_hosts(monkeypatch):
+    fake = _FakeMcp()
+    monkeypatch.setattr(runner, "mcp", fake)
+    monkeypatch.setenv("MCP_ALLOWED_HOSTS", "mcp.example.com, localhost:8765")
+    monkeypatch.setenv("MCP_ALLOWED_ORIGINS", "https://mcp.example.com")
+
+    await runner._serve("http")
+
+    security = fake.settings.transport_security
+    assert security.enable_dns_rebinding_protection is True
+    assert security.allowed_hosts == ["mcp.example.com", "localhost:8765"]
+    assert security.allowed_origins == ["https://mcp.example.com"]


### PR DESCRIPTION
Hello. 

I am using the mcp for customer service analyses and automation. 

As I deployed the server on my VPS and put on Caddy over the exposed port, I received _Invalid Host header_ from the server. On further invesitagion, I realised that the current implementation on the **main** branch does not offer a way to allow custom hosts in case someone like me decides to host the MCP server for their team. 

This pull request offers a solution, adding the config to allow for allowed hosts customisation. 

My fork is up and running, the server works off my custom domain. Open to suggestions. 