### PR TITLE
fix(http): keep clients usable across server restarts

### DIFF
--- a/telegram_mcp/runtime.py
+++ b/telegram_mcp/runtime.py
@@ -110,7 +110,10 @@ load_dotenv()
 TELEGRAM_API_ID = int(os.getenv("TELEGRAM_API_ID"))
 TELEGRAM_API_HASH = os.getenv("TELEGRAM_API_HASH")
 
-mcp = FastMCP("telegram")
+# The shared HTTP service is consumed by several long-lived clients (Codex and Hermes).
+# Stateless requests keep those clients usable after a systemd restart instead of rejecting
+# their next call with "No valid session ID provided". Stdio transport remains unaffected.
+mcp = FastMCP("telegram", stateless_http=True)
 
 # Annotate all tool results with audience=["user"] so MCP clients know
 # the content is user-generated data, not instructions for the model.

--- a/telegram_mcp/runtime.py
+++ b/telegram_mcp/runtime.py
@@ -110,9 +110,9 @@ load_dotenv()
 TELEGRAM_API_ID = int(os.getenv("TELEGRAM_API_ID"))
 TELEGRAM_API_HASH = os.getenv("TELEGRAM_API_HASH")
 
-# The shared HTTP service is consumed by several long-lived clients (Codex and Hermes).
-# Stateless requests keep those clients usable after a systemd restart instead of rejecting
-# their next call with "No valid session ID provided". Stdio transport remains unaffected.
+# The shared HTTP service can be consumed by long-lived MCP clients. Stateless requests keep
+# those clients usable across server-process restarts instead of rejecting their next call
+# with "No valid session ID provided". Stdio transport remains unaffected.
 mcp = FastMCP("telegram", stateless_http=True)
 
 # Annotate all tool results with audience=["user"] so MCP clients know

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -43,6 +43,11 @@ def _synthetic_mcp():
     return server
 
 
+def test_shared_server_uses_stateless_http_transport():
+    """A service restart must not invalidate long-lived Codex or Hermes HTTP clients."""
+    assert runtime.mcp.settings.stateless_http is True
+
+
 def test_get_exposed_tools_mode_defaults_to_all(monkeypatch):
     monkeypatch.delenv("TELEGRAM_EXPOSED_TOOLS", raising=False)
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -44,7 +44,7 @@ def _synthetic_mcp():
 
 
 def test_shared_server_uses_stateless_http_transport():
-    """A service restart must not invalidate long-lived Codex or Hermes HTTP clients."""
+    """A service restart must not invalidate long-lived Streamable HTTP clients."""
     assert runtime.mcp.settings.stateless_http is True
 
 


### PR DESCRIPTION
## Problem

The shared Streamable HTTP server is intended for long-lived clients such as
Codex, Claude, and Cursor. With FastMCP's stateful HTTP sessions, those clients
retain an MCP session ID. After the Telegram MCP service restarts, the new
server process no longer knows that ID, so the client's next request can fail
with:

```text
No valid session ID provided
```

The Telegram connection may be healthy at that point; the failure is in the
HTTP transport session left behind by the previous process. Users then have to
re-register or restart otherwise healthy MCP clients.

## Change

Construct the shared `FastMCP` server with `stateless_http=True`.

Each Streamable HTTP request can then be handled after a process restart
without relying on an in-memory session created by the old process. Telegram
authentication and the long-lived Telethon client remain owned by the server
process as before.

This setting affects Streamable HTTP transport semantics only. The default
stdio flow remains unchanged.

## Validation

- Added a regression test asserting that the shared server is configured for
  stateless HTTP.
- `uv run pytest tests/test_runtime.py -q` — 45 passed.
- `uv run pytest` — 164 passed.
- `uv run black --check telegram_mcp/runtime.py tests/test_runtime.py`
- `uv run flake8 telegram_mcp/runtime.py tests/test_runtime.py --count --select=E9,F63,F7,F82 --show-source --statistics`
- `git diff --check`
- Restarted the shared HTTP service and verified both:
  - a fresh MCP connection could call `get_me`;
  - an already configured MCP client could call `get_me` after the restart.
