### PR TITLE
feat(chats): report avatar presence (has_photo) in get_chat

### DIFF
--- a/telegram_mcp/tools/chats.py
+++ b/telegram_mcp/tools/chats.py
@@ -637,6 +637,14 @@ async def get_chat(chat_id: Union[int, str], account: str = None) -> str:
             record["bot"] = bool(entity.bot)
             record["verified"] = bool(entity.verified)
 
+        # Photo presence — the entity carries ChatPhoto/ChatPhotoEmpty (chats/channels)
+        # or UserProfilePhoto/UserProfilePhotoEmpty (users). Surfaced so callers can
+        # detect chats that have no avatar set.
+        photo = getattr(entity, "photo", None)
+        record["has_photo"] = photo is not None and not isinstance(
+            photo, (types.ChatPhotoEmpty, types.UserProfilePhotoEmpty)
+        )
+
         # Get unread count + last activity for THIS specific peer.
         #
         # NOTE: do NOT use get_dialogs(limit=1, offset_peer=entity) here. In

--- a/tests/test_get_chat.py
+++ b/tests/test_get_chat.py
@@ -3,6 +3,7 @@ import json
 from types import SimpleNamespace
 
 import pytest
+from telethon.tl import types as tl_types
 
 from telegram_mcp.tools import chats
 
@@ -116,3 +117,29 @@ async def test_get_chat_marks_archived_from_folder_id(monkeypatch):
 
     assert payload["archived"] is True
     assert payload["last_message"]["sender"] == "Ada Lovelace"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "photo, expected",
+    [
+        # Any real ChatPhoto/UserProfilePhoto object means an avatar is set
+        (SimpleNamespace(photo_id=42), True),
+        (tl_types.ChatPhotoEmpty(), False),
+        (tl_types.UserProfilePhotoEmpty(), False),
+        (None, False),
+    ],
+)
+async def test_get_chat_reports_avatar_presence(monkeypatch, photo, expected):
+    entity = SimpleNamespace(title="Avatar Probe", username=None, photo=photo)
+    last_msg = SimpleNamespace(
+        date=datetime.datetime(2026, 7, 19, 1, 0, 0, tzinfo=datetime.timezone.utc),
+        message="hi",
+        sender=SimpleNamespace(first_name="Ada", last_name=None, title=None),
+    )
+    client = FakeChatClient(entity, last_msg)
+    _patch(monkeypatch, client, entity)
+
+    payload = _parse(await chats.get_chat(chat_id=-100123, account=None))
+
+    assert payload["has_photo"] is expected


### PR DESCRIPTION
## Summary
- `get_chat` now includes a boolean `has_photo` field so callers can detect chats/users that have no avatar set, without having to attempt a media download.
- The entity already carries this information (`ChatPhoto`/`ChatPhotoEmpty` for chats and channels, `UserProfilePhoto`/`UserProfilePhotoEmpty` for users); this just surfaces it in the record.

## Test plan
- Added a parametrized test in `tests/test_get_chat.py` covering: a real photo object → `true`; `ChatPhotoEmpty` → `false`; `UserProfilePhotoEmpty` → `false`; no photo → `false`.
- Full suite passes (279 tests), `black --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)