### PR TITLE
feat(reactions): support custom emoji reactions

### DIFF
--- a/telegram_mcp/tools/messages.py
+++ b/telegram_mcp/tools/messages.py
@@ -1585,22 +1585,61 @@ async def send_reaction(
     Args:
         chat_id: The chat ID or username
         message_id: The message ID to react to
-        emoji: The emoji to react with (e.g., "👍", "❤️", "🔥", "😂", "😮", "😢", "🎉", "💩", "👎")
+        emoji: A normal emoji (e.g. "👍") or ``custom:<document_id>`` as
+            returned by get_message_reactions.
         big: Whether to show a big animation for the reaction (default: False)
     """
     try:
         cl = get_client(account)
-        from telethon.tl.types import ReactionEmoji
+        from telethon.tl.types import ReactionCustomEmoji, ReactionEmoji
+
+        # get_message_reactions exposes custom reactions in this stable form.
+        # Accepting the same representation here makes reactions round-trip
+        # without guessing a visually similar Unicode fallback.
+        if emoji.startswith("custom:"):
+            document_id = emoji.removeprefix("custom:")
+            if not document_id.isdigit() or int(document_id) <= 0:
+                raise ValueError("Custom reaction must use custom:<positive document id>.")
+            reaction = ReactionCustomEmoji(document_id=int(document_id))
+            # Telegram rejects some Premium custom reactions as "only emoji are
+            # allowed" unless the client also asks to add the selected custom
+            # emoji to its recent-reactions list. Official clients set this flag
+            # when a custom reaction is chosen from the picker.
+            add_to_recent = True
+        else:
+            reaction = ReactionEmoji(emoticon=emoji)
+            add_to_recent = None
 
         peer = await resolve_input_entity(chat_id, cl)
-        await cl(
-            functions.messages.SendReactionRequest(
-                peer=peer,
-                msg_id=message_id,
-                big=big,
-                reaction=[ReactionEmoji(emoticon=emoji)],
+        try:
+            await cl(
+                functions.messages.SendReactionRequest(
+                    peer=peer,
+                    msg_id=message_id,
+                    big=big,
+                    add_to_recent=add_to_recent,
+                    reaction=[reaction],
+                )
             )
-        )
+        except telethon.errors.rpcerrorlist.ReactionInvalidError as first_error:
+            # Telegram's private-chat API currently rejects some otherwise valid
+            # custom reactions when add_to_recent is present, even though the
+            # same account can select them in the official client. Retry the
+            # identical reaction without that optional picker-state flag.
+            if not isinstance(reaction, ReactionCustomEmoji):
+                raise
+            logger.info(
+                "Custom reaction with add_to_recent was rejected; retrying without it: %s",
+                first_error,
+            )
+            await cl(
+                functions.messages.SendReactionRequest(
+                    peer=peer,
+                    msg_id=message_id,
+                    big=big,
+                    reaction=[reaction],
+                )
+            )
         return f"Reaction '{emoji}' sent to message {message_id} in chat {chat_id}."
     except Exception as e:
         logger.exception(

--- a/tests/test_reactions.py
+++ b/tests/test_reactions.py
@@ -1,0 +1,105 @@
+import pytest
+from telethon.errors import ReactionInvalidError
+from telethon.tl.types import ReactionCustomEmoji, ReactionEmoji
+
+from telegram_mcp.tools import messages
+
+
+class _RecordingClient:
+    """Capture reaction requests without contacting Telegram."""
+
+    def __init__(self, errors=None):
+        self.errors = list(errors or [])
+        self.requests = []
+
+    async def __call__(self, request):
+        self.requests.append(request)
+        if self.errors:
+            raise self.errors.pop(0)
+
+
+@pytest.fixture
+def reaction_client(monkeypatch):
+    """Route the tool through a deterministic peer and fake Telegram client."""
+    client = _RecordingClient()
+    monkeypatch.setattr(messages, "get_client", lambda _account=None: client)
+
+    async def _resolve_input_entity(chat_id, resolved_client):
+        assert chat_id == 123
+        assert resolved_client is client
+        return "resolved-peer"
+
+    monkeypatch.setattr(messages, "resolve_input_entity", _resolve_input_entity)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_send_reaction_keeps_unicode_emoji_behavior(reaction_client):
+    """A standard Unicode reaction must remain a one-request operation."""
+    result = await messages.send_reaction(chat_id=123, message_id=456, emoji="👍")
+
+    assert "sent" in result
+    assert len(reaction_client.requests) == 1
+    request = reaction_client.requests[0]
+    assert request.peer == "resolved-peer"
+    assert request.msg_id == 456
+    assert request.add_to_recent is None
+    assert request.reaction == [ReactionEmoji(emoticon="👍")]
+
+
+@pytest.mark.asyncio
+async def test_send_reaction_accepts_round_trip_custom_document_id(reaction_client):
+    """The custom:<id> shape returned by reads must work unchanged on writes."""
+    result = await messages.send_reaction(
+        chat_id=123,
+        message_id=456,
+        emoji="custom:5206607081334906820",
+    )
+
+    assert "sent" in result
+    assert len(reaction_client.requests) == 1
+    request = reaction_client.requests[0]
+    assert request.add_to_recent is True
+    assert request.reaction == [ReactionCustomEmoji(document_id=5206607081334906820)]
+
+
+@pytest.mark.asyncio
+async def test_send_reaction_retries_custom_emoji_without_picker_state(monkeypatch):
+    """Private chats that reject add_to_recent should get one narrow retry."""
+    client = _RecordingClient(errors=[ReactionInvalidError(request=None)])
+    monkeypatch.setattr(messages, "get_client", lambda _account=None: client)
+
+    async def _resolve_input_entity(_chat_id, _client):
+        return "resolved-peer"
+
+    monkeypatch.setattr(messages, "resolve_input_entity", _resolve_input_entity)
+
+    result = await messages.send_reaction(
+        chat_id=123,
+        message_id=456,
+        emoji="custom:5206607081334906820",
+    )
+
+    assert "sent" in result
+    assert len(client.requests) == 2
+    assert client.requests[0].add_to_recent is True
+    assert client.requests[1].add_to_recent is None
+    assert client.requests[0].reaction == client.requests[1].reaction
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("emoji", ["custom:", "custom:abc", "custom:0", "custom:-1"])
+async def test_send_reaction_rejects_invalid_custom_document_id(
+    monkeypatch, reaction_client, emoji
+):
+    """Malformed custom identifiers must fail before resolving or sending."""
+
+    async def _unexpected_resolution(_chat_id, _client):
+        pytest.fail("invalid custom reactions must not resolve a Telegram peer")
+
+    monkeypatch.setattr(messages, "resolve_input_entity", _unexpected_resolution)
+
+    result = await messages.send_reaction(chat_id=123, message_id=456, emoji=emoji)
+
+    assert result.startswith("An error occurred")
+    assert reaction_client.requests == []

--- a/tests/test_reactions.py
+++ b/tests/test_reactions.py
@@ -5,6 +5,9 @@ from telethon.tl.types import ReactionCustomEmoji, ReactionEmoji
 from telegram_mcp.tools import messages
 
 
+CUSTOM_DOCUMENT_ID = 1234567890123456789
+
+
 class _RecordingClient:
     """Capture reaction requests without contacting Telegram."""
 
@@ -53,14 +56,14 @@ async def test_send_reaction_accepts_round_trip_custom_document_id(reaction_clie
     result = await messages.send_reaction(
         chat_id=123,
         message_id=456,
-        emoji="custom:5206607081334906820",
+        emoji=f"custom:{CUSTOM_DOCUMENT_ID}",
     )
 
     assert "sent" in result
     assert len(reaction_client.requests) == 1
     request = reaction_client.requests[0]
     assert request.add_to_recent is True
-    assert request.reaction == [ReactionCustomEmoji(document_id=5206607081334906820)]
+    assert request.reaction == [ReactionCustomEmoji(document_id=CUSTOM_DOCUMENT_ID)]
 
 
 @pytest.mark.asyncio
@@ -77,7 +80,7 @@ async def test_send_reaction_retries_custom_emoji_without_picker_state(monkeypat
     result = await messages.send_reaction(
         chat_id=123,
         message_id=456,
-        emoji="custom:5206607081334906820",
+        emoji=f"custom:{CUSTOM_DOCUMENT_ID}",
     )
 
     assert "sent" in result


### PR DESCRIPTION
## Problem

`get_message_reactions` already exposes custom reactions as
`custom:<document_id>`, but `send_reaction` always constructs
`ReactionEmoji`. Passing the value returned by the read API back into the write
API therefore cannot reproduce the custom reaction.

This breaks an otherwise useful read-modify-write flow for MCP clients: they can
identify a Telegram custom reaction, but cannot send the same reaction.

## Change

- Accept `custom:<positive document id>` in `send_reaction`.
- Build a Telethon `ReactionCustomEmoji` for that representation.
- Set `add_to_recent=True`, matching the behavior expected when a custom
  reaction is selected from Telegram's reaction picker.
- If Telegram rejects that optional picker-state flag with
  `REACTION_INVALID`, retry the same custom reaction once without the flag.
  This handles private-chat behavior without hiding errors for normal Unicode
  reactions.
- Preserve the existing Unicode emoji path unchanged.
- Reject malformed custom identifiers before resolving a peer or sending a
  request.

The input representation intentionally matches the existing
`get_message_reactions` output, so custom reactions now round-trip without a
new tool field or breaking schema change.

## Validation

- `uv run pytest tests/test_reactions.py -q` — 7 passed.
- `uv run pytest` — 170 passed.
- `uv run black --check telegram_mcp/tools/messages.py tests/test_reactions.py`
- `uv run flake8 telegram_mcp/tools/messages.py tests/test_reactions.py --count --select=E9,F63,F7,F82 --show-source --statistics`
- `git diff --check`

The regression coverage includes:

- unchanged Unicode reaction behavior;
- successful `custom:<document_id>` conversion;
- the narrow retry without `add_to_recent`;
- malformed and non-positive custom document IDs.
