### PR TITLE
fix: report MTProto schema drift instead of a generic error code

### DIFF
--- a/telegram_mcp/runtime.py
+++ b/telegram_mcp/runtime.py
@@ -732,7 +732,29 @@ def log_and_format_error(
     if user_message:
         return user_message
 
+    # MTProto schema drift must not hide behind the generic code. Telethon releases lag
+    # behind production Telegram, and when the server sends an object whose constructor
+    # the installed schema does not know, the read buffer desynchronises: some tools fail
+    # while their neighbours keep working. Reported as a generic error, that pattern is
+    # indistinguishable from "no such user/chat" and sends debugging the wrong way.
+    if _is_schema_drift(error):
+        return (
+            f"MTProto schema mismatch: the installed Telethon does not know an object the "
+            f"server sent ({error}). This is NOT a missing user or chat — the data arrived, "
+            f"parsing it failed. Upgrade Telethon; if it is already the latest release, its "
+            f"schema is behind the current layer (code: {error_code})."
+        )
+
     return f"An error occurred (code: {error_code}). Check mcp_errors.log for details."
+
+
+def _is_schema_drift(error: Exception) -> bool:
+    """True for TypeNotFoundError — the installed TL schema is older than what the server sends."""
+    try:
+        from telethon.errors.common import TypeNotFoundError
+    except Exception:  # telethon missing or moved — not this helper's problem
+        return False
+    return isinstance(error, TypeNotFoundError)
 
 
 def validate_id(*param_names_to_validate):

--- a/tests/test_schema_drift.py
+++ b/tests/test_schema_drift.py
@@ -1,0 +1,21 @@
+"""Schema drift must be reported as such, not as a generic error code.
+
+A `TypeNotFoundError` means the installed TL schema is older than what the server
+sends. Hidden behind the generic message, it reads like "no such user/chat" and
+costs hours of debugging in the wrong direction.
+"""
+
+from telegram_mcp.runtime import log_and_format_error
+from telethon.errors.common import TypeNotFoundError
+
+
+def test_schema_drift_is_named_and_actionable():
+    msg = log_and_format_error("list_chats", TypeNotFoundError(0xD58A08C6, b"\x00"))
+    assert "MTProto schema mismatch" in msg
+    assert "NOT a missing user or chat" in msg
+
+
+def test_ordinary_error_keeps_the_generic_format():
+    msg = log_and_format_error("get_chat", ValueError("boom"))
+    assert "code:" in msg
+    assert "MTProto schema mismatch" not in msg


### PR DESCRIPTION
## Problem

When Telegram sends an object whose constructor the installed Telethon schema does not know, Telethon raises `TypeNotFoundError`. Right now `log_and_format_error` swallows it and the user sees:

```
An error occurred (code: CHAT-ERR-418). Check mcp_errors.log for details.
```

That is indistinguishable from "no such user/chat" — and it sends debugging in exactly the wrong direction.

## Why this one deserves a named message

Schema drift does not fail cleanly. An unknown constructor **desynchronises the whole read buffer**, so the failure is partial and looks arbitrary: in our case `list_chats`, `get_common_chats`, `resolve_username` and `get_full_user` were failing while `get_chats`, `search_contacts`, `list_messages` and `send_message` kept working normally.

Two things made it worse:

- Resolving a username failed, so the obvious reading was "that account does not exist". It did exist — the raw bytes in `mcp_errors.log` contained the person's name and username in plain text, meaning the data had arrived and only parsing had failed.
- The constructor id in the error was **not in any schema** (we checked the installed one, the frozen v1 branch, and the current Telegram Desktop `api.tl`), because it is garbage read from the desynchronised stream. So searching for it leads nowhere either.

Root cause in our case: the installed Telethon was built for LAYER 227 while the server had moved to 228, where the `user` constructor changed (`0x31774388` → `0xb1b8cc83`).

## Change

`TypeNotFoundError` now returns a message that names the condition, states that the data arrived and only parsing failed, and points at the fix. Every other error keeps the existing generic format — the helper's behaviour is unchanged for them.

The telethon import is done lazily inside a helper and guarded, so the module does not gain a hard import-time dependency.

## Tests

`tests/test_schema_drift.py` covers both branches.

The new test was first run against a **sabotaged** implementation (the branch disabled) and fails there, so it can actually catch a regression rather than passing vacuously. Full suite green.

---

Separately we needed to *fix* the drift, not just report it, and did so by regenerating Telethon's TL classes against the current layer. That part is more invasive (it vendors a schema and the generator), so I'm not proposing it here — happy to open it as a second PR if you'd find it useful.