### PR TITLE
fix(messages): list_messages never calls get_media_label

### DIFF
--- a/telegram_mcp/tools/messages.py
+++ b/telegram_mcp/tools/messages.py
@@ -927,6 +927,14 @@ async def list_messages(
                 "date": msg.date,
                 "text": sanitize_user_content(msg.message),
             }
+            # Upstream bug: this hand-built record never called get_media_label,
+            # so a voice/photo/etc. with no caption was indistinguishable from
+            # an actually-empty message. message_to_dict (used by get_history)
+            # already gets this right.
+            media_label = get_media_label(msg)
+            if media_label:
+                record["media"] = media_label
+
             grouped_id = getattr(msg, "grouped_id", None)
             if grouped_id is not None:
                 record["grouped_id"] = grouped_id


### PR DESCRIPTION
## Summary

- `list_messages` builds its own record dict directly from `msg.message`, without the `get_media_label(msg)` fallback that `message_to_dict` (used by `get_history`) already has.
- Net effect: a voice message, photo, sticker, or any other captionless media item shows up in `list_messages` output looking identical to an actually-empty message — no `media` field, no indication anything was attached.
- Fix adds the same one-line `get_media_label` call `message_to_dict` already does, so `list_messages` records get a `media` field (e.g. `"media": "voice"`, `"media": "photo"`) whenever the message carries media, whether or not there's a caption.

## Test plan

```
uv run pytest tests/ -q
# 281 passed
```

```
uv run pre-commit run --files telegram_mcp/tools/messages.py
black....................................................................Passed
flake8...................................................................Passed
```

Manually confirmed against a real chat with several voice/photo messages via a running server — `list_messages` now reports `"media": "voice"` for a voice message that previously showed no media indicator at all.