### PR TITLE
fix: bound reconnect and fail fast when the session pool is exhausted

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,11 @@ Generate extra sessions with `uv run session_string_generator.py`. The pool
 takes precedence over `TELEGRAM_SESSION_STRING` for the default account. As an
 extra safety net, a transient `AuthKeyDuplicatedError` at connect time (e.g.
 during a VPN reconnect) is retried with backoff before the server gives up.
+
+Size the pool to the number of clients you actually run concurrently. If every
+slot is already claimed, the server refuses to start with an explicit error
+rather than reusing a session another client holds — reuse would make Telegram
+permanently invalidate that session for both clients.
 - "Send this from my work account to @example"
 
 ## Device Identity

--- a/telegram_mcp/runtime.py
+++ b/telegram_mcp/runtime.py
@@ -20,6 +20,7 @@ from mcp.types import Annotations, TextContent, ToolAnnotations
 from mcp.shared.exceptions import McpError
 from pythonjsonlogger import jsonlogger
 from telethon import TelegramClient, functions, types, utils
+from telethon.errors import AuthKeyDuplicatedError
 from telethon.sessions import StringSession
 from telethon.tl.types import (
     User,
@@ -393,13 +394,16 @@ def _acquire_session(pool: List[str]) -> str:
             pass
         print(f"Using Telegram session slot {idx + 1}/{len(pool)}.", file=sys.stderr)
         return session
-    print(
-        f"WARNING: all {len(pool)} pooled Telegram session(s) are already in use "
-        "by other clients; reusing the first (may raise AuthKeyDuplicatedError). "
-        "Add another session to TELEGRAM_SESSION_STRINGS to run more clients.",
-        file=sys.stderr,
+    # Handing out an already-claimed session here would make Telegram burn it
+    # with AuthKeyDuplicatedError — losing the slot for the client that owns it
+    # too. Refusing to start is recoverable; a burned session is not.
+    raise RuntimeError(
+        f"All {len(pool)} pooled Telegram session(s) are already claimed by other "
+        "live clients, so this one has no session to use. Add another session to "
+        "TELEGRAM_SESSION_STRINGS (generate it with "
+        "`uv run session_string_generator.py`) — one slot per concurrent client — "
+        "or stop one of the other clients."
     )
-    return pool[0]
 
 
 def _discover_accounts() -> dict[str, TelegramClient]:
@@ -521,6 +525,7 @@ def with_account(readonly=False):
 
 _last_conn_verified: dict[int, float] = {}
 _CONN_VERIFY_INTERVAL: float = 30.0  # seconds between live pings
+_RECONNECT_TIMEOUT: float = 30.0  # seconds before a reconnect attempt is abandoned
 
 
 async def _force_reconnect(cl: TelegramClient):
@@ -531,10 +536,26 @@ async def _force_reconnect(cl: TelegramClient):
         await cl.disconnect()
     except Exception:
         pass
-    await cl.connect()
+    try:
+        await asyncio.wait_for(cl.connect(), timeout=_RECONNECT_TIMEOUT)
+    except AuthKeyDuplicatedError as exc:
+        # Telegram permanently invalidates an auth key used from two IPs at
+        # once, so retrying here can never succeed — surface it instead of
+        # letting the caller sit in a reconnect loop.
+        raise RuntimeError(
+            "Telegram session is no longer usable: the same session string was "
+            "used by another client at the same time (AuthKeyDuplicatedError). "
+            "Give each concurrent client its own session via "
+            "TELEGRAM_SESSION_STRINGS or TELEGRAM_SESSION_STRING_<LABEL>, then "
+            "regenerate the burned session with `uv run session_string_generator.py`."
+        ) from exc
+    except asyncio.TimeoutError as exc:
+        raise RuntimeError(
+            f"Reconnecting to Telegram timed out after {_RECONNECT_TIMEOUT:.0f}s."
+        ) from exc
     if not await cl.is_user_authorized():
         reconnect_logger.warning("Client not authorized after reconnect, calling start()...")
-        await cl.start()
+        await asyncio.wait_for(cl.start(), timeout=_RECONNECT_TIMEOUT)
     _last_conn_verified[id(cl)] = time.time()
     reconnect_logger.warning("Forced reconnect successful")
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -428,6 +429,37 @@ async def test_ensure_connected_skips_recently_verified_client(monkeypatch):
     await runtime.ensure_connected(client)
 
     assert client.calls == ["is_connected"]
+
+
+class _HangingConnectClient(_ConnectivityClient):
+    async def connect(self):
+        self.calls.append("connect")
+        await asyncio.sleep(3600)
+
+
+class _DuplicatedKeyClient(_ConnectivityClient):
+    async def connect(self):
+        from telethon.errors import AuthKeyDuplicatedError
+
+        self.calls.append("connect")
+        raise AuthKeyDuplicatedError(request=None)
+
+
+@pytest.mark.asyncio
+async def test_force_reconnect_times_out_instead_of_hanging(monkeypatch):
+    client = _HangingConnectClient(connected=False, authorized=True)
+    monkeypatch.setattr(runtime, "_RECONNECT_TIMEOUT", 0.01)
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        await runtime._force_reconnect(client)
+
+
+@pytest.mark.asyncio
+async def test_force_reconnect_reports_burned_session(monkeypatch):
+    client = _DuplicatedKeyClient(connected=False, authorized=True)
+
+    with pytest.raises(RuntimeError, match="no longer usable"):
+        await runtime._force_reconnect(client)
 
 
 class _ResolvingClient:

--- a/tests/test_session_pool.py
+++ b/tests/test_session_pool.py
@@ -52,11 +52,13 @@ def test_acquire_session_skips_slot_locked_by_another_client(isolated_lock_dir):
         foreign.close()
 
 
-def test_acquire_session_falls_back_to_first_when_pool_exhausted(isolated_lock_dir):
+def test_acquire_session_raises_when_pool_exhausted(isolated_lock_dir):
     held = [_lock_slot(isolated_lock_dir, s) for s in ("AAA", "BBB")]
     try:
-        # Only two slots exist and both are taken -> reuse the first.
-        assert runtime._acquire_session(["AAA", "BBB"]) == "AAA"
+        # Only two slots exist and both are taken -> refuse rather than hand out
+        # a session another live client is already using.
+        with pytest.raises(RuntimeError, match="already claimed"):
+            runtime._acquire_session(["AAA", "BBB"])
     finally:
         for fh in held:
             fh.close()


### PR DESCRIPTION
When more MCP clients run than `TELEGRAM_SESSION_STRINGS` has slots for, every tool call hangs forever instead of failing. Two separate issues combine to produce that.

### 1. Exhausted pool silently hands out an in-use session

`_acquire_session` treats an exhausted pool as a warning and returns `pool[0]` — a session another live client already holds the lock on:

```python
print(f"WARNING: all {len(pool)} pooled Telegram session(s) are already in use ...")
return pool[0]
```

Telegram responds to one auth key being used from two IPs by **permanently invalidating it**. So the fallback not only fails for the new client, it burns the slot for the client that legitimately owned it. The warning goes to stderr, which MCP clients generally do not surface, so this is invisible until everything stops working.

This PR raises a `RuntimeError` with an actionable message instead. Refusing to start is recoverable; a burned session is not.

### 2. `_force_reconnect` has no timeout

`ensure_connected` wraps only the liveness ping in a 5s `wait_for`:

```python
await asyncio.wait_for(cl(functions.help.GetNearestDcRequest()), timeout=5.0)
```

The reconnect it falls back to does not:

```python
await cl.connect()   # no timeout, no AuthKeyDuplicatedError handling
```

With an invalidated auth key, `connect()` retries internally and never returns — the tool call hangs indefinitely. `runner._connect_authorized_client` already handles this properly at startup (bounded retry, then raise), but the per-tool-call path in `runtime.py` does not.

This PR bounds the reconnect with `_RECONNECT_TIMEOUT` (30s) and surfaces `AuthKeyDuplicatedError` immediately rather than retrying it — that error is permanent, so a retry loop cannot recover from it.

### How this showed up

Six concurrent clients (two editors plus several CLI sessions) against a 2-slot pool. Both slots were flock-held by long-lived processes; every other process took the `pool[0]` fallback and then hung. Observed as ~30 minute timeouts on every call, including `get_me`, with `mcp_errors.log` full of `AuthKeyDuplicatedError`.

### Changes

- `_acquire_session` raises instead of returning an already-claimed session.
- `_force_reconnect` bounds `connect()`/`start()` and maps `AuthKeyDuplicatedError` to a clear error.
- Tests for both new paths; updated the test that asserted the old fallback.
- README note on sizing the pool to the number of concurrent clients.

`uv run pytest` — 177 passed. `black --check` and the configured `flake8` selection are clean.