### PR TITLE
fix(deps): pin mcp to <2 so Docker and pip installs keep working

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ requires-python = ">=3.10"
 dependencies = [
     "dotenv>=0.9.9",
     "httpx>=0.28.1",
-    "mcp[cli]>=1.8.0",
+    "mcp[cli]>=1.8.0,<2",
     "python-dotenv>=1.1.0",
     "python-json-logger>=3.3.0",
     "qrcode>=8.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 dotenv>=0.9.9
 httpx>=0.28.1
-mcp[cli]>=1.8.0
+mcp[cli]>=1.8.0,<2
 python-dotenv>=1.1.0
 python-json-logger>=3.3.0
 qrcode>=8.2

--- a/uv.lock
+++ b/uv.lock
@@ -1346,7 +1346,7 @@ dev = [
 requires-dist = [
     { name = "dotenv", specifier = ">=0.9.9" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.8.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.8.0,<2" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "python-json-logger", specifier = ">=3.3.0" },
     { name = "python-socks", marker = "extra == 'proxy'", specifier = ">=2.4.3" },


### PR DESCRIPTION
### Problem

`mcp 2.0.0`, released on 2026-07-28, removed the `mcp.server.fastmcp` module that `telegram_mcp/runtime.py:21` imports. Because the dependency was declared as `mcp[cli]>=1.8.0` with no upper bound, every install path that resolves freely started pulling 2.0.0 from that date on and dies at import — from unchanged source that built fine days earlier:

```
File "/app/telegram_mcp/runtime.py", line 21, in <module>
    from mcp.server.fastmcp import FastMCP, Context
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

That breaks `docker compose up`, `pip install -r requirements.txt` and `pip install -e .`. CI stayed green because `tests.yml` resolves from `uv.lock` (pinned at 1.22.0), and the Docker job only builds the image without ever starting it.

Fixes #184

### Change

Constrain the requirement to the 1.x line in `requirements.txt` and `pyproject.toml`, and refresh `uv.lock`. Three one-line changes; no source changes.

### Verification

- Rebuilt the image with the pin: resolves mcp **1.29.0** — the latest 1.x, published the same day as 2.0.0, not the old locked 1.22.0. Container starts and serves streamable HTTP on 8765, and a `POST /mcp` `initialize` call returns 200.
- `uv lock` produced a single-line diff (the recorded specifier only) — no version churn for existing `uv` users.
- `uv run pytest` in a clean checkout: **266 passed** on this branch, identical to unmodified `main`.

### Notes

This is a stopgap that unblocks Docker users now; adopting the mcp 2.x server API is a separate piece of work. A CI step that runs the built image (e.g. `docker run --rm --entrypoint python <image> -c "import main"`) would catch this class of regression — happy to add it here or in a follow-up if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
