### PR TITLE
fix: exit on stdin EOF instead of leaking an orphaned process

### DIFF
--- a/telegram_mcp/runner.py
+++ b/telegram_mcp/runner.py
@@ -73,7 +73,11 @@ async def _main() -> None:
 def main() -> None:
     _configure_allowed_roots_from_cli(sys.argv[1:])
     _runtime._apply_exposed_tools_mode()
-    nest_asyncio.apply()
+    # Do NOT call nest_asyncio.apply() here. Patching the loop stops
+    # mcp.run_stdio_async() from returning when stdin reaches EOF, so the
+    # server outlives the MCP client that spawned it and is reparented to
+    # init — every closed client session then leaks a server process that
+    # nothing reaps. Nothing in this package needs re-entrant loops.
     asyncio.run(_main())
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -38,3 +38,33 @@ async def test_connect_authorized_client_rejects_unauthorized_session():
 
     assert client.connected is True
     assert client.started is False
+
+
+def test_main_does_not_patch_the_event_loop(monkeypatch):
+    """nest_asyncio.apply() must not be re-introduced into main().
+
+    Patching the loop stops mcp.run_stdio_async() from returning when stdin
+    reaches EOF, so the server outlives the MCP client that spawned it and is
+    reparented to init. Every closed client session then leaks a server that
+    nothing ever reaps.
+    """
+    applied = []
+    monkeypatch.setattr(runner.nest_asyncio, "apply", lambda *a, **k: applied.append(1))
+
+    ran = []
+
+    def _fake_run(coro):
+        coro.close()  # we are asserting on wiring, not executing the server
+        ran.append(1)
+
+    monkeypatch.setattr(runner.asyncio, "run", _fake_run)
+    monkeypatch.setattr(runner, "_configure_allowed_roots_from_cli", lambda *a, **k: None)
+    monkeypatch.setattr(runner._runtime, "_apply_exposed_tools_mode", lambda *a, **k: None)
+
+    runner.main()
+
+    assert ran == [1], "main() should still drive the server through asyncio.run"
+    assert applied == [], (
+        "main() called nest_asyncio.apply(); this breaks stdin-EOF shutdown "
+        "and leaks an orphaned server process per client session"
+    )


### PR DESCRIPTION
## The problem

`main()` calls `nest_asyncio.apply()` before `asyncio.run()`. Patching the event loop stops `mcp.run_stdio_async()` from returning when stdin reaches EOF, so the server **outlives the MCP client that spawned it** and is reparented to init. Every closed client session leaks a server process that nothing ever reaps.

I found this while tracking down sustained memory pressure on a 32GB machine: **57 orphaned `telegram-mcp` instances** (114 processes counting the `uv` wrappers) had accumulated over a single day, holding **6.5GB of RAM**. Their parents were long dead — all had been reparented to `systemd --user`. They had to be killed by hand.

They spawn steadily through the day and never leave:

```
10:00  16    14:00  14
11:00   4    15:00  28
12:00   6    16:00  22
13:00   4    17:00  22
```

## Reproduction

A minimal FastMCP server driven over a socketpair, mirroring `runner.py`'s structure, toggling only this one call:

| | result on stdin EOF |
|---|---|
| without `nest_asyncio.apply()` | **exits after 1s** |
| with `nest_asyncio.apply()` | **still alive after 10s** |

Confirmed against the real `runner.main()` too (with `clients` emptied so no Telegram connection is made): it now exits 1s after its stdin closes.

## The fix

Remove the call. `nest_asyncio` isn't needed here — there is no nested `run_until_complete` anywhere in the package, and the server already runs under a single `asyncio.run()`. The import stays because `runtime.py` re-exports it.

## Test plan

Adds `test_main_does_not_patch_the_event_loop` to `tests/test_runner.py`, pinning the invariant. Verified it actually guards the regression:

- with the fix → `3 passed`
- with `nest_asyncio.apply()` put back → `1 failed, 2 passed`

Full suite is unchanged at `122 passed`. There are 9 pre-existing failures in `test_forum_topics.py` / `test_media_album.py` on `main` — identical before and after this change, so they're untouched by it.