### PR TITLE
fix(roots): recover Windows bare-path Roots reported as url_scheme

### DIFF
--- a/telegram_mcp/runtime.py
+++ b/telegram_mcp/runtime.py
@@ -1085,6 +1085,12 @@ def _coerce_paths_from_list_roots_validation_error(error: Exception) -> List[Pat
     paths instead of ``file://`` URIs. The MCP SDK then fails pydantic validation
     of ``ListRootsResult`` even though the roots themselves are usable. Extract
     those paths from the validation error payload so file-path tools keep working.
+
+    Which error pydantic reports depends on the path's shape. A POSIX path like
+    ``/home/dev/ws`` has no scheme at all and yields ``url_parsing``, but on a
+    Windows path like ``C:\\Users\\dev\\ws`` the drive letter parses as a scheme,
+    so pydantic gets far enough to reject it as ``url_scheme`` instead. Accept
+    both, or the Windows branch below is unreachable.
     """
     errors_fn = getattr(error, "errors", None)
     if not callable(errors_fn):
@@ -1099,7 +1105,7 @@ def _coerce_paths_from_list_roots_validation_error(error: Exception) -> List[Pat
     for item in details:
         if not isinstance(item, dict):
             continue
-        if item.get("type") != "url_parsing":
+        if item.get("type") not in ("url_parsing", "url_scheme"):
             continue
         value = item.get("input")
         if not isinstance(value, str):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -847,6 +847,28 @@ def test_coerce_paths_from_list_roots_validation_error_recovers_bare_paths(tmp_p
     assert root_b.resolve() in recovered
 
 
+def test_coerce_paths_from_list_roots_validation_error_recovers_windows_paths():
+    """A Windows drive letter is reported as url_scheme, not url_parsing.
+
+    ``C:\\Users\\dev\\workspace`` gets far enough through pydantic's URL parsing
+    for the drive letter to be taken as the scheme, so validation fails with
+    ``url_scheme``. The path is hardcoded rather than derived from ``tmp_path``
+    so this case is exercised on POSIX CI as well as on Windows.
+    """
+    from pydantic import ValidationError
+    from mcp.types import ListRootsResult
+
+    windows_root = r"C:\Users\dev\workspace"
+
+    with pytest.raises(ValidationError) as exc_info:
+        ListRootsResult.model_validate({"roots": [{"uri": windows_root}]})
+
+    assert any(item.get("type") == "url_scheme" for item in exc_info.value.errors())
+
+    recovered = runtime._coerce_paths_from_list_roots_validation_error(exc_info.value)
+    assert recovered == [Path(windows_root).expanduser().resolve()]
+
+
 @pytest.mark.asyncio
 async def test_list_roots_validation_error_recovers_client_paths(tmp_path, monkeypatch):
     from pydantic import ValidationError


### PR DESCRIPTION
## Problem

`_coerce_paths_from_list_roots_validation_error()` recovers workspace roots when a
client returns bare absolute paths instead of `file://` URIs. It filters the pydantic
errors down to `type == "url_parsing"`.

On Windows that filter never matches. A drive letter parses as a URL *scheme*, so
validation gets further along and fails as `url_scheme` instead:

```python
>>> from mcp.types import ListRootsResult
>>> ListRootsResult.model_validate({"roots": [{"uri": r"C:\Users\dev\workspace"}]})
ValidationError: 1 validation error for ListRootsResult
# type='url_scheme', input='C:\\Users\\dev\\workspace'
```

That makes the Windows half of the guard immediately below it unreachable -- the
`candidate[1] == ":"` check, whose own comment says *"Windows drive path like C:\\..."*.
A Windows client that returns bare paths (Cursor) therefore recovers nothing,
`_get_effective_allowed_roots_with_status()` reports `ROOTS_STATUS_ERROR`, and file-path
tools (`download_media`, `send_file`, ...) stay disabled by the deny-all fallback:

```
MCP roots request failed; disabling file-path tools for safety.
```

## Fix

Accept `url_scheme` alongside `url_parsing`. Inputs that merely *look* like URLs are
still rejected by the existing shape guard -- `http://example.com` also raises
`url_scheme`, but fails both `startswith("/")` and `candidate[1] == ":"`.

## Test

The new test hardcodes a Windows path rather than deriving one from `tmp_path`.
pydantic's URL parsing is platform-independent, so the `url_scheme` error reproduces on
Linux CI. The existing `tmp_path`-based test only produces this error shape when the
suite happens to run on Windows, which is why CI stayed green on the original change.

Without the fix it fails with `assert [] == [PosixPath('C:\\Users\\dev\\workspace')]`;
with it, it passes.

## Verification (Windows 11, Python 3.13)

- `pytest tests/test_runtime.py -k "roots or coerce"` -- 11 passed; 2 of those fail on
  unmodified `main`.
- Full suite: 5 failed before, 3 after. The 3 remaining also fail on unmodified `main`
  here and are unrelated to this change:
  - `test_install_guard.py::test_install_guard_accepts_file_install_from_project_root`
  - 2 x `test_session_pool.py`, which do a bare `import fcntl` at test scope with no
    `skipif` -- POSIX-only, so they cannot pass on Windows. (The production code in
    `_acquire_session()` guards this correctly with `if fcntl is None`, so it is only
    the tests.) Happy to send that as a separate PR if you'd like it fixed.
- `black --check .` clean; `flake8 --select=E9,F63,F7,F82` reports 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
