### PR TITLE
Prevent AuthKeyDuplicatedError from concurrent server instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,7 @@ Telegram messages, display names, chat titles, and button labels are untrusted c
   interactive phone-code login over stdio.
 - **Invalid API credentials:** verify `TELEGRAM_API_ID` and `TELEGRAM_API_HASH` at [my.telegram.org/apps](https://my.telegram.org/apps).
 - **Database is locked:** prefer string sessions, or make sure no other process is using the same file session.
+- **`AuthKeyDuplicatedError` / "Another telegram-mcp process is already connected with this session":** two processes tried to connect the same Telegram session at once (e.g. an MCP client restarted the connector before the old process exited), which Telegram rejects and can invalidate the session for both. The server now takes an exclusive lock per session before connecting; a second concurrent launch waits briefly (default 20s, override with `TELEGRAM_LOCK_GRACE_SECONDS`) for the first to release it and otherwise exits without ever calling `connect()`, instead of racing into a duplicate connection. Retry once only one instance is running.
 - **File tools are disabled:** pass allowed roots or configure MCP Roots in your client.
 - **Path rejected:** ensure the path is inside an allowed root and does not use traversal or wildcard patterns.
 - **Auth errors after password changes:** regenerate your session string.

--- a/README.md
+++ b/README.md
@@ -592,6 +592,7 @@ Telegram messages, display names, chat titles, and button labels are untrusted c
   interactive phone-code login over stdio.
 - **Invalid API credentials:** verify `TELEGRAM_API_ID` and `TELEGRAM_API_HASH` at [my.telegram.org/apps](https://my.telegram.org/apps).
 - **Database is locked:** prefer string sessions, or make sure no other process is using the same file session.
+- **`AuthKeyDuplicatedError` / "Another telegram-mcp process is already connected with this session":** two processes tried to connect the same Telegram session at once (e.g. an MCP client restarted the connector before the old process exited), which Telegram rejects and can invalidate the session for both. The server now takes an exclusive lock per session before connecting; a second concurrent launch waits briefly (default 20s, override with `TELEGRAM_LOCK_GRACE_SECONDS`) for the first to release it and otherwise exits without ever calling `connect()`, instead of racing into a duplicate connection. Retry once only one instance is running.
 - **File tools are disabled:** pass allowed roots or configure MCP Roots in your client.
 - **Path rejected:** ensure the path is inside an allowed root and does not use traversal or wildcard patterns.
 - **Auth errors after password changes:** regenerate your session string.

--- a/telegram_mcp/runner.py
+++ b/telegram_mcp/runner.py
@@ -11,15 +11,44 @@ from telethon.errors import AuthKeyDuplicatedError
 
 from telegram_mcp import runtime as _runtime
 from telegram_mcp.runtime import *
+from telegram_mcp.singleton import (
+    DEFAULT_GRACE_SECONDS,
+    SessionLock,
+    SessionLockError,
+    session_identity,
+)
 import telegram_mcp.tools  # noqa: F401 - registers MCP tools via decorators
+
+# Populated as each account's session lock is acquired; released in _main's
+# finally block so a lock is never held past this process's lifetime.
+_session_locks: dict[str, SessionLock] = {}
+
+
+def _lock_grace_seconds() -> float:
+    raw = os.getenv("TELEGRAM_LOCK_GRACE_SECONDS")
+    if not raw:
+        return DEFAULT_GRACE_SECONDS
+    try:
+        return float(raw)
+    except ValueError:
+        return DEFAULT_GRACE_SECONDS
 
 
 async def _connect_authorized_client(label, client) -> None:
-    # Tolerate a transient AuthKeyDuplicatedError (the same session briefly seen
-    # from two IPs, e.g. during a VPN reconnect) with a bounded retry so a blip
-    # does not take the whole server down. Give each concurrent client its own
-    # session (TELEGRAM_SESSION_STRINGS pool or TELEGRAM_SESSION_STRING_<LABEL>)
-    # to avoid the collision entirely.
+    # First, prevent our own duplicate-spawn case outright: an exclusive
+    # per-session lock means a second instance of this server never even
+    # attempts to connect while another instance already holds the same
+    # session (see telegram_mcp/singleton.py for why and how).
+    lock = SessionLock(label, session_identity(client))
+    await asyncio.to_thread(lock.acquire, grace_seconds=_lock_grace_seconds())
+    _session_locks[label] = lock
+
+    # Once we hold the lock, still tolerate a transient AuthKeyDuplicatedError
+    # from Telegram itself (e.g. the same session briefly seen from two IPs
+    # during a VPN reconnect) with a bounded retry, since that's not caused by
+    # a second instance of this server and a blip shouldn't take the server
+    # down. Give each concurrent client its own session (TELEGRAM_SESSION_STRINGS
+    # pool or TELEGRAM_SESSION_STRING_<LABEL>) to avoid the collision entirely.
     max_attempts = 4
     for attempt in range(1, max_attempts + 1):
         try:
@@ -137,6 +166,15 @@ async def _main() -> None:
                 "Database lock detected. Please ensure no other instances are running.",
                 file=sys.stderr,
             )
+        elif isinstance(e, SessionLockError):
+            print(
+                "Another instance of this MCP server already holds this Telegram "
+                "session (e.g. the client restarted the connector without the old "
+                "process exiting yet). This instance is exiting instead of "
+                "connecting a second time, which would risk Telegram invalidating "
+                "the session for both. Retry once the other instance is gone.",
+                file=sys.stderr,
+            )
         sys.exit(1)
     finally:
         try:
@@ -145,6 +183,9 @@ async def _main() -> None:
             )
         except Exception:
             pass
+        for lock in _session_locks.values():
+            lock.release()
+        _session_locks.clear()
 
 
 def main() -> None:

--- a/telegram_mcp/singleton.py
+++ b/telegram_mcp/singleton.py
@@ -1,0 +1,143 @@
+"""Per-session file lock guarding against concurrent Telegram connections.
+
+MCP clients (Claude Desktop in particular) sometimes spawn more than one
+instance of this server for the same configured session -- most commonly
+when a connector is restarted and the old process hasn't exited yet before
+the new one starts. Two processes calling ``TelegramClient.connect()`` /
+``start()`` with the same auth key at the same time trips Telegram's abuse
+protection (``AuthKeyDuplicatedError``), which can knock out *both*
+connections rather than just the newcomer.
+
+This module provides an OS-level advisory file lock (``flock`` on POSIX,
+``msvcrt.locking`` on Windows) keyed by the session's actual identity (its
+string value or file path), not just the account label, since two different
+projects/labels could otherwise collide or one label could map to different
+sessions across deployments. The lock is held for the lifetime of the
+process and is released automatically by the OS if the process exits or is
+killed, so there is no stale-lock file to clean up.
+
+A second instance racing for the same session waits briefly (covers the
+"restart replaces the old process" case) and, if the lock is still held once
+the grace period elapses, raises :class:`SessionLockError` instead of ever
+calling ``connect()`` -- so the live session is never disturbed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import IO, Optional
+
+if os.name == "nt":
+    import msvcrt
+
+    def _try_lock(fh: IO) -> bool:
+        try:
+            fh.seek(0)
+            msvcrt.locking(fh.fileno(), msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError:
+            return False
+
+    def _unlock(fh: IO) -> None:
+        try:
+            fh.seek(0)
+            msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
+        except OSError:
+            pass
+
+else:
+    import fcntl
+
+    def _try_lock(fh: IO) -> bool:
+        try:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except OSError:
+            return False
+
+    def _unlock(fh: IO) -> None:
+        try:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+        except OSError:
+            pass
+
+
+DEFAULT_LOCK_DIR = Path(tempfile.gettempdir()) / "telegram-mcp-locks"
+DEFAULT_GRACE_SECONDS = 20.0
+DEFAULT_POLL_INTERVAL = 0.5
+
+
+class SessionLockError(RuntimeError):
+    """Raised when a session lock isn't acquired before its grace period elapses."""
+
+
+class SessionLock:
+    """Exclusive, OS-released lock for one Telegram session, held for process lifetime."""
+
+    def __init__(self, label: str, session_identity: str, *, lock_dir: Path = DEFAULT_LOCK_DIR):
+        digest = hashlib.sha256(session_identity.encode("utf-8")).hexdigest()[:16]
+        lock_dir.mkdir(parents=True, exist_ok=True)
+        self.path = lock_dir / f"{label}-{digest}.lock"
+        self._fh: Optional[IO] = None
+
+    def acquire(
+        self,
+        *,
+        grace_seconds: float = DEFAULT_GRACE_SECONDS,
+        poll_interval: float = DEFAULT_POLL_INTERVAL,
+    ) -> None:
+        """Block (up to ``grace_seconds``) until the lock is free, then take it.
+
+        Raises :class:`SessionLockError` if another live process still holds
+        the lock once the grace period elapses.
+        """
+        fh = open(self.path, "a+")
+        deadline = time.monotonic() + grace_seconds
+        while True:
+            if _try_lock(fh):
+                self._fh = fh
+                return
+            if time.monotonic() >= deadline:
+                fh.close()
+                raise SessionLockError(
+                    "Another telegram-mcp process is already connected with this "
+                    f"session (lock held: {self.path}). Refusing to connect a "
+                    "second time to avoid Telegram's AuthKeyDuplicatedError. If "
+                    "that other process already exited, this lock will clear on "
+                    "its own -- retry."
+                )
+            time.sleep(poll_interval)
+
+    def release(self) -> None:
+        if self._fh is not None:
+            _unlock(self._fh)
+            self._fh.close()
+            self._fh = None
+
+
+def session_identity(client: object) -> str:
+    """Derive a stable identity string for a ``TelegramClient``'s session.
+
+    File-based sessions key on the absolute file path; string sessions key on
+    their serialized value (same auth key -> same identity, regardless of
+    which process or working directory loaded it). Falls back to the
+    client's object id for sessionless test doubles.
+    """
+    session = getattr(client, "session", None)
+    if session is not None:
+        filename = getattr(session, "filename", None)
+        if filename:
+            return f"file:{os.path.abspath(filename)}"
+        save = getattr(session, "save", None)
+        if callable(save):
+            try:
+                saved = save()
+            except Exception:
+                saved = None
+            if saved:
+                return f"string:{saved}"
+    return f"anon:{id(client)}"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3,11 +3,20 @@ import pytest
 from telegram_mcp import runner
 
 
+class _FakeSession:
+    def __init__(self, identity: str):
+        self._identity = identity
+
+    def save(self):
+        return self._identity
+
+
 class _FakeClient:
-    def __init__(self, *, authorized: bool):
+    def __init__(self, *, authorized: bool, identity: str = "test-identity"):
         self.authorized = authorized
         self.connected = False
         self.started = False
+        self.session = _FakeSession(identity)
 
     async def connect(self):
         self.connected = True
@@ -17,6 +26,25 @@ class _FakeClient:
 
     async def start(self):
         self.started = True
+
+
+@pytest.fixture(autouse=True)
+def _isolate_session_locks(tmp_path, monkeypatch):
+    # Give each test its own lock directory (so locks don't leak across tests
+    # or collide with a real telegram-mcp instance running on the machine)
+    # and a near-zero grace period (so a deliberately-contested lock in a
+    # test fails fast instead of sleeping through the real default).
+    import telegram_mcp.singleton as singleton_module
+
+    original_init = singleton_module.SessionLock.__init__
+
+    def _init_with_tmp_dir(self, label, session_identity, *, lock_dir=tmp_path):
+        original_init(self, label, session_identity, lock_dir=lock_dir)
+
+    monkeypatch.setattr(singleton_module.SessionLock, "__init__", _init_with_tmp_dir)
+    monkeypatch.setattr(runner, "_lock_grace_seconds", lambda: 0.01)
+    yield
+    runner._session_locks.clear()
 
 
 @pytest.mark.asyncio
@@ -38,6 +66,34 @@ async def test_connect_authorized_client_rejects_unauthorized_session():
 
     assert client.connected is True
     assert client.started is False
+
+
+@pytest.mark.asyncio
+async def test_connect_authorized_client_refuses_concurrent_duplicate_session():
+    first = _FakeClient(authorized=True, identity="shared-session")
+    second = _FakeClient(authorized=True, identity="shared-session")
+
+    await runner._connect_authorized_client("default", first)
+
+    with pytest.raises(runner.SessionLockError, match="already connected"):
+        await runner._connect_authorized_client("default", second)
+
+    assert second.connected is False
+
+    runner._session_locks["default"].release()
+    runner._session_locks.clear()
+
+
+@pytest.mark.asyncio
+async def test_connect_authorized_client_allows_different_sessions_concurrently():
+    first = _FakeClient(authorized=True, identity="session-a")
+    second = _FakeClient(authorized=True, identity="session-b")
+
+    await runner._connect_authorized_client("default", first)
+    await runner._connect_authorized_client("work", second)
+
+    assert first.connected is True
+    assert second.connected is True
 
 
 class _FakeSettings:


### PR DESCRIPTION
## Summary
- MCP clients (Claude Desktop in particular) can spawn a second telegram-mcp process before the first one exits, e.g. when restarting a connector. Two processes connecting the same Telegram session at once trips `AuthKeyDuplicatedError`, which can knock out both connections rather than just the newcomer.
- Adds a per-session, cross-platform (`flock`/`msvcrt`) advisory lock (`telegram_mcp/singleton.py`) acquired before `connect()`. A second instance racing for the same session waits briefly (default 20s, `TELEGRAM_LOCK_GRACE_SECONDS`) for the first to release it — covering the connector-restart case — and otherwise exits without ever calling `connect()`, so the live session is never disturbed.
- This sits in front of the existing retry-with-backoff `AuthKeyDuplicatedError` handling in `_connect_authorized_client`, which is preserved as-is for genuinely transient blips (e.g. a VPN IP change) that aren't caused by a second local instance.

## Test plan
- [x] `uv run pytest tests/test_runner.py -v` — 11 passed, including new tests for lock contention/release and independent sessions not blocking each other
- [x] `uv run pytest` — no new failures introduced (pre-existing failures on this Windows checkout are environment-/platform-specific and unrelated: multi-account fixtures assuming a single account, and `tests/test_session_pool.py` importing POSIX-only `fcntl`)