### PR TITLE
fix: create_poll and get_full_chat on basic groups

### DIFF
--- a/telegram_mcp/tools/chats.py
+++ b/telegram_mcp/tools/chats.py
@@ -735,17 +735,35 @@ async def get_full_chat(chat_id: Union[int, str], account: str = None) -> str:
         cl = get_client(account)
         await ensure_connected(cl)
         entity = await resolve_entity(chat_id, cl)
-        full = await cl(functions.channels.GetFullChannelRequest(channel=entity))
+
+        # Basic ("legacy") groups are not channels: GetFullChannelRequest cannot
+        # cast an InputPeerChat and raises TypeError. They are served by
+        # messages.GetFullChatRequest instead.
+        if isinstance(entity, (Chat, InputPeerChat)):
+            basic_id = getattr(entity, "chat_id", None) or getattr(entity, "id", None)
+            full = await cl(functions.messages.GetFullChatRequest(chat_id=basic_id))
+        else:
+            full = await cl(functions.channels.GetFullChannelRequest(channel=entity))
 
         chat = full.chats[0] if full.chats else None
         full_chat = full.full_chat
+
+        # Channels carry participants_count on the full object; basic groups only
+        # carry the member list, so count that instead.
+        participants_count = getattr(full_chat, "participants_count", None)
+        if participants_count is None:
+            members = getattr(getattr(full_chat, "participants", None), "participants", None)
+            if members is not None:
+                participants_count = len(members)
 
         result = {
             "id": get_marked_id(chat) if chat else None,
             "title": sanitize_name(getattr(chat, "title", None)) if chat else None,
             "username": getattr(chat, "username", None) if chat else None,
-            "about": sanitize_user_content(full_chat.about or "", max_length=1024),
-            "participants_count": getattr(full_chat, "participants_count", None),
+            "about": sanitize_user_content(
+                getattr(full_chat, "about", None) or "", max_length=1024
+            ),
+            "participants_count": participants_count,
             "linked_chat_id": getattr(full_chat, "linked_chat_id", None),
         }
 

--- a/telegram_mcp/tools/messages.py
+++ b/telegram_mcp/tools/messages.py
@@ -1542,6 +1542,9 @@ async def create_poll(
                 PollAnswer(text=TextWithEntities(text=option, entities=[]), option=bytes([i]))
                 for i, option in enumerate(options)
             ],
+            # Telethon 1.44 made `hash` a required argument on Poll. It caches
+            # server-side results, so a poll being created sends 0.
+            hash=0,
             multiple_choice=multiple_choice,
             quiz=quiz_mode,
             public_voters=public_votes,


### PR DESCRIPTION
Two tools still fail after the telethon 1.44 bump (#148). Both are reproducible on `main` (89d6bad) against a live account.

### 1. `create_poll` is broken for every call

```
TypeError: Poll.__init__() missing 1 required positional argument: 'hash'
```

Telethon 1.44 added a required `hash` to `Poll`. It caches server-side poll results, so a poll being created sends `0`.

### 2. `get_full_chat` fails on basic (non-supergroup) groups

```
TypeError: Cannot cast InputPeerChat to any kind of InputChannel.
```

The tool always issued `channels.GetFullChannelRequest`, which cannot accept a basic group. Basic groups are routed to `messages.GetFullChatRequest` instead. `ChatFull` carries no `participants_count`, so it is derived from the member list. Channels and supergroups take the same path as before.

### Verification

Against a real account, on this branch:

| Case | Result |
|---|---|
| `get_full_chat` basic group | `{"title": "Salo", "participants_count": 3}` (was `TypeError`) |
| `get_full_chat` channel (`durov`) | unchanged, still returns about/participants_count |
| `create_poll` | poll posts successfully (was `TypeError`) |

`pytest` 175 passed; `black --check` clean.

Note: `get_participants` hit the same class of breakage and is already fixed on main by #171, so it is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)