### PR TITLE
Expose reply_to on send_file/send_album so media can be posted into forum topics

### DIFF
--- a/telegram_mcp/tools/media.py
+++ b/telegram_mcp/tools/media.py
@@ -10,6 +10,7 @@ async def send_file(
     chat_id: Union[int, str],
     file_path: Union[str, List[str]],
     caption: str = None,
+    reply_to: Optional[int] = None,
     ctx: Optional[Context] = None,
     account: str = None,
 ) -> str:
@@ -19,7 +20,13 @@ async def send_file(
         chat_id: The chat ID or username.
         file_path: Absolute or relative path to the file under allowed roots.
             Pass a list of 2-10 paths to send them as one Telegram media group.
-        caption: Optional caption for the file or media group.
+        caption: Optional caption for the file or media group. Markdown is
+            parsed, so `[text](url)` becomes a real hyperlink.
+        reply_to: Optional message ID to reply to. In a forum supergroup, pass
+            the TOPIC ID here to post the media inside that topic — this is the
+            only way to place media in a topic, since Telegram addresses topics
+            through the reply/thread field. Without it the media lands in the
+            group's General topic regardless of which topic you meant.
     """
     try:
         if isinstance(file_path, list):
@@ -27,6 +34,7 @@ async def send_file(
                 chat_id=chat_id,
                 file_paths=file_path,
                 caption=caption,
+                reply_to=reply_to,
                 ctx=ctx,
                 account=account,
             )
@@ -40,11 +48,17 @@ async def send_file(
         if path_error:
             return path_error
         entity = await resolve_entity(chat_id, cl)
-        await cl.send_file(entity, str(safe_path), caption=caption)
-        return f"File sent to chat {chat_id} from {safe_path}."
+        await cl.send_file(entity, str(safe_path), caption=caption, reply_to=reply_to)
+        target = f"chat {chat_id}" if reply_to is None else f"chat {chat_id} (reply_to {reply_to})"
+        return f"File sent to {target} from {safe_path}."
     except Exception as e:
         return log_and_format_error(
-            "send_file", e, chat_id=chat_id, file_path=file_path, caption=caption
+            "send_file",
+            e,
+            chat_id=chat_id,
+            file_path=file_path,
+            caption=caption,
+            reply_to=reply_to,
         )
 
 
@@ -52,6 +66,7 @@ async def _send_album(
     chat_id: Union[int, str],
     file_paths: List[str],
     caption: str = None,
+    reply_to: Optional[int] = None,
     ctx: Optional[Context] = None,
     account: str = None,
 ) -> str:
@@ -71,8 +86,9 @@ async def _send_album(
         safe_paths.append(str(safe_path))
 
     entity = await resolve_entity(chat_id, cl)
-    await cl.send_file(entity, safe_paths, caption=caption)
-    return f"Album sent to chat {chat_id} with {len(safe_paths)} files."
+    await cl.send_file(entity, safe_paths, caption=caption, reply_to=reply_to)
+    target = f"chat {chat_id}" if reply_to is None else f"chat {chat_id} (reply_to {reply_to})"
+    return f"Album sent to {target} with {len(safe_paths)} files."
 
 
 @mcp.tool(
@@ -84,6 +100,7 @@ async def send_album(
     chat_id: Union[int, str],
     file_paths: List[str],
     caption: str = None,
+    reply_to: Optional[int] = None,
     ctx: Optional[Context] = None,
     account: str = None,
 ) -> str:
@@ -94,6 +111,9 @@ async def send_album(
         chat_id: The chat ID or username.
         file_paths: 2-10 absolute or relative file paths under allowed roots.
         caption: Optional caption for the album. Telegram displays it on the first item.
+        reply_to: Optional message ID to reply to. In a forum supergroup, pass the
+            TOPIC ID here to post the album inside that topic; without it the
+            album lands in the group's General topic.
     """
     try:
         if not isinstance(file_paths, list):
@@ -102,12 +122,18 @@ async def send_album(
             chat_id=chat_id,
             file_paths=file_paths,
             caption=caption,
+            reply_to=reply_to,
             ctx=ctx,
             account=account,
         )
     except Exception as e:
         return log_and_format_error(
-            "send_album", e, chat_id=chat_id, file_paths=file_paths, caption=caption
+            "send_album",
+            e,
+            chat_id=chat_id,
+            file_paths=file_paths,
+            caption=caption,
+            reply_to=reply_to,
         )
 
 

--- a/tests/test_media_album.py
+++ b/tests/test_media_album.py
@@ -8,11 +8,12 @@ class _DummyClient:
     def __init__(self):
         self.sent = None
 
-    async def send_file(self, entity, file_paths, caption=None):
+    async def send_file(self, entity, file_paths, caption=None, reply_to=None):
         self.sent = {
             "entity": entity,
             "file_paths": file_paths,
             "caption": caption,
+            "reply_to": reply_to,
         }
 
 
@@ -52,7 +53,82 @@ async def test_album_mode_sends_multiple_files_as_one_media_group(
         "entity": "entity:AgenticAIChat",
         "file_paths": [str(first), str(second)],
         "caption": "pick one",
+        "reply_to": None,
     }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool_name", ["send_album", "send_file"])
+async def test_album_forwards_reply_to_so_media_can_target_a_forum_topic(
+    tmp_path, monkeypatch, tool_name
+):
+    root = (tmp_path / "root").resolve()
+    root.mkdir()
+    (root / "one.png").write_bytes(b"png-one")
+    (root / "two.png").write_bytes(b"png-two")
+
+    client = _DummyClient()
+    monkeypatch.setattr(runtime, "SERVER_ALLOWED_ROOTS", [root])
+    monkeypatch.setattr(media, "clients", {"default": client})
+    monkeypatch.setattr(media, "get_client", lambda account=None: client)
+
+    async def _resolve_entity(chat_id, cl):
+        return "entity:forum"
+
+    monkeypatch.setattr(media, "resolve_entity", _resolve_entity)
+
+    tool = getattr(media, tool_name)
+    result = await tool(-100123, ["one.png", "two.png"], reply_to=458)
+
+    # Telegram addresses forum topics through the reply/thread field, so the id
+    # has to reach Telethon or the album silently lands in General instead.
+    assert client.sent["reply_to"] == 458
+    assert result == "Album sent to chat -100123 (reply_to 458) with 2 files."
+
+
+@pytest.mark.asyncio
+async def test_send_file_forwards_reply_to_for_a_single_file(tmp_path, monkeypatch):
+    root = (tmp_path / "root").resolve()
+    root.mkdir()
+    (root / "one.png").write_bytes(b"png-one")
+
+    client = _DummyClient()
+    monkeypatch.setattr(runtime, "SERVER_ALLOWED_ROOTS", [root])
+    monkeypatch.setattr(media, "clients", {"default": client})
+    monkeypatch.setattr(media, "get_client", lambda account=None: client)
+
+    async def _resolve_entity(chat_id, cl):
+        return "entity:forum"
+
+    monkeypatch.setattr(media, "resolve_entity", _resolve_entity)
+
+    result = await media.send_file(-100123, "one.png", caption="cover", reply_to=458)
+
+    assert client.sent["reply_to"] == 458
+    assert client.sent["file_paths"] == str(root / "one.png")
+    assert result == f"File sent to chat -100123 (reply_to 458) from {root / 'one.png'}."
+
+
+@pytest.mark.asyncio
+async def test_send_file_without_reply_to_keeps_the_original_message(tmp_path, monkeypatch):
+    root = (tmp_path / "root").resolve()
+    root.mkdir()
+    (root / "one.png").write_bytes(b"png-one")
+
+    client = _DummyClient()
+    monkeypatch.setattr(runtime, "SERVER_ALLOWED_ROOTS", [root])
+    monkeypatch.setattr(media, "clients", {"default": client})
+    monkeypatch.setattr(media, "get_client", lambda account=None: client)
+
+    async def _resolve_entity(chat_id, cl):
+        return "entity:chat"
+
+    monkeypatch.setattr(media, "resolve_entity", _resolve_entity)
+
+    result = await media.send_file("AgenticAIChat", "one.png")
+
+    assert client.sent["reply_to"] is None
+    assert result == f"File sent to chat AgenticAIChat from {root / 'one.png'}."
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Media cannot be placed inside a forum topic. `send_message` and `reply_to_message` can target a topic, but every media tool sends to the chat as a whole, so photos and documents always land in **General** no matter which topic was intended.

The cause is not Telegram or Telethon — `TelegramClient.send_file` already accepts `reply_to`, and Telegram addresses forum topics through the reply/thread field. The wrapper simply never passed the argument through, so there was no way to reach a topic from an MCP client.

Reproducing it before the change: create a topic, note its id, send a photo — the photo appears in General, and `get_history` shows no `reply_to` on it, while a text message sent to the same topic shows `reply_to: <topic id>`.

## Change

`send_file` and `send_album` take an optional `reply_to: Optional[int] = None` and forward it to Telethon. `_send_album` threads it through as well, so the album path behaves the same as the single-file path.

Two smaller things that come with it:

- The docstrings state explicitly that the topic id goes in this field, since "reply to a message" does not obviously imply "post into a topic".
- The success string echoes `reply_to` when it is set, so a mis-targeted send is visible in the tool result instead of silently going to General.

The parameter defaults to `None`, and with it omitted the call and the returned message are byte-for-byte what they were before.

## Tests

`_DummyClient.send_file` in `tests/test_media_album.py` did not accept `reply_to`, so forwarding the argument broke the two existing album tests with a `TypeError`. The stub is widened and now asserts the field, plus new cases:

- `reply_to` reaches the client for a single file and for an album
- the success string includes it
- omitting it leaves the previous behaviour and message unchanged

```
120 passed
```

`black --check` and the blocking `flake8` selection from CI both pass on the touched files.

## Verified against a live forum

Sent 20 photos with captions into a real topic. Every message came back with `reply_to: <topic id>` in `get_history`, and captions kept markdown link parsing, so `[text](url)` still renders as a hyperlink.