### PR TITLE
fix(groups): correct get_participants pagination

### DIFF
--- a/telegram_mcp/tools/groups.py
+++ b/telegram_mcp/tools/groups.py
@@ -243,12 +243,13 @@ async def get_participants(
         cl = get_client(account)
         await ensure_connected(cl)
 
-        # Use iter_participants with offset to fetch only the needed slice,
-        # avoiding O(N) fetching on later pages.
+        # iter_participants takes no `offset`, and its `limit` is not honoured
+        # for basic groups. Fetch through the page, then slice it out.
         offset = (page - 1) * page_size
         participants = []
-        async for participant in cl.iter_participants(chat_id, limit=page_size, offset=offset):
+        async for participant in cl.iter_participants(chat_id, limit=offset + page_size):
             participants.append(participant)
+        participants = participants[offset : offset + page_size]
 
         if not participants:
             return format_tool_result([])


### PR DESCRIPTION
Fixes #170.

`get_participants` pagination has two independent defects; this fixes both in `telegram_mcp/tools/groups.py`.

**1. `iter_participants` has no `offset` parameter.** Telethon's signature is `(entity, limit=None, *, search, filter, aggressive)` — no `offset`, in the [v1 source](https://github.com/LonamiWebs/Telethon/blob/v1/telethon/client/chats.py) or the [1.44.0 docs](https://docs.telethon.dev/en/stable/modules/client.html), and the project requires `telethon>=1.44.0`. Since `offset` is passed unconditionally, every call raises `TypeError`.

**2. `limit` does not bound basic groups.** In `telethon/requestiter.py`:

```python
if await self._init(**self.kwargs):
    self.left = len(self.buffer)
```

For `_EntityType.CHAT`, `_ParticipantsIter._init` buffers the whole participant list and returns `True`, so `left` is overwritten with the buffer length and the requested `limit` is discarded. Channels are unaffected — there `_init` returns falsy. So `limit` alone cannot bound a page.

**Fix.** Skip to the start of the requested page and stop once it is full, relying on neither `offset` nor `limit`. `limit` is still passed so channels do not over-fetch.

**Verification.** Against a live account on telethon 1.44.0:

- basic group, 6 members, `page_size=2` — pages 1/2/3 each return 2 non-overlapping participants in list order, page 4 returns empty
- supergroup, `page_size=3` — pages 1 and 2 each return 3, disjoint

Before the fix the same calls returned a formatted `TypeError`; with only defect 1 fixed, `page=1, page_size=1` on the basic group returned all 6 participants.

No behaviour change for `page=1, page_size=200` (the defaults) beyond it no longer erroring.