### PR TITLE
fix: prevent hanging media downloads when Roots requests stall

### DIFF
--- a/telegram_mcp/runtime.py
+++ b/telegram_mcp/runtime.py
@@ -1124,6 +1124,29 @@ def _server_roots_fallback_enabled(value: Optional[str] = None) -> bool:
     return _parse_bool_env(raw_value, False)
 
 
+def _roots_request_timeout_seconds(value: Optional[str] = None) -> float:
+    """Return the deadline for the MCP client's reverse ``roots/list`` call.
+
+    Some stateless HTTP clients advertise an MCP session but cannot answer
+    server-to-client Roots requests. Without a deadline every file-path tool
+    remains pending until the outer tool call is aborted. A short deadline lets
+    the existing opt-in server-root fallback handle those clients while still
+    preferring real client roots whenever they are available.
+    """
+    raw_value = (
+        os.getenv("TELEGRAM_ROOTS_REQUEST_TIMEOUT_SECONDS")
+        if value is None
+        else value
+    )
+    if raw_value is None:
+        return 1.0
+    try:
+        timeout = float(raw_value)
+    except ValueError:
+        return 1.0
+    return timeout if timeout > 0 else 1.0
+
+
 async def _get_effective_allowed_roots_with_status(
     ctx: Optional[Context],
 ) -> tuple[List[Path], str]:
@@ -1134,7 +1157,10 @@ async def _get_effective_allowed_roots_with_status(
         return [], ROOTS_STATUS_NOT_CONFIGURED
 
     try:
-        list_roots_result = await ctx.session.list_roots()
+        list_roots_result = await asyncio.wait_for(
+            ctx.session.list_roots(),
+            timeout=_roots_request_timeout_seconds(),
+        )
     except Exception as error:
         recovered_roots = _coerce_paths_from_list_roots_validation_error(error)
         if recovered_roots:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -765,6 +766,15 @@ def test_server_roots_fallback_enabled_parsing(monkeypatch):
     assert runtime._server_roots_fallback_enabled() is True
 
 
+def test_roots_request_timeout_parsing(monkeypatch):
+    """The reverse Roots request keeps a finite deadline even with bad config."""
+    monkeypatch.delenv("TELEGRAM_ROOTS_REQUEST_TIMEOUT_SECONDS", raising=False)
+    assert runtime._roots_request_timeout_seconds() == 1.0
+    assert runtime._roots_request_timeout_seconds("0.25") == 0.25
+    assert runtime._roots_request_timeout_seconds("0") == 1.0
+    assert runtime._roots_request_timeout_seconds("not-a-number") == 1.0
+
+
 @pytest.mark.asyncio
 async def test_empty_client_roots_denies_by_default(tmp_path, monkeypatch):
     root = tmp_path / "root"
@@ -814,6 +824,34 @@ class _FailingRootsSession:
 
 def _ctx_with_list_roots_error(error: Exception):
     return SimpleNamespace(session=_FailingRootsSession(error))
+
+
+class _HangingRootsSession:
+    async def list_roots(self):
+        """Model a stateless client that never answers server-to-client requests."""
+        await asyncio.Event().wait()
+
+
+@pytest.mark.asyncio
+async def test_hanging_list_roots_times_out_and_uses_opt_in_fallback(
+    tmp_path, monkeypatch
+):
+    """File tools must fail over quickly instead of hanging the whole MCP call."""
+    root = tmp_path / "root"
+    root.mkdir()
+    monkeypatch.setattr(runtime, "SERVER_ALLOWED_ROOTS", [root.resolve()])
+    monkeypatch.setenv("TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK", "1")
+    monkeypatch.setenv("TELEGRAM_ROOTS_REQUEST_TIMEOUT_SECONDS", "0.01")
+
+    roots, status = await asyncio.wait_for(
+        runtime._get_effective_allowed_roots_with_status(
+            SimpleNamespace(session=_HangingRootsSession())
+        ),
+        timeout=0.25,
+    )
+
+    assert roots == [root.resolve()]
+    assert status == runtime.ROOTS_STATUS_SERVER_FALLBACK
 
 
 def test_coerce_paths_from_list_roots_validation_error_recovers_bare_paths(tmp_path):


### PR DESCRIPTION
## Summary

Adds a finite timeout around the reverse MCP `roots/list` request used by file-path tools such as `download_media`.

## Root cause

Some stateless HTTP MCP clients advertise a session but do not implement server-to-client Roots requests. `ctx.session.list_roots()` could therefore wait indefinitely, leaving `download_media` pending until its outer request was aborted.

## Fix

- Wrap `list_roots()` in `asyncio.wait_for` with a one-second default timeout.
- Allow an opt-in `TELEGRAM_ROOTS_REQUEST_TIMEOUT_SECONDS` override; invalid or non-positive values safely retain the default.
- On timeout, retain the existing opt-in server-roots fallback behavior.

## Validation

- `uv run pytest tests/test_runtime.py -q` — 46 passed.
- Full local suite previously passed: 166 tests.
- Live JPG and DOCX media downloads completed successfully.

