### PR TITLE
fix: restore the broken star history chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ Maintained by [@chigwell](https://github.com/chigwell) and [@l1v0n1](https://git
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=chigwell/telegram-mcp&type=Date)](https://www.star-history.com/#chigwell/telegram-mcp&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=chigwell/telegram-mcp&type=Date)](https://star-history.dera.page/#chigwell/telegram-mcp&Date)
 
 ## Contributors
 


### PR DESCRIPTION
The star history chart in the README is broken and no longer renders. This PR updates the link to a maintained alternative that uses a different data source and requires no API token, so the chart works again. The badge is left untouched.