### PR TITLE
feat(export): bulk chat export CLI (JSONL/HTML/MD/TXT, media, transcription)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,3 +86,36 @@ TELEGRAM_SESSION_NAME=telegram_session
 # --- Remembered contacts (optional) ---
 # TELEGRAM_ALIASES_FILE=/path/to/aliases.json
 # TELEGRAM_CONTACT_FUZZY=0   # exact-match aliases only
+
+# --- Voice/video-note transcription (optional) ---
+# off: transcribe_voice tool disabled, listings never show transcripts.
+# on-demand (default): transcribe_voice works; get_history/get_messages/
+#   list_messages fill in already-cached transcripts but never spend an API
+#   call fetching a new one during a listing.
+# auto: also prefetches missing transcripts during a listing, bounded by
+#   TELEGRAM_TRANSCRIBE_MAX_VOICES / _MAX_SECONDS per call.
+# TELEGRAM_TRANSCRIBE=on-demand
+#
+# Which engine transcribe_voice and auto-mode prefetch use by default (the
+# per-call engine= argument always overrides this):
+# - groq (default): Groq-hosted whisper-large-v3-turbo. Requires GROQ_API_KEY.
+#   Downloads the voice note and sends it to Groq - leaves the server, not
+#   free, but does not drop the recording's last words the way native
+#   Telegram transcription does (proven 2026-08-20, see docs).
+# - telegram: native Telegram Premium transcription. Free, audio never
+#   leaves Telegram, but empirically drops the last speech segment in
+#   roughly 2 of 3 recordings. Requires Telegram Premium on the account.
+#   Use for chats that should never be sent to a third party.
+# TELEGRAM_TRANSCRIBE_ENGINE=groq
+# GROQ_API_KEY=<groq api key, required when engine=groq is ever used>
+#
+# Per-call budget for TELEGRAM_TRANSCRIBE=auto prefetch (ignored otherwise;
+# transcribe_voice itself is never budget-limited since it's an explicit call).
+# TELEGRAM_TRANSCRIBE_MAX_VOICES=5
+# TELEGRAM_TRANSCRIBE_MAX_SECONDS=300
+#
+# Where the SQLite transcript cache lives. This is personal-chat text in
+# plaintext on disk - keep it on a mounted volume (see docker-compose.yml) and
+# in its own directory, not shared with backups of anything else. The file
+# gets mode 600; the directory 700.
+# TELEGRAM_TRANSCRIPT_CACHE_DIR=data/transcripts

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Message sent successfully:
 - [Device Identity](#device-identity)
 - [Proxy Support](#proxy-support)
 - [File Path Security](#file-path-security)
+- [Bulk Chat Export](#bulk-chat-export)
 - [Docker](#docker)
 - [Development](#development)
 - [Security Notes](#security-notes)
@@ -498,6 +499,114 @@ From an MCP client configuration, pass the same roots after `main.py`:
   }
 }
 ```
+
+## Bulk Chat Export
+
+Exporting a dozen chats is a CLI job, not an MCP tool: the output belongs on
+disk, not in a client's context window. `telegram-mcp-export` ships with this
+package and shares its plumbing - client construction, device identity, proxy
+support and voice transcription.
+
+**JSONL is the source of truth; HTML, Markdown and plain text are rendered from
+it**, so changing your mind about the format costs nothing and never touches the
+Telegram API again.
+
+### Session
+
+Export authorises as its **own device** and refuses to reuse any
+`TELEGRAM_SESSION_STRING*` it finds in the environment. Sharing one auth key
+between the running server and a second client is what makes Telegram revoke it
+(`AuthKeyDuplicatedError`), taking the server down with it. The session pool in
+[Multi-Account Setup](#multi-account-setup) solves a different problem -
+concurrent clients on one host - and a pool slot is claimed per process, so
+export stays out of it.
+
+```bash
+telegram-mcp-export login          # once, interactive: phone, code, 2FA password
+telegram-mcp-export whoami
+```
+
+The session file lives in `~/.config/telegram-mcp/export.session` (override with
+`--session`).
+
+### Exporting
+
+```bash
+# find the exact chats first
+telegram-mcp-export chats --out chats.tsv
+
+# one chat, whole history
+telegram-mcp-export export @somechat --all
+
+# a batch, last six months, JSONL + HTML
+telegram-mcp-export export --from-file targets.txt --months 6 --format jsonl,html
+```
+
+A target is an `@username`, a `t.me/...` link, a numeric id, or a chat title
+(exact match first, then a case-insensitive substring over your dialogs; an
+ambiguous title lists the candidates and stops rather than guessing).
+`--from-file` takes one target per line and allows `#` comments.
+
+Exactly one depth flag is required - the tool never guesses how much history you
+meant:
+
+| Flag | Window |
+|---|---|
+| `--all` | everything, from the first message |
+| `--months N` | the last N months |
+| `--since 2026-01-01` | from a date |
+| `--until 2026-06-30` | additionally cut the top |
+
+A date filter does not walk the whole history: the message id at the date
+boundary is located first, and the scan runs forward from there.
+
+### Output
+
+`--format jsonl,html,md,txt` (default `jsonl`, which is always written).
+
+- `messages.jsonl` - one message per line: normalised fields plus `raw`, the
+  full Telethon `to_dict()` with datetimes as ISO strings and bytes as base64.
+  `--no-raw` shrinks it considerably at the cost of fidelity.
+- `messages.html` - a Telegram Desktop-style read: date dividers, consecutive
+  messages from one sender joined, a colour per participant, replies linking to
+  the quoted message, forwards, reactions and inline media. Paginated every 3000
+  messages.
+- `messages.md` / `messages.txt` - for reading and for feeding to other tools.
+- `meta.json` - export parameters, date window, counts and an id-to-name map.
+
+Re-render an existing export without going online:
+
+```bash
+telegram-mcp-export render out/Some\ chat_-1001234567890 --format html,md
+```
+
+### Media and transcription are opt-in
+
+```bash
+telegram-mcp-export export @chat --all --media --media-max-mb 50
+telegram-mcp-export export @chat --months 3 --transcribe            # groq
+telegram-mcp-export export @chat --months 3 --transcribe=telegram   # native, Premium
+```
+
+Without `--media` nothing is downloaded, but every attachment is still described
+(kind, size, name, duration), so the conversation stays readable.
+
+Transcription uses the same engines as the `transcribe_voice` tool, with the
+same caveat: the native Telegram engine drops the last speech segment in roughly
+two recordings out of three, and the truncation is invisible in the text. Groq
+is the default for that reason. Every transcript records which engine produced
+it and is a machine reading, not a verbatim quote.
+
+### Interruptions
+
+Ctrl+C loses nothing already written. Continue with:
+
+```bash
+telegram-mcp-export export @chat --all --resume
+```
+
+`--resume` reads the last id from the existing `messages.jsonl` and appends only
+what is newer.
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,24 @@ The server currently includes 80+ MCP tools grouped into these areas:
 When a reference is unknown, resembles one contact, matches several, or points at a contact that no longer resolves, tools send nothing and return a structured instruction telling the agent exactly what to ask you, to save the answer with `set_contact_alias`, and to retry once. `list_contact_aliases` shows one row per person with all their aliases (use it to spot a wrong memory), `delete_contact_alias` forgets one, and repointing an alias at someone else requires `replace=True`. The save path itself refuses a target it would have to guess at: contacts are saved by @username, phone, numeric ID, or an alias already confirmed for them.
 
 Aliases live in `${XDG_STATE_HOME:-~/.local/state}/telegram-mcp/aliases.json` (owner-only, written atomically); `TELEGRAM_ALIASES_FILE` overrides the path, and a pre-existing `aliases.json` next to the code is still read as a fallback.
-- **Media:** send files, download media, upload files, send voice notes, stickers, GIFs, and inspect message media.
+- **Media:** send files, download media, upload files, send voice notes, stickers, GIFs, inspect message media, and transcribe voice messages/video notes (see below).
+
+### Voice transcription
+
+`transcribe_voice(chat_id, message_id, engine=None)` turns a voice message or video note into text. Two engines are available:
+
+- `groq` (default): uploads the recording to Groq's hosted `whisper-large-v3-turbo`. Leaves the server and costs a download+upload per call, but doesn't drop the recording's last few words the way native transcription does. Requires `GROQ_API_KEY`.
+- `telegram`: native Telegram Premium transcription (`messages.TranscribeAudioRequest`). Free and never leaves Telegram, but empirically drops the last speech segment in roughly 2 of 3 recordings and requires Telegram Premium on the account. Long recordings come back `pending` and are polled automatically.
+
+The engine is chosen per call via the `engine` argument, or otherwise defaults to `TELEGRAM_TRANSCRIBE_ENGINE` (`groq` or `telegram`). Results are cached by `(chat_id, message_id)` in a local SQLite file so repeat reads and repeat listings never re-transcribe the same message. Every transcript is returned with a `note` marking it as a machine transcript, not a verbatim quote — treat it as a paraphrase, not exact wording.
+
+`get_history`, `get_messages`, and `list_messages` fill in already-cached transcripts for voice messages instead of leaving the text empty, controlled by `TELEGRAM_TRANSCRIBE`:
+
+- `off`: `transcribe_voice` is disabled and listings never show transcripts.
+- `on-demand` (default): listings show cached transcripts but never spend an API call fetching a new one.
+- `auto`: listings also prefetch missing transcripts, bounded per call by `TELEGRAM_TRANSCRIBE_MAX_VOICES`/`TELEGRAM_TRANSCRIBE_MAX_SECONDS` (Groq isn't free, so this prefetch is budgeted rather than unbounded).
+
+The cache lives in `TELEGRAM_TRANSCRIPT_CACHE_DIR` (default `data/transcripts`), written as a 700 directory / 600 file since it holds personal-chat text in plaintext — see [Docker](#docker) for why this needs its own volume mount in a container.
 - **Profile and privacy:** get your own account info, update profile fields, set or delete profile photos, inspect privacy settings, get user info/photos/status, and manage bot commands.
 - **Folders and drafts:** list, create, update, reorder, and delete Telegram folders; save, list, and clear drafts.
 - **Events:** wait for incoming messages with debounce (`wait_for_new_message`, `wait_for_settled_message`), optionally for one chat only via `chat_id` — without it any unrelated conversation wakes the wait — or enable the opt-in incoming event feed for callback-style delivery (see below).
@@ -160,6 +177,23 @@ reduced Telegram account permission. The Telegram session string still has its
 normal authority inside the server process; read-only mode only prevents
 non-read-only tools from being registered and exposed through MCP. Accepted
 values are `all` (the default), `read-only`, and `read-only+<tool>,<tool>`.
+
+Voice transcription (see [Voice transcription](#voice-transcription) above) is
+off by default in the sense that no transcript is ever fetched unless you ask
+for one — `transcribe_voice` is always available, and listings only pick up
+already-cached transcripts. Enable prefetching or pick an engine explicitly:
+
+```env
+TELEGRAM_TRANSCRIBE=on-demand       # off / on-demand (default) / auto
+TELEGRAM_TRANSCRIBE_ENGINE=groq     # groq (default) or telegram
+GROQ_API_KEY=your_groq_api_key_here # required whenever engine=groq is used
+```
+
+`engine=groq` requires `GROQ_API_KEY`; `engine=telegram` requires Telegram
+Premium on the account. `TELEGRAM_TRANSCRIBE_MAX_VOICES` (default 5) and
+`TELEGRAM_TRANSCRIBE_MAX_SECONDS` (default 300) bound how much `auto` mode
+prefetches per listing call; `TELEGRAM_TRANSCRIPT_CACHE_DIR` (default
+`data/transcripts`) sets where the SQLite cache is written.
 
 Run the server locally:
 
@@ -496,6 +530,16 @@ The bundled Compose file runs the same setup:
 
 ```bash
 docker compose up --build -d
+```
+
+It also mounts `./transcript_cache` into the container at
+`/app/data/transcripts` so the voice-transcription SQLite cache (see
+[Voice transcription](#voice-transcription)) survives a rebuild instead of
+living in the container's writable layer. Create it once, owned by the
+container's `appuser` (uid 1000), before starting:
+
+```bash
+mkdir -p ./transcript_cache && chown 1000:1000 ./transcript_cache
 ```
 
 ### One container per client (stdio)

--- a/README.md
+++ b/README.md
@@ -591,6 +591,15 @@ telegram-mcp-export export @chat --months 3 --transcribe=telegram   # native, Pr
 Without `--media` nothing is downloaded, but every attachment is still described
 (kind, size, name, duration), so the conversation stays readable.
 
+Link previews are not media. What a message links to belongs to whoever it
+links to, so a preview is left as the link in the text, the way Telegram
+Desktop's own export leaves it. Otherwise a chat where people share videos
+would drag those videos onto your disk.
+
+`--media-max-mb` is enforced on the bytes, not on the size the message claims.
+A message can report one of its thumbnails and still be tens of megabytes, so
+a download that passes the limit while it runs is stopped and thrown away.
+
 Transcription uses the same engines as the `transcribe_voice` tool, with the
 same caveat: the native Telegram engine drops the last speech segment in roughly
 two recordings out of three, and the truncation is invisible in the text. Groq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,4 +23,13 @@ services:
     # Replace './telegram_sessions' with your desired host path.
     # volumes:
     #   - ./telegram_sessions:/app
+    volumes:
+      # Voice/video-note transcript cache (SQLite, see telegram_mcp/transcription.py).
+      # Without this mount the cache lives only in the container's writable
+      # layer and is lost on every `docker compose build`. It holds plaintext
+      # personal-chat transcripts, so this directory should get its own
+      # backup/retention policy rather than riding along with a general backup.
+      # Host directory must be readable/writable by uid 1000 (appuser):
+      #   mkdir -p ./transcript_cache && chown 1000:1000 ./transcript_cache
+      - ./transcript_cache:/app/data/transcripts
     restart: unless-stopped

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,11 +44,12 @@ proxy = [
 
 [tool.setuptools]
 py-modules = ["main", "sanitize", "session_string_generator"]
-packages = ["telegram_mcp", "telegram_mcp.tools"]
+packages = ["telegram_mcp", "telegram_mcp.tools", "telegram_mcp.export"]
 
 [project.scripts]
 telegram-mcp = "main:main"
 telegram-mcp-generate-session = "session_string_generator:main"
+telegram-mcp-export = "telegram_mcp.export.cli:main"
 
 [tool.black]
 line-length = 99

--- a/telegram_mcp/client_factory.py
+++ b/telegram_mcp/client_factory.py
@@ -1,0 +1,136 @@
+"""Construction of ``TelegramClient`` instances: credentials, proxy, identity.
+
+Split out of ``runtime`` so a client can be built without importing the MCP
+server. ``runtime`` discovers accounts and exits the process when none is
+configured, which is right for the server and wrong for every other caller -
+the export CLI authorises its own session and has no server session at all.
+
+Credentials are read at call time rather than at import, so importing this
+module never fails and error messages surface where they can be reported.
+"""
+
+import os
+from typing import Any, Optional
+
+from telethon import TelegramClient
+
+from telegram_mcp.client_identity import client_identity_kwargs
+from telegram_mcp.errors import ValidationError
+
+PROXY_TYPES_SOCKS_HTTP = {"socks5", "socks4", "http"}
+PROXY_TYPES_ALL = PROXY_TYPES_SOCKS_HTTP | {"mtproxy"}
+
+
+def api_credentials() -> tuple[int, str]:
+    """``(api_id, api_hash)`` from the environment, with a readable failure."""
+    api_id = (os.getenv("TELEGRAM_API_ID") or "").strip()
+    api_hash = (os.getenv("TELEGRAM_API_HASH") or "").strip()
+    if not api_id or not api_hash:
+        raise ValidationError(
+            "TELEGRAM_API_ID and TELEGRAM_API_HASH are required. Set them in .env "
+            "or in the environment."
+        )
+    try:
+        return int(api_id), api_hash
+    except ValueError as exc:
+        raise ValidationError(f"TELEGRAM_API_ID must be an integer, got '{api_id}'.") from exc
+
+
+def get_proxy_env(name: str, label: str) -> Optional[str]:
+    """Resolve a TELEGRAM_PROXY_* env var with optional ``_<LABEL>`` suffix.
+
+    Per-account values override the unsuffixed defaults so a global proxy can
+    coexist with per-label overrides.
+    """
+    suffixed = os.getenv(f"TELEGRAM_PROXY_{name}_{label.upper()}")
+    if suffixed:
+        return suffixed
+    return os.getenv(f"TELEGRAM_PROXY_{name}") or None
+
+
+def parse_bool_env(value: Optional[str], default: bool) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def build_proxy_for_label(label: str) -> tuple[Optional[Any], Optional[Any]]:
+    """Return ``(proxy, connection)`` kwargs for ``TelegramClient`` for a label.
+
+    Reads ``TELEGRAM_PROXY_*`` env vars (with optional ``_<LABEL>`` suffix).
+    Returns ``(None, None)`` when no proxy is configured. Raises
+    :class:`ValidationError` for malformed configuration so the caller fails
+    fast instead of silently bypassing the proxy.
+    """
+    proxy_type = get_proxy_env("TYPE", label)
+    if not proxy_type:
+        return None, None
+
+    proxy_type = proxy_type.strip().lower()
+    if proxy_type not in PROXY_TYPES_ALL:
+        raise ValidationError(
+            f"Invalid TELEGRAM_PROXY_TYPE '{proxy_type}'. "
+            f"Expected one of: {', '.join(sorted(PROXY_TYPES_ALL))}."
+        )
+
+    host = get_proxy_env("HOST", label)
+    port_raw = get_proxy_env("PORT", label)
+    if not host or not port_raw:
+        raise ValidationError(
+            "TELEGRAM_PROXY_HOST and TELEGRAM_PROXY_PORT are required when "
+            "TELEGRAM_PROXY_TYPE is set."
+        )
+    try:
+        port = int(port_raw)
+    except ValueError as exc:
+        raise ValidationError(
+            f"TELEGRAM_PROXY_PORT must be an integer, got '{port_raw}'."
+        ) from exc
+
+    if proxy_type == "mtproxy":
+        secret = get_proxy_env("SECRET", label)
+        if not secret:
+            raise ValidationError("TELEGRAM_PROXY_SECRET is required for mtproxy.")
+        try:
+            from telethon.network import ConnectionTcpMTProxyRandomizedIntermediate
+        except ImportError as exc:  # pragma: no cover - defensive guard
+            raise ValidationError(
+                "Telethon MTProxy connection class is unavailable; upgrade telethon."
+            ) from exc
+        return (host, port, secret), ConnectionTcpMTProxyRandomizedIntermediate
+
+    # SOCKS4/SOCKS5/HTTP via python-socks (Telethon's optional dependency).
+    try:
+        import python_socks  # noqa: F401
+    except ImportError as exc:
+        raise ValidationError(
+            f"Proxy type '{proxy_type}' requires the 'python-socks' package. "
+            "Install it with `pip install python-socks` or `uv sync --extra proxy`."
+        ) from exc
+
+    proxy: dict[str, Any] = {
+        "proxy_type": proxy_type,
+        "addr": host,
+        "port": port,
+        "rdns": parse_bool_env(get_proxy_env("RDNS", label), default=True),
+    }
+    username = get_proxy_env("USERNAME", label)
+    password = get_proxy_env("PASSWORD", label)
+    if username:
+        proxy["username"] = username
+    if password:
+        proxy["password"] = password
+    return proxy, None
+
+
+def build_client(session: Any, label: str) -> TelegramClient:
+    """Construct a ``TelegramClient`` honoring per-label proxy configuration."""
+    proxy, connection = build_proxy_for_label(label)
+    kwargs: dict[str, Any] = {}
+    if proxy is not None:
+        kwargs["proxy"] = proxy
+    if connection is not None:
+        kwargs["connection"] = connection
+    kwargs.update(client_identity_kwargs())
+    api_id, api_hash = api_credentials()
+    return TelegramClient(session, api_id, api_hash, **kwargs)

--- a/telegram_mcp/errors.py
+++ b/telegram_mcp/errors.py
@@ -1,0 +1,12 @@
+"""Shared exception types.
+
+Kept in a module of its own so helpers can raise them without importing
+``runtime``, which builds the MCP server and discovers Telegram accounts as an
+import side effect.
+"""
+
+
+class ValidationError(Exception):
+    """Custom exception for validation errors."""
+
+    pass

--- a/telegram_mcp/export/__init__.py
+++ b/telegram_mcp/export/__init__.py
@@ -1,0 +1,12 @@
+"""Bulk chat export to local files.
+
+This is a CLI, not an MCP tool, and deliberately so: an export of a dozen chats
+must land on the operator's disk, not in an MCP client's context window. It
+shares this package's Telegram plumbing - client construction, device identity,
+proxy handling, voice transcription - and adds only what export needs.
+
+JSONL is the source of truth; HTML, Markdown and plain text are rendered from
+it, so re-rendering never touches the Telegram API.
+"""
+
+__all__ = ["cli"]

--- a/telegram_mcp/export/cli.py
+++ b/telegram_mcp/export/cli.py
@@ -1,0 +1,400 @@
+"""Command line: login, chats, export, render."""
+
+import argparse
+import asyncio
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+from .fetch import chat_meta, display_name, iter_records, resolve_target
+from .render import read_records, render
+from .session import build_client, connected, ensure_authorised, session_path
+from .util import json_default, log, months_ago, parse_date, safe_name
+
+try:  # the console script is installed from this package
+    from importlib.metadata import version as _dist_version
+
+    __version__ = _dist_version("telegram-mcp")
+except Exception:  # running from a source checkout without an install
+    __version__ = "dev"
+
+DEFAULT_OUT = Path("out")
+KNOWN_FORMATS = ("jsonl", "html", "md", "txt")
+
+
+# --------------------------------------------------------------------------
+# Argument parsing
+# --------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="telegram-mcp-export",
+        description="Export Telegram chats to local files. JSONL is always written; "
+        "every other format is rendered from it.",
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"telegram-mcp-export {__version__}"
+    )
+    parser.add_argument(
+        "--session",
+        help="Path to the session file (default ~/.config/telegram-mcp/export.session).",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("login", help="Authorise this tool as a new Telegram device (interactive).")
+    sub.add_parser("whoami", help="Show the logged-in account.")
+
+    chats = sub.add_parser("chats", help="List dialogs so you can pick export targets.")
+    chats.add_argument("--limit", type=int, default=0, help="Stop after N dialogs (0 = all).")
+    chats.add_argument("--out", help="Also write the list as TSV to this file.")
+
+    export = sub.add_parser("export", help="Export one or more chats.")
+    export.add_argument("targets", nargs="*", help="@username, t.me link, chat id, or chat title.")
+    export.add_argument(
+        "--from-file", help="File with one target per line ('#' comments allowed)."
+    )
+    window = export.add_mutually_exclusive_group(required=True)
+    window.add_argument(
+        "--all", action="store_true", help="Whole history, from the first message."
+    )
+    window.add_argument("--months", type=int, help="Only the last N months.")
+    window.add_argument("--since", help="Only messages from this date (YYYY-MM-DD).")
+    export.add_argument("--until", help="Stop at this date (YYYY-MM-DD).")
+    export.add_argument(
+        "--format",
+        default="jsonl",
+        help=f"Comma-separated: {', '.join(KNOWN_FORMATS)} (default jsonl).",
+    )
+    export.add_argument("--media", action="store_true", help="Download media files.")
+    export.add_argument(
+        "--media-max-mb", type=float, default=0, help="Skip media larger than this (0 = no limit)."
+    )
+    export.add_argument(
+        "--transcribe",
+        nargs="?",
+        const="groq",
+        help="Transcribe voice and video notes (default engine: groq).",
+    )
+    export.add_argument(
+        "--no-raw",
+        action="store_true",
+        help="Drop the raw Telegram payload from the JSONL (smaller, lossy).",
+    )
+    export.add_argument(
+        "--out", default=str(DEFAULT_OUT), help="Output directory (default ./out)."
+    )
+    export.add_argument(
+        "--resume",
+        action="store_true",
+        help="Append only messages newer than the last export in that folder.",
+    )
+
+    render_cmd = sub.add_parser("render", help="Re-render an existing export from its JSONL.")
+    render_cmd.add_argument("directory", help="An export folder containing messages.jsonl.")
+    render_cmd.add_argument(
+        "--format", default="html", help=f"Comma-separated: {', '.join(KNOWN_FORMATS)}."
+    )
+    return parser
+
+
+def parse_formats(raw: str) -> list[str]:
+    names = [item.strip().lower() for item in raw.split(",") if item.strip()]
+    unknown = [name for name in names if name not in KNOWN_FORMATS]
+    if unknown:
+        raise SystemExit(
+            f"Unknown format(s): {', '.join(unknown)}. Known: {', '.join(KNOWN_FORMATS)}."
+        )
+    if "jsonl" not in names:
+        names.insert(0, "jsonl")
+    return names
+
+
+def collect_targets(args) -> list[str]:
+    targets = list(args.targets)
+    if args.from_file:
+        path = Path(args.from_file).expanduser()
+        if not path.exists():
+            raise SystemExit(f"No such file: {path}")
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                targets.append(line)
+    if not targets:
+        raise SystemExit("No chats given. Pass targets on the command line or use --from-file.")
+    seen, ordered = set(), []
+    for target in targets:
+        if target not in seen:
+            seen.add(target)
+            ordered.append(target)
+    return ordered
+
+
+def window_bounds(args) -> tuple[Optional[dt.datetime], Optional[dt.datetime]]:
+    since = None
+    if args.months:
+        since = months_ago(args.months)
+    elif args.since:
+        since = parse_date(args.since)
+    until = parse_date(args.until) if args.until else None
+    return since, until
+
+
+# --------------------------------------------------------------------------
+# Commands
+# --------------------------------------------------------------------------
+
+
+async def cmd_login(args) -> int:
+    client = build_client(args.session)
+    async with connected(client):
+        await ensure_authorised(client, interactive=True)
+        me = await client.get_me()
+        log(f"Logged in as {display_name(me)} (id {me.id}).")
+        log(f"Session file: {session_path(args.session)}")
+    return 0
+
+
+async def cmd_whoami(args) -> int:
+    client = build_client(args.session)
+    async with connected(client):
+        await ensure_authorised(client, interactive=False)
+        me = await client.get_me()
+        print(
+            json.dumps(
+                {
+                    "id": me.id,
+                    "name": display_name(me),
+                    "username": me.username,
+                    "premium": bool(getattr(me, "premium", False)),
+                    "session": str(session_path(args.session)),
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+    return 0
+
+
+async def cmd_chats(args) -> int:
+    client = build_client(args.session)
+    rows = []
+    async with connected(client):
+        await ensure_authorised(client, interactive=False)
+        async for dialog in client.iter_dialogs():
+            entity = dialog.entity
+            rows.append(
+                {
+                    "id": dialog.id,
+                    "type": (
+                        "user" if dialog.is_user else ("channel" if dialog.is_channel else "group")
+                    ),
+                    "title": dialog.name or "",
+                    "username": getattr(entity, "username", None) or "",
+                    "last": dialog.date.isoformat() if dialog.date else "",
+                }
+            )
+            if args.limit and len(rows) >= args.limit:
+                break
+
+    header = f"{'id':>16}  {'type':<8}  {'username':<22}  title"
+    print(header)
+    print("-" * len(header))
+    for row in rows:
+        print(
+            f"{row['id']:>16}  {row['type']:<8}  {('@' + row['username']) if row['username'] else '':<22}  {row['title']}"
+        )
+
+    if args.out:
+        path = Path(args.out).expanduser()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as handle:
+            handle.write("id\ttype\tusername\ttitle\tlast_message\n")
+            for row in rows:
+                handle.write(
+                    f"{row['id']}\t{row['type']}\t{row['username']}\t{row['title']}\t{row['last']}\n"
+                )
+        log(f"Wrote {len(rows)} dialogs to {path}")
+    return 0
+
+
+def _resume_floor(export_dir: Path) -> int:
+    source = export_dir / "messages.jsonl"
+    if not source.exists():
+        return 0
+    last = 0
+    for record in read_records(source):
+        last = max(last, int(record.get("id") or 0))
+    return last
+
+
+async def export_one(
+    client, target: str, args, formats: list[str], since, until
+) -> Optional[dict]:
+    entity = await resolve_target(client, target)
+    meta = await chat_meta(client, entity)
+    folder = f"{safe_name(meta['title'] or 'chat')}_{meta['id']}"
+    export_dir = Path(args.out).expanduser() / folder
+    export_dir.mkdir(parents=True, exist_ok=True)
+
+    min_id = _resume_floor(export_dir) if args.resume else 0
+    mode = "a" if (args.resume and min_id) else "w"
+    if mode == "w" and (export_dir / "messages.jsonl").exists():
+        (export_dir / "messages.jsonl").unlink()
+
+    log(
+        f"→ {meta['title']} ({meta['type']}, id {meta['id']})"
+        + (f" · resuming after message {min_id}" if min_id else "")
+    )
+
+    media_root = export_dir / "media" if args.media else None
+    if media_root:
+        media_root.mkdir(parents=True, exist_ok=True)
+    media_max = int(args.media_max_mb * 1024 * 1024) if args.media_max_mb else None
+
+    people: dict[int, str] = {}
+    count = 0
+    first_date = last_date = None
+    jsonl_path = export_dir / "messages.jsonl"
+
+    with jsonl_path.open(mode, encoding="utf-8") as handle:
+        async for record in iter_records(
+            client,
+            entity,
+            since=since,
+            until=until,
+            min_id=min_id,
+            media_root=media_root,
+            media_max_bytes=media_max,
+            transcribe_engine=args.transcribe,
+            include_raw=not args.no_raw,
+            people=people,
+        ):
+            handle.write(json.dumps(record, default=json_default, ensure_ascii=False) + "\n")
+            count += 1
+            stamp = record.get("date")
+            if stamp is not None:
+                stamp = stamp.isoformat() if hasattr(stamp, "isoformat") else str(stamp)
+                first_date = first_date or stamp
+                last_date = stamp
+
+    # On a resume the window has to describe the whole file, not just the tail.
+    total = count
+    if mode == "a":
+        total = sum(1 for _ in read_records(jsonl_path))
+        rows = list(read_records(jsonl_path))
+        first_date = rows[0].get("date") if rows else first_date
+        last_date = rows[-1].get("date") if rows else last_date
+
+    meta_payload = {
+        "tool": f"telegram-mcp-export {__version__}",
+        "exported_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "chat": meta,
+        "message_count": total,
+        "added_this_run": count,
+        "window": {
+            "requested_since": since.isoformat() if since else None,
+            "requested_until": until.isoformat() if until else None,
+            "first": first_date,
+            "last": last_date,
+        },
+        "options": {
+            "media": bool(args.media),
+            "media_max_mb": args.media_max_mb or None,
+            "transcribe": args.transcribe,
+            "raw_included": not args.no_raw,
+            "formats": formats,
+        },
+        "people": {str(k): v for k, v in sorted(people.items())},
+    }
+    (export_dir / "meta.json").write_text(
+        json.dumps(meta_payload, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    log(f"  jsonl: {count} new message(s), {total} total → {jsonl_path}")
+    render(export_dir, meta_payload, formats)
+    return {"dir": export_dir, "meta": meta_payload}
+
+
+async def cmd_export(args) -> int:
+    targets = collect_targets(args)
+    if args.transcribe:
+        # Validated here rather than as an argparse choice so that --help and
+        # the offline commands never import the MCP runtime.
+        from telegram_mcp.transcription import ENGINES
+
+        if args.transcribe not in ENGINES:
+            raise SystemExit(
+                f"Unknown transcription engine '{args.transcribe}'. "
+                f"Known: {', '.join(sorted(ENGINES))}."
+            )
+    formats = parse_formats(args.format)
+    since, until = window_bounds(args)
+    if args.transcribe == "groq":
+        import os
+
+        if not os.getenv("GROQ_API_KEY"):
+            log(
+                "warning: --transcribe=groq needs GROQ_API_KEY; falling back to no transcription "
+                "would be silent, so set the key or pass --transcribe=telegram."
+            )
+
+    client = build_client(args.session)
+    results, failures = [], []
+    async with connected(client):
+        await ensure_authorised(client, interactive=False)
+        for index, target in enumerate(targets, start=1):
+            log(f"[{index}/{len(targets)}] {target}")
+            try:
+                result = await export_one(client, target, args, formats, since, until)
+                if result:
+                    results.append(result)
+            except SystemExit as exc:
+                failures.append((target, str(exc)))
+                log(f"  ! skipped: {exc}")
+            except Exception as exc:
+                failures.append((target, repr(exc)))
+                log(f"  ! failed: {exc}")
+
+    log("")
+    log(f"Done: {len(results)} chat(s) exported, {len(failures)} failed.")
+    for target, reason in failures:
+        log(f"  failed: {target} - {reason}")
+    return 1 if failures and not results else 0
+
+
+async def cmd_render(args) -> int:
+    export_dir = Path(args.directory).expanduser()
+    meta_path = export_dir / "meta.json"
+    if not (export_dir / "messages.jsonl").exists():
+        raise SystemExit(f"{export_dir} has no messages.jsonl.")
+    meta = (
+        json.loads(meta_path.read_text(encoding="utf-8")) if meta_path.exists() else {"chat": {}}
+    )
+    render(export_dir, meta, parse_formats(args.format))
+    return 0
+
+
+COMMANDS = {
+    "login": cmd_login,
+    "whoami": cmd_whoami,
+    "chats": cmd_chats,
+    "export": cmd_export,
+    "render": cmd_render,
+}
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    handler = COMMANDS[args.command]
+    try:
+        return asyncio.run(handler(args))
+    except KeyboardInterrupt:
+        log("Interrupted. Whatever was written stays on disk; re-run with --resume.")
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/telegram_mcp/export/entities.py
+++ b/telegram_mcp/export/entities.py
@@ -1,0 +1,201 @@
+"""Message formatting: Telegram entities -> HTML / Markdown / plain text.
+
+Telegram entity offsets are counted in UTF-16 code units, not Python
+characters. An emoji or any astral-plane character shifts every later offset by
+one, so slicing the Python string directly corrupts formatting in exactly the
+messages people paste screenshots of. Everything here works on the UTF-16-LE
+encoding and decodes each slice back.
+"""
+
+import html
+from typing import Any, Iterable, Optional
+
+# Entity class names (Telethon types) mapped to a neutral kind. Names are used
+# rather than imports so an unknown/newer entity degrades to plain text instead
+# of raising.
+_KIND_BY_CLASS = {
+    "MessageEntityBold": "bold",
+    "MessageEntityItalic": "italic",
+    "MessageEntityUnderline": "underline",
+    "MessageEntityStrike": "strike",
+    "MessageEntitySpoiler": "spoiler",
+    "MessageEntityCode": "code",
+    "MessageEntityPre": "pre",
+    "MessageEntityBlockquote": "quote",
+    "MessageEntityTextUrl": "text_url",
+    "MessageEntityUrl": "url",
+    "MessageEntityEmail": "email",
+    "MessageEntityPhone": "phone",
+    "MessageEntityMention": "mention",
+    "MessageEntityMentionName": "mention_name",
+    "MessageEntityHashtag": "hashtag",
+    "MessageEntityCashtag": "hashtag",
+    "MessageEntityBotCommand": "plain",
+    "MessageEntityCustomEmoji": "plain",
+    "MessageEntityBankCard": "plain",
+    "MessageEntityUnknown": "plain",
+}
+
+
+def _u16(text: str) -> bytes:
+    return text.encode("utf-16-le")
+
+
+def _slice(buf: bytes, start: int, end: int) -> str:
+    return buf[start * 2 : end * 2].decode("utf-16-le", errors="replace")
+
+
+def entity_kind(entity: Any) -> str:
+    return _KIND_BY_CLASS.get(type(entity).__name__, "plain")
+
+
+def entities_to_json(entities: Optional[Iterable[Any]]) -> list[dict]:
+    """A compact, engine-independent description kept in the JSONL record."""
+    out: list[dict] = []
+    for entity in entities or []:
+        item = {
+            "type": entity_kind(entity),
+            "class": type(entity).__name__,
+            "offset": getattr(entity, "offset", None),
+            "length": getattr(entity, "length", None),
+        }
+        url = getattr(entity, "url", None)
+        if url:
+            item["url"] = url
+        user_id = getattr(entity, "user_id", None)
+        if user_id:
+            item["user_id"] = user_id
+        language = getattr(entity, "language", None)
+        if language:
+            item["language"] = language
+        document_id = getattr(entity, "document_id", None)
+        if document_id:
+            item["document_id"] = str(document_id)
+        out.append(item)
+    return out
+
+
+def _segments(text: str, entities: list[dict]) -> list[tuple[str, list[dict]]]:
+    """Split the text at every entity boundary.
+
+    Each segment carries the entities covering it, outermost first. Nested and
+    overlapping entities (bold inside a link, say) therefore re-open per segment
+    instead of producing crossed tags.
+    """
+    buf = _u16(text)
+    total = len(buf) // 2
+    usable = [
+        e
+        for e in entities
+        if isinstance(e.get("offset"), int)
+        and isinstance(e.get("length"), int)
+        and e["length"] > 0
+    ]
+    bounds = {0, total}
+    for e in usable:
+        bounds.add(max(0, min(total, e["offset"])))
+        bounds.add(max(0, min(total, e["offset"] + e["length"])))
+    ordered = sorted(bounds)
+    segments: list[tuple[str, list[dict]]] = []
+    for start, end in zip(ordered, ordered[1:]):
+        if end <= start:
+            continue
+        covering = [e for e in usable if e["offset"] <= start and e["offset"] + e["length"] >= end]
+        covering.sort(key=lambda e: (e["offset"], -e["length"]))
+        segments.append((_slice(buf, start, end), covering))
+    return segments
+
+
+# --------------------------------------------------------------------------
+# HTML
+# --------------------------------------------------------------------------
+
+
+def _html_wrap(kind: str, entity: dict, inner: str) -> str:
+    if kind == "bold":
+        return f"<strong>{inner}</strong>"
+    if kind == "italic":
+        return f"<em>{inner}</em>"
+    if kind == "underline":
+        return f"<u>{inner}</u>"
+    if kind == "strike":
+        return f"<s>{inner}</s>"
+    if kind == "spoiler":
+        return f'<span class="spoiler">{inner}</span>'
+    if kind == "code":
+        return f"<code>{inner}</code>"
+    if kind == "pre":
+        return f"<pre>{inner}</pre>"
+    if kind == "quote":
+        return f"<blockquote>{inner}</blockquote>"
+    if kind == "text_url":
+        return f'<a href="{html.escape(entity.get("url") or "", quote=True)}">{inner}</a>'
+    if kind == "url":
+        return f'<a href="{html.escape(inner, quote=True)}">{inner}</a>'
+    if kind == "email":
+        return f'<a href="mailto:{html.escape(inner, quote=True)}">{inner}</a>'
+    if kind == "phone":
+        return f'<a href="tel:{html.escape(inner, quote=True)}">{inner}</a>'
+    if kind == "mention":
+        return f'<a href="https://t.me/{html.escape(inner.lstrip("@"), quote=True)}">{inner}</a>'
+    if kind == "mention_name":
+        return f'<a href="https://t.me/user?id={entity.get("user_id")}">{inner}</a>'
+    if kind == "hashtag":
+        return f'<span class="tag">{inner}</span>'
+    return inner
+
+
+def to_html(text: Optional[str], entities: Optional[list[dict]]) -> str:
+    if not text:
+        return ""
+    if not entities:
+        return html.escape(text).replace("\n", "<br>")
+    parts: list[str] = []
+    for chunk, covering in _segments(text, entities):
+        rendered = html.escape(chunk)
+        for entity in reversed(covering):
+            rendered = _html_wrap(entity["type"], entity, rendered)
+        parts.append(rendered)
+    return "".join(parts).replace("\n", "<br>")
+
+
+# --------------------------------------------------------------------------
+# Markdown
+# --------------------------------------------------------------------------
+
+_MD_WRAP = {
+    "bold": ("**", "**"),
+    "italic": ("_", "_"),
+    "underline": ("__", "__"),
+    "strike": ("~~", "~~"),
+    "spoiler": ("||", "||"),
+    "code": ("`", "`"),
+}
+
+
+def to_markdown(text: Optional[str], entities: Optional[list[dict]]) -> str:
+    if not text:
+        return ""
+    if not entities:
+        return text
+    parts: list[str] = []
+    for chunk, covering in _segments(text, entities):
+        rendered = chunk
+        for entity in reversed(covering):
+            kind = entity["type"]
+            if kind in _MD_WRAP:
+                open_tag, close_tag = _MD_WRAP[kind]
+                rendered = f"{open_tag}{rendered}{close_tag}"
+            elif kind == "pre":
+                language = entity.get("language") or ""
+                rendered = f"\n```{language}\n{rendered}\n```\n"
+            elif kind == "quote":
+                rendered = "\n".join(f"> {line}" for line in rendered.splitlines()) or "> "
+            elif kind == "text_url":
+                rendered = f"[{rendered}]({entity.get('url') or ''})"
+        parts.append(rendered)
+    return "".join(parts)
+
+
+def to_plain(text: Optional[str], entities: Optional[list[dict]] = None) -> str:
+    return text or ""

--- a/telegram_mcp/export/fetch.py
+++ b/telegram_mcp/export/fetch.py
@@ -1,0 +1,274 @@
+"""Resolving chats and streaming their history into normalized records."""
+
+import datetime as dt
+from pathlib import Path
+from typing import Any, AsyncIterator, Optional
+
+from telethon import utils as tl_utils
+from telethon.errors import FloodWaitError
+from telethon.tl.types import (
+    ReactionCustomEmoji,
+    ReactionEmoji,
+    User,
+)
+
+from . import media as media_mod
+from .entities import entities_to_json
+from .util import log
+
+
+def display_name(entity: Any) -> Optional[str]:
+    if entity is None:
+        return None
+    title = getattr(entity, "title", None)
+    if title:
+        return title
+    first = getattr(entity, "first_name", "") or ""
+    last = getattr(entity, "last_name", "") or ""
+    name = f"{first} {last}".strip()
+    return name or getattr(entity, "username", None) or None
+
+
+def entity_kind(entity: Any) -> str:
+    if isinstance(entity, User):
+        return "bot" if getattr(entity, "bot", False) else "user"
+    if getattr(entity, "broadcast", False):
+        return "channel"
+    if getattr(entity, "megagroup", False):
+        return "supergroup"
+    return "group"
+
+
+async def resolve_target(client: Any, target: str) -> Any:
+    """Accept @username, t.me link, numeric id, or a chat title (exact, then
+    case-insensitive substring over the dialog list)."""
+    raw = target.strip()
+    if not raw:
+        raise SystemExit("Empty chat target.")
+
+    if raw.startswith("https://t.me/") or raw.startswith("t.me/"):
+        raw = "@" + raw.rsplit("/", 1)[-1]
+
+    if raw.startswith("@") or (
+        raw.lstrip("-").isdigit() is False and " " not in raw and "." in raw
+    ):
+        try:
+            return await client.get_entity(raw)
+        except Exception:
+            pass
+
+    if raw.lstrip("-").isdigit():
+        try:
+            return await client.get_entity(int(raw))
+        except Exception as exc:
+            raise SystemExit(f"Cannot resolve chat id {raw}: {exc}")
+
+    try:
+        return await client.get_entity(raw)
+    except Exception:
+        pass
+
+    needle = raw.casefold()
+    matches = []
+    async for dialog in client.iter_dialogs():
+        title = (dialog.name or "").casefold()
+        if title == needle:
+            return dialog.entity
+        if needle in title:
+            matches.append(dialog)
+    if len(matches) == 1:
+        return matches[0].entity
+    if not matches:
+        raise SystemExit(
+            f"No chat matches '{target}'. Run 'telegram-mcp-export chats' to see the list."
+        )
+    listing = "\n".join(f"  {d.id}\t{d.name}" for d in matches[:15])
+    raise SystemExit(
+        f"'{target}' matches {len(matches)} chats - be more specific or use an id:\n{listing}"
+    )
+
+
+async def chat_meta(client: Any, entity: Any) -> dict:
+    return {
+        "id": tl_utils.get_peer_id(entity),
+        "raw_id": getattr(entity, "id", None),
+        "type": entity_kind(entity),
+        "title": display_name(entity),
+        "username": getattr(entity, "username", None),
+        "phone": getattr(entity, "phone", None),
+        "is_self": bool(getattr(entity, "is_self", False)),
+    }
+
+
+async def _anchor_min_id(client: Any, entity: Any, since: Optional[dt.datetime]) -> int:
+    """Message id just before ``since``.
+
+    Telegram's ``offset_date`` returns the newest message strictly older than
+    the date, which makes an exact ``min_id`` for a forward (chronological)
+    scan. Without it a date filter would have to walk the whole history.
+    """
+    if since is None:
+        return 0
+    found = await client.get_messages(entity, limit=1, offset_date=since)
+    return found[0].id if found else 0
+
+
+def _reactions(message: Any) -> list[dict]:
+    reactions = getattr(message, "reactions", None)
+    if not reactions or not getattr(reactions, "results", None):
+        return []
+    out = []
+    for item in reactions.results:
+        reaction = getattr(item, "reaction", None)
+        if isinstance(reaction, ReactionEmoji):
+            key = reaction.emoticon
+        elif isinstance(reaction, ReactionCustomEmoji):
+            key = f"custom:{reaction.document_id}"
+        else:
+            key = str(reaction)
+        out.append({"reaction": key, "count": getattr(item, "count", None)})
+    return out
+
+
+def _forward(message: Any) -> Optional[dict]:
+    fwd = getattr(message, "forward", None)
+    if fwd is None:
+        return None
+    return {
+        "from_id": getattr(fwd, "sender_id", None),
+        "from_name": getattr(fwd, "from_name", None)
+        or display_name(getattr(fwd, "sender", None))
+        or display_name(getattr(fwd, "chat", None)),
+        "date": getattr(fwd, "date", None),
+        "channel_post": getattr(fwd, "channel_post", None),
+        "post_author": getattr(fwd, "post_author", None),
+    }
+
+
+def _reply(message: Any) -> Optional[dict]:
+    reply = getattr(message, "reply_to", None)
+    if reply is None:
+        return None
+    return {
+        "reply_to_msg_id": getattr(reply, "reply_to_msg_id", None),
+        "top_msg_id": getattr(reply, "reply_to_top_id", None),
+        "forum_topic": bool(getattr(reply, "forum_topic", False)),
+    }
+
+
+def _service(message: Any) -> Optional[dict]:
+    action = getattr(message, "action", None)
+    if action is None:
+        return None
+    payload = {"action": type(action).__name__}
+    for field in ("title", "users", "user_id", "duration", "photo", "message"):
+        value = getattr(action, field, None)
+        if value is not None and field != "photo":
+            payload[field] = value if not isinstance(value, list) else list(value)
+    return payload
+
+
+async def iter_records(
+    client: Any,
+    entity: Any,
+    *,
+    since: Optional[dt.datetime],
+    until: Optional[dt.datetime],
+    min_id: int = 0,
+    media_root: Optional[Path] = None,
+    media_max_bytes: Optional[int] = None,
+    transcribe_engine: Optional[str] = None,
+    include_raw: bool = True,
+    progress_every: int = 200,
+    people: Optional[dict] = None,
+) -> AsyncIterator[dict]:
+    """Yield chat history oldest-first as plain dicts ready for JSONL.
+
+    ``people``, when given, is filled with every sender id seen -> display
+    name, so the caller can write a participant map next to the messages.
+    """
+    anchor = await _anchor_min_id(client, entity, since)
+    floor = max(min_id, anchor)
+    count = 0
+    if people is None:
+        people = {}
+    # Imported here, not at module scope: telegram_mcp.transcription pulls in
+    # runtime, which reads the API credentials at import time.
+    from telegram_mcp import transcription
+
+    iterator = client.iter_messages(entity, reverse=True, min_id=floor)
+    while True:
+        try:
+            message = await iterator.__anext__()
+        except StopAsyncIteration:
+            break
+        except FloodWaitError as exc:
+            log(f"  … Telegram asked to wait {exc.seconds}s (flood limit); sleeping.")
+            import asyncio
+
+            await asyncio.sleep(exc.seconds + 1)
+            continue
+
+        if until is not None and message.date and message.date > until:
+            break
+
+        sender = getattr(message, "sender", None)
+        sender_id = getattr(message, "sender_id", None)
+        sender_name = display_name(sender)
+        if sender_id and sender_name:
+            people[sender_id] = sender_name
+
+        record: dict[str, Any] = {
+            "id": message.id,
+            "date": message.date,
+            "edit_date": getattr(message, "edit_date", None),
+            "from_id": sender_id,
+            "from_name": sender_name,
+            "from_username": getattr(sender, "username", None),
+            "outgoing": bool(getattr(message, "out", False)),
+            "text": message.message or "",
+            "entities": entities_to_json(getattr(message, "entities", None)),
+            "reply": _reply(message),
+            "forward": _forward(message),
+            "via_bot_id": getattr(message, "via_bot_id", None),
+            "reactions": _reactions(message),
+            "views": getattr(message, "views", None),
+            "pinned": bool(getattr(message, "pinned", False)),
+            "service": _service(message),
+            "media": None,
+            "transcript": None,
+        }
+
+        kind = media_mod.classify(message)
+        if kind:
+            info = media_mod.describe(message, kind)
+            if media_root is not None:
+                info = await media_mod.download(client, message, info, media_root, media_max_bytes)
+            record["media"] = info
+
+        if transcribe_engine and transcription.is_transcribable(message):
+            result = await transcription.transcribe(client, entity, message, transcribe_engine)
+            if result.get("status") == "ok":
+                record["transcript"] = {
+                    "text": result["text"],
+                    "engine": transcribe_engine,
+                    "lang": result.get("lang"),
+                    "duration": transcription.voice_duration(message),
+                }
+            else:
+                record["transcript"] = {
+                    "text": None,
+                    "engine": transcribe_engine,
+                    "error": result.get("error") or result.get("status"),
+                    "duration": transcription.voice_duration(message),
+                }
+
+        if include_raw:
+            record["raw"] = message.to_dict()
+
+        count += 1
+        if progress_every and count % progress_every == 0:
+            stamp = message.date.strftime("%Y-%m-%d") if message.date else "?"
+            log(f"  … {count} messages (at {stamp})")
+
+        yield record

--- a/telegram_mcp/export/media.py
+++ b/telegram_mcp/export/media.py
@@ -25,6 +25,14 @@ def classify(message: Any) -> Optional[str]:
     """The message's media kind, or None for a text-only message."""
     if getattr(message, "media", None) is None:
         return None
+    # A link preview is the sender's link, not the chat's media, and Telegram
+    # Desktop does not save it either. This has to be tested before anything
+    # else: Telethon exposes a preview's own photo and document through
+    # `.photo` and `.document`, so checked further down it never matches - a
+    # preview of a video link comes out classified as a photo and the export
+    # downloads the whole linked video under a `.jpg` name.
+    if getattr(message, "web_preview", None) is not None:
+        return None
     if getattr(message, "photo", None) is not None:
         return "photo"
     if getattr(message, "voice", None) is not None:
@@ -43,8 +51,6 @@ def classify(message: Any) -> Optional[str]:
         return "contact"
     if getattr(message, "document", None) is not None:
         return "document"
-    if getattr(message, "web_preview", None) is not None:
-        return None
     return "other"
 
 
@@ -81,6 +87,24 @@ def target_path(root: Path, message: Any, info: dict) -> Path:
     return root / subdir / f"{message.id:08d}_{stem}{ext}"
 
 
+class _TooLarge(Exception):
+    """Raised from the download's progress callback to stop it mid-flight."""
+
+    def __init__(self, received: int) -> None:
+        super().__init__(received)
+        self.received = received
+
+
+def _discard(path: Path) -> None:
+    """Remove a partial or oversized download. Left on disk it is worse than
+    nothing: the resume path sees a non-empty file and takes it for the media.
+    """
+    try:
+        path.unlink()
+    except OSError:
+        pass
+
+
 async def download(
     client: Any, message: Any, info: dict, root: Path, max_bytes: Optional[int]
 ) -> dict:
@@ -94,14 +118,41 @@ async def download(
         info["file"] = str(path.relative_to(root.parent))
         return info
     path.parent.mkdir(parents=True, exist_ok=True)
+
+    # The declared size is a hint, not a promise - a photo can report one of
+    # its thumbnails and still pull tens of megabytes. So the limit is enforced
+    # again on the bytes as they arrive, and once more on the finished file for
+    # the downloads that never report progress. Without that, the limit is
+    # advisory and one message can spend the whole export's disk budget.
+    def _guard(received: int, total: int) -> None:
+        if received > max_bytes:
+            raise _TooLarge(received)
+
     try:
-        saved = await client.download_media(message, file=str(path))
+        saved = await client.download_media(
+            message, file=str(path), progress_callback=_guard if max_bytes else None
+        )
+    except _TooLarge as exc:
+        _discard(path)
+        info["skipped"] = f"larger than limit (over {human_size(exc.received)})"
+        return info
     except Exception as exc:  # network, revoked file reference, deleted media
+        _discard(path)
         info["skipped"] = f"download failed: {exc}"
         log(f"  ! media for message {message.id}: {exc}")
         return info
     if not saved:
         info["skipped"] = "nothing to download"
         return info
-    info["file"] = str(Path(saved).relative_to(root.parent))
+    saved_path = Path(saved)
+    if max_bytes:
+        try:
+            actual = saved_path.stat().st_size
+        except OSError:
+            actual = 0
+        if actual > max_bytes:
+            _discard(saved_path)
+            info["skipped"] = f"larger than limit ({human_size(actual)})"
+            return info
+    info["file"] = str(saved_path.relative_to(root.parent))
     return info

--- a/telegram_mcp/export/media.py
+++ b/telegram_mcp/export/media.py
@@ -1,0 +1,107 @@
+"""Media classification and download, laid out the way Telegram Desktop does it."""
+
+from pathlib import Path
+from typing import Any, Optional
+
+from .util import human_size, log, safe_name
+
+# kind -> subdirectory, mirroring a Telegram Desktop export so the folders are
+# familiar to anyone who has ever exported a chat from the client.
+_DIRS = {
+    "photo": "photos",
+    "video": "video_files",
+    "voice": "voice_messages",
+    "round": "round_video_messages",
+    "sticker": "stickers",
+    "animation": "animations",
+    "audio": "audio_files",
+    "document": "files",
+    "contact": "files",
+    "other": "files",
+}
+
+
+def classify(message: Any) -> Optional[str]:
+    """The message's media kind, or None for a text-only message."""
+    if getattr(message, "media", None) is None:
+        return None
+    if getattr(message, "photo", None) is not None:
+        return "photo"
+    if getattr(message, "voice", None) is not None:
+        return "voice"
+    if getattr(message, "video_note", None) is not None:
+        return "round"
+    if getattr(message, "sticker", None) is not None:
+        return "sticker"
+    if getattr(message, "gif", None) is not None:
+        return "animation"
+    if getattr(message, "video", None) is not None:
+        return "video"
+    if getattr(message, "audio", None) is not None:
+        return "audio"
+    if getattr(message, "contact", None) is not None:
+        return "contact"
+    if getattr(message, "document", None) is not None:
+        return "document"
+    if getattr(message, "web_preview", None) is not None:
+        return None
+    return "other"
+
+
+def describe(message: Any, kind: str) -> dict:
+    """Media metadata that survives even when the bytes are not downloaded."""
+    file_attr = getattr(message, "file", None)
+    info: dict[str, Any] = {
+        "kind": kind,
+        "mime": getattr(file_attr, "mime_type", None),
+        "size": getattr(file_attr, "size", None),
+        "name": getattr(file_attr, "name", None),
+        "ext": getattr(file_attr, "ext", None),
+        "duration": getattr(file_attr, "duration", None),
+        "width": getattr(file_attr, "width", None),
+        "height": getattr(file_attr, "height", None),
+        "file": None,
+        "skipped": None,
+    }
+    sticker_emoji = getattr(getattr(message, "sticker", None), "id", None)
+    if sticker_emoji is not None:
+        info["sticker_id"] = str(sticker_emoji)
+    return info
+
+
+def target_path(root: Path, message: Any, info: dict) -> Path:
+    subdir = _DIRS.get(info["kind"], "files")
+    ext = info.get("ext") or ""
+    name = info.get("name")
+    if name:
+        stem = safe_name(Path(name).stem, limit=40)
+        ext = Path(name).suffix or ext
+    else:
+        stem = info["kind"]
+    return root / subdir / f"{message.id:08d}_{stem}{ext}"
+
+
+async def download(
+    client: Any, message: Any, info: dict, root: Path, max_bytes: Optional[int]
+) -> dict:
+    """Download the message's media into ``root``; annotate ``info`` in place."""
+    size = info.get("size")
+    if max_bytes and size and size > max_bytes:
+        info["skipped"] = f"larger than limit ({human_size(size)})"
+        return info
+    path = target_path(root, message, info)
+    if path.exists() and path.stat().st_size > 0:
+        info["file"] = str(path.relative_to(root.parent))
+        return info
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        saved = await client.download_media(message, file=str(path))
+    except Exception as exc:  # network, revoked file reference, deleted media
+        info["skipped"] = f"download failed: {exc}"
+        log(f"  ! media for message {message.id}: {exc}")
+        return info
+    if not saved:
+        info["skipped"] = "nothing to download"
+        return info
+    info["file"] = str(Path(saved).relative_to(root.parent))
+    return info

--- a/telegram_mcp/export/media.py
+++ b/telegram_mcp/export/media.py
@@ -3,6 +3,8 @@
 from pathlib import Path
 from typing import Any, Optional
 
+from telethon.tl import types as tl_types
+
 from .util import human_size, log, safe_name
 
 # kind -> subdirectory, mirroring a Telegram Desktop export so the folders are
@@ -31,7 +33,12 @@ def classify(message: Any) -> Optional[str]:
     # `.photo` and `.document`, so checked further down it never matches - a
     # preview of a video link comes out classified as a photo and the export
     # downloads the whole linked video under a `.jpg` name.
-    if getattr(message, "web_preview", None) is not None:
+    #
+    # Tested on the media type rather than on `.web_preview`, which is None for
+    # a preview Telegram has not resolved yet (WebPageEmpty, WebPagePending).
+    # Those fall through to "other" and put a media note on a message that is
+    # nothing but text.
+    if isinstance(getattr(message, "media", None), tl_types.MessageMediaWebPage):
         return None
     if getattr(message, "photo", None) is not None:
         return "photo"

--- a/telegram_mcp/export/render.py
+++ b/telegram_mcp/export/render.py
@@ -1,0 +1,423 @@
+"""Renderers. Every format is produced from the JSONL, never from the network.
+
+That split is deliberate: a re-render after a change of mind costs nothing and
+touches no Telegram API, and the JSONL stays the one artifact that has to be
+right.
+"""
+
+import datetime as dt
+import html
+import json
+from pathlib import Path
+from string import Template
+from typing import Iterator, Optional
+
+from .entities import to_html, to_markdown
+from .util import format_duration, human_size, log
+
+PAGE_SIZE = 3000
+
+# Telegram Desktop assigns each participant one of a small palette; the same
+# trick keeps long group exports readable.
+_PALETTE = ["#c03d33", "#4fad2d", "#d09306", "#168acd", "#8544d6", "#cd4073", "#2996ad", "#ce671b"]
+
+
+def read_records(path: Path) -> Iterator[dict]:
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if line:
+                yield json.loads(line)
+
+
+def _parse_date(value: Optional[str]) -> Optional[dt.datetime]:
+    if not value:
+        return None
+    try:
+        return dt.datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _colour(sender_id: Optional[int]) -> str:
+    if sender_id is None:
+        return "#707579"
+    return _PALETTE[abs(int(sender_id)) % len(_PALETTE)]
+
+
+def _initials(name: Optional[str]) -> str:
+    if not name:
+        return "?"
+    parts = [p for p in name.split() if p]
+    if not parts:
+        return "?"
+    if len(parts) == 1:
+        return parts[0][:1].upper()
+    return (parts[0][:1] + parts[1][:1]).upper()
+
+
+def _sender_label(record: dict) -> str:
+    if record.get("from_name"):
+        return record["from_name"]
+    if record.get("outgoing"):
+        return "You"
+    if record.get("from_id"):
+        return f"id{record['from_id']}"
+    return "Unknown"
+
+
+def _service_text(record: dict) -> str:
+    service = record.get("service") or {}
+    action = service.get("action", "Service message")
+    label = action.replace("MessageAction", "")
+    title = service.get("title")
+    return f"{label}: {title}" if title else label
+
+
+# --------------------------------------------------------------------------
+# HTML
+# --------------------------------------------------------------------------
+
+_HTML_PAGE = Template("""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>$title</title>
+<style>
+  :root { color-scheme: light; }
+  body { margin: 0; background: #e6ebee; font: 15px/1.45 -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; color: #000; }
+  .wrap { max-width: 780px; margin: 0 auto; padding: 16px 12px 64px; }
+  .chat-header { background: #fff; border-radius: 10px; padding: 16px 20px; margin-bottom: 16px; box-shadow: 0 1px 2px rgba(16,35,47,.12); }
+  .chat-header h1 { font-size: 20px; margin: 0 0 6px; }
+  .chat-header .meta { color: #6d7883; font-size: 13px; }
+  .divider { text-align: center; margin: 18px 0 12px; }
+  .divider span { background: rgba(0,0,0,.16); color: #fff; border-radius: 12px; padding: 3px 12px; font-size: 12px; }
+  .service { text-align: center; margin: 10px 0; }
+  .service span { background: rgba(0,0,0,.1); color: #43484d; border-radius: 12px; padding: 3px 12px; font-size: 12px; }
+  .msg { display: flex; gap: 10px; margin: 2px 0; padding: 4px 0; }
+  .msg.joined .avatar { visibility: hidden; }
+  .msg.joined .name { display: none; }
+  .avatar { flex: 0 0 42px; width: 42px; height: 42px; border-radius: 50%; color: #fff; display: flex; align-items: center; justify-content: center; font-size: 15px; font-weight: 600; }
+  .body { background: #fff; border-radius: 10px; padding: 8px 12px; box-shadow: 0 1px 1px rgba(16,35,47,.10); min-width: 0; max-width: 640px; }
+  .msg.out .body { background: #eeffde; }
+  .name { font-weight: 600; margin-bottom: 2px; }
+  .text { white-space: pre-wrap; overflow-wrap: anywhere; }
+  .time { color: #a1aab3; font-size: 12px; margin-top: 4px; }
+  .fwd, .reply { border-left: 2px solid #3390ec; padding: 2px 0 2px 8px; margin-bottom: 6px; font-size: 13px; color: #4b5a68; }
+  .reply a { color: #3390ec; text-decoration: none; }
+  .media img, .media video { max-width: 100%; border-radius: 6px; display: block; margin: 6px 0; }
+  .filechip { display: inline-block; background: #f1f3f5; border-radius: 6px; padding: 6px 10px; margin: 6px 0; font-size: 13px; color: #43484d; }
+  .filechip a { color: #3390ec; text-decoration: none; }
+  .transcript { background: #f6f7f8; border-radius: 6px; padding: 6px 8px; margin: 6px 0; font-size: 13px; color: #43484d; }
+  .transcript .src { color: #8b96a0; font-size: 11px; display: block; margin-top: 3px; }
+  .reactions { margin-top: 5px; font-size: 12px; color: #6d7883; }
+  .reactions span { background: #f1f3f5; border-radius: 10px; padding: 2px 7px; margin-right: 4px; display: inline-block; }
+  .spoiler { background: #b6bcc2; border-radius: 3px; color: transparent; }
+  .spoiler:hover { background: transparent; color: inherit; }
+  blockquote { border-left: 3px solid #c4c9ce; margin: 4px 0; padding-left: 8px; color: #43484d; }
+  pre { background: #f1f3f5; padding: 8px; border-radius: 6px; overflow-x: auto; }
+  code { background: #f1f3f5; border-radius: 3px; padding: 1px 4px; }
+  .nav { text-align: center; margin: 22px 0 0; font-size: 14px; }
+  .nav a { color: #3390ec; text-decoration: none; margin: 0 8px; }
+  .edited { color: #a1aab3; font-size: 12px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+<div class="chat-header">
+  <h1>$title</h1>
+  <div class="meta">$meta</div>
+</div>
+$content
+<div class="nav">$nav</div>
+</div>
+</body>
+</html>
+""")
+
+
+def _media_html(record: dict) -> str:
+    info = record.get("media")
+    if not info:
+        return ""
+    kind = info.get("kind")
+    path = info.get("file")
+    label = info.get("name") or kind
+    size = human_size(info.get("size"))
+    if path:
+        src = html.escape(path, quote=True)
+        if kind in ("photo", "sticker"):
+            return f'<div class="media"><img src="{src}" alt="{html.escape(str(label))}" loading="lazy"></div>'
+        if kind in ("video", "animation", "round"):
+            return f'<div class="media"><video src="{src}" controls preload="none"></video></div>'
+        if kind in ("voice", "audio"):
+            duration = format_duration(info.get("duration"))
+            return (
+                f'<div class="media"><audio src="{src}" controls preload="none"></audio>'
+                f'<div class="filechip">{html.escape(str(kind))} {duration}</div></div>'
+            )
+        return (
+            f'<div class="filechip">📎 <a href="{src}">{html.escape(str(label))}</a> '
+            f"<span>{size}</span></div>"
+        )
+    note = info.get("skipped") or "not downloaded"
+    duration = f" {format_duration(info['duration'])}" if info.get("duration") else ""
+    return (
+        f'<div class="filechip">📎 {html.escape(str(kind))}{duration} · {size} '
+        f"· <em>{html.escape(str(note))}</em></div>"
+    )
+
+
+def _transcript_html(record: dict) -> str:
+    transcript = record.get("transcript")
+    if not transcript:
+        return ""
+    if transcript.get("text"):
+        engine = html.escape(str(transcript.get("engine") or "?"))
+        return (
+            f'<div class="transcript">{html.escape(transcript["text"])}'
+            f'<span class="src">machine transcript · engine: {engine} · not a verbatim quote</span></div>'
+        )
+    error = html.escape(str(transcript.get("error") or "failed"))
+    return f'<div class="transcript"><em>transcription failed: {error}</em></div>'
+
+
+def _message_html(record: dict, joined: bool, name_by_id: dict) -> str:
+    if record.get("service"):
+        return f'<div class="service"><span>{html.escape(_service_text(record))}</span></div>'
+
+    sender = _sender_label(record)
+    colour = _colour(record.get("from_id"))
+    stamp = _parse_date(record.get("date"))
+    time_text = stamp.strftime("%H:%M") if stamp else ""
+    classes = ["msg"]
+    if record.get("outgoing"):
+        classes.append("out")
+    if joined:
+        classes.append("joined")
+
+    pieces = [
+        f'<div class="{" ".join(classes)}" id="msg{record["id"]}">',
+        f'<div class="avatar" style="background:{colour}">{html.escape(_initials(sender))}</div>',
+        '<div class="body">',
+        f'<div class="name" style="color:{colour}">{html.escape(sender)}</div>',
+    ]
+
+    forward = record.get("forward")
+    if forward:
+        origin = forward.get("from_name") or (
+            f"id{forward['from_id']}" if forward.get("from_id") else "unknown"
+        )
+        pieces.append(f'<div class="fwd">Forwarded from {html.escape(str(origin))}</div>')
+
+    reply = record.get("reply")
+    if reply and reply.get("reply_to_msg_id"):
+        target = reply["reply_to_msg_id"]
+        who = name_by_id.get(target)
+        label = f"In reply to {html.escape(who)}" if who else "In reply to a message"
+        pieces.append(f'<div class="reply"><a href="#msg{target}">{label}</a></div>')
+
+    pieces.append(_media_html(record))
+    pieces.append(_transcript_html(record))
+
+    body = to_html(record.get("text"), record.get("entities"))
+    if body:
+        pieces.append(f'<div class="text">{body}</div>')
+
+    reactions = record.get("reactions") or []
+    if reactions:
+        chips = "".join(
+            f'<span>{html.escape(str(r.get("reaction")))} {r.get("count")}</span>'
+            for r in reactions
+        )
+        pieces.append(f'<div class="reactions">{chips}</div>')
+
+    edited = ' <span class="edited">edited</span>' if record.get("edit_date") else ""
+    pieces.append(f'<div class="time">{time_text}{edited}</div>')
+    pieces.append("</div></div>")
+    return "".join(pieces)
+
+
+def render_html(export_dir: Path, meta: dict, page_size: int = PAGE_SIZE) -> list[Path]:
+    """Write messages.html (+ messages2.html, …) next to the JSONL."""
+    source = export_dir / "messages.jsonl"
+    records = list(read_records(source))
+    name_by_id = {r["id"]: _sender_label(r) for r in records}
+
+    pages = [records[i : i + page_size] for i in range(0, len(records), page_size)] or [[]]
+    written: list[Path] = []
+
+    for index, page in enumerate(pages, start=1):
+        chunks: list[str] = []
+        previous_day = None
+        previous_sender = None
+        previous_stamp = None
+        for record in page:
+            stamp = _parse_date(record.get("date"))
+            day = stamp.date() if stamp else None
+            if day != previous_day:
+                label = day.strftime("%d %B %Y") if day else "Unknown date"
+                chunks.append(f'<div class="divider"><span>{label}</span></div>')
+                previous_day = day
+                previous_sender = None
+            sender_id = record.get("from_id")
+            gap = None
+            if stamp and previous_stamp:
+                gap = (stamp - previous_stamp).total_seconds()
+            joined = (
+                not record.get("service")
+                and sender_id is not None
+                and sender_id == previous_sender
+                and gap is not None
+                and gap < 300
+            )
+            chunks.append(_message_html(record, joined, name_by_id))
+            previous_sender = None if record.get("service") else sender_id
+            previous_stamp = stamp
+
+        nav_parts = []
+        if index > 1:
+            previous_name = "messages.html" if index == 2 else f"messages{index - 1}.html"
+            nav_parts.append(f'<a href="{previous_name}">← previous</a>')
+        nav_parts.append(f"page {index} of {len(pages)}")
+        if index < len(pages):
+            nav_parts.append(f'<a href="messages{index + 1}.html">next →</a>')
+
+        title = meta.get("chat", {}).get("title") or "Telegram chat"
+        window = meta.get("window", {})
+        meta_line = " · ".join(
+            part
+            for part in [
+                meta.get("chat", {}).get("type"),
+                f"@{meta['chat']['username']}" if meta.get("chat", {}).get("username") else None,
+                f"id {meta.get('chat', {}).get('id')}",
+                f"{meta.get('message_count', 0)} messages",
+                f"{window.get('first') or '?'} … {window.get('last') or '?'}",
+            ]
+            if part
+        )
+        page_html = _HTML_PAGE.substitute(
+            title=html.escape(title),
+            meta=html.escape(meta_line),
+            content="\n".join(chunks) or "<p>No messages in this window.</p>",
+            nav=" ".join(nav_parts),
+        )
+        name = "messages.html" if index == 1 else f"messages{index}.html"
+        path = export_dir / name
+        path.write_text(page_html, encoding="utf-8")
+        written.append(path)
+
+    log(f"  html: {len(written)} page(s)")
+    return written
+
+
+# --------------------------------------------------------------------------
+# Markdown / plain text
+# --------------------------------------------------------------------------
+
+
+def _media_note(record: dict) -> str:
+    info = record.get("media")
+    if not info:
+        return ""
+    bits = [info.get("kind") or "media"]
+    if info.get("duration"):
+        bits.append(format_duration(info["duration"]))
+    if info.get("name"):
+        bits.append(info["name"])
+    if info.get("size"):
+        bits.append(human_size(info["size"]))
+    label = " · ".join(str(b) for b in bits)
+    if info.get("file"):
+        return f"[{label}]({info['file']})"
+    return f"[{label} · not downloaded]"
+
+
+def render_markdown(export_dir: Path, meta: dict) -> Path:
+    source = export_dir / "messages.jsonl"
+    chat = meta.get("chat", {})
+    lines = [f"# {chat.get('title') or 'Telegram chat'}", ""]
+    window = meta.get("window", {})
+    lines.append(
+        f"*{chat.get('type')} · id `{chat.get('id')}` · {meta.get('message_count', 0)} messages · "
+        f"{window.get('first') or '?'} … {window.get('last') or '?'}*"
+    )
+    lines.append("")
+
+    previous_day = None
+    for record in read_records(source):
+        stamp = _parse_date(record.get("date"))
+        day = stamp.date() if stamp else None
+        if day != previous_day:
+            lines.extend(["", f"## {day.isoformat() if day else 'unknown date'}", ""])
+            previous_day = day
+        if record.get("service"):
+            lines.append(f"*{_service_text(record)}*")
+            lines.append("")
+            continue
+        time_text = stamp.strftime("%H:%M") if stamp else "--:--"
+        lines.append(f"**{time_text} {_sender_label(record)}**")
+        forward = record.get("forward")
+        if forward:
+            lines.append(f"> forwarded from {forward.get('from_name') or forward.get('from_id')}")
+        reply = record.get("reply")
+        if reply and reply.get("reply_to_msg_id"):
+            lines.append(f"> in reply to message {reply['reply_to_msg_id']}")
+        note = _media_note(record)
+        if note:
+            lines.append(note)
+        transcript = record.get("transcript")
+        if transcript and transcript.get("text"):
+            lines.append(f"> transcript ({transcript.get('engine')}): {transcript['text']}")
+        body = to_markdown(record.get("text"), record.get("entities"))
+        if body:
+            lines.append(body)
+        reactions = record.get("reactions") or []
+        if reactions:
+            lines.append("· " + "  ".join(f"{r['reaction']} {r['count']}" for r in reactions))
+        lines.append("")
+
+    path = export_dir / "messages.md"
+    path.write_text("\n".join(lines), encoding="utf-8")
+    log("  markdown: messages.md")
+    return path
+
+
+def render_text(export_dir: Path, meta: dict) -> Path:
+    source = export_dir / "messages.jsonl"
+    lines: list[str] = []
+    for record in read_records(source):
+        stamp = _parse_date(record.get("date"))
+        time_text = stamp.strftime("%d.%m.%Y %H:%M") if stamp else "?"
+        if record.get("service"):
+            lines.append(f"[{time_text}] -- {_service_text(record)}")
+            lines.append("")
+            continue
+        lines.append(f"{_sender_label(record)}, [{time_text}]")
+        note = _media_note(record)
+        if note:
+            lines.append(note)
+        transcript = record.get("transcript")
+        if transcript and transcript.get("text"):
+            lines.append(f"(transcript, {transcript.get('engine')}): {transcript['text']}")
+        if record.get("text"):
+            lines.append(record["text"])
+        lines.append("")
+    path = export_dir / "messages.txt"
+    path.write_text("\n".join(lines), encoding="utf-8")
+    log("  text: messages.txt")
+    return path
+
+
+RENDERERS = {"html": render_html, "md": render_markdown, "txt": render_text}
+
+
+def render(export_dir: Path, meta: dict, formats: list[str]) -> None:
+    for name in formats:
+        if name == "jsonl":
+            continue
+        renderer = RENDERERS.get(name)
+        if renderer is None:
+            raise SystemExit(f"Unknown format '{name}'. Known: jsonl, html, md, txt.")
+        renderer(export_dir, meta)

--- a/telegram_mcp/export/session.py
+++ b/telegram_mcp/export/session.py
@@ -1,0 +1,107 @@
+"""Client and session handling for the export CLI.
+
+The export runs on an operator's machine while the MCP server usually runs
+elsewhere against the same account. Telegram revokes an auth key used from two
+places at once (``AuthKeyDuplicatedError``), which would take the server down,
+so this module refuses to touch any session string it finds in the environment
+and authorises as its own device instead. Extra interchangeable sessions for
+the same account are what ``session_string_generator.py`` and the
+``TELEGRAM_SESSION_STRINGS`` pool are for; export stays out of that pool on
+purpose, because a pool slot is claimed per process on one host.
+"""
+
+import os
+import sys
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Optional
+
+from telethon import TelegramClient
+
+from .util import log
+
+# The server's session strings are frequently present in a shared environment
+# (a .env file, or a secrets-manager `run` wrapper). Dropping them is the guard.
+_FORBIDDEN_ENV = (
+    "TELEGRAM_SESSION_STRING",
+    "TELEGRAM_SESSION_STRINGS",
+    "TELEGRAM_SESSION_STRING_PERSONAL",
+)
+
+PROXY_LABEL = "export"
+
+
+def session_path(explicit: Optional[str] = None) -> Path:
+    if explicit:
+        path = Path(explicit).expanduser()
+    else:
+        base = Path(os.getenv("XDG_CONFIG_HOME", "~/.config")).expanduser() / "telegram-mcp"
+        path = base / "export.session"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(path.parent, 0o700)
+    except OSError:
+        pass
+    return path
+
+
+def _check_credentials() -> None:
+    """Fail with a readable message before ``runtime`` casts the id to int."""
+    api_id = os.getenv("TELEGRAM_API_ID", "").strip()
+    api_hash = os.getenv("TELEGRAM_API_HASH", "").strip()
+    if not api_id or not api_hash:
+        raise SystemExit(
+            "TELEGRAM_API_ID / TELEGRAM_API_HASH are not set. Put them in .env "
+            "next to the repo, export them, or run this command through your "
+            "secrets manager."
+        )
+    if not api_id.isdigit():
+        raise SystemExit(f"TELEGRAM_API_ID must be an integer, got '{api_id}'.")
+
+
+def build_client(session: Optional[str] = None) -> TelegramClient:
+    """A client on this tool's own session, built the way the rest of the
+    package builds clients (device identity and proxy support included)."""
+    for name in _FORBIDDEN_ENV:
+        if os.environ.pop(name, None):
+            log(f"note: ignoring {name} from the environment - export uses its own session.")
+    _check_credentials()
+
+    # Imported here, not at module import: runtime pulls in the MCP server and
+    # reads the credentials at import time, and the message above is friendlier
+    # than the TypeError that would raise.
+    from telegram_mcp import runtime
+
+    path = session_path(session)
+    client = runtime._build_client(str(path.with_suffix("")), PROXY_LABEL)
+    # Telethon sleeps through floods under this threshold by itself; anything
+    # longer is surfaced instead of stalling a long export for hours.
+    client.flood_sleep_threshold = 900
+    return client
+
+
+@asynccontextmanager
+async def connected(client: TelegramClient):
+    """Connect without authorising.
+
+    Telethon's own ``async with client`` calls ``start()``, which prompts for a
+    phone number as soon as the session is not authorised - that turns every
+    non-interactive command into a hang on a pipe. Connecting explicitly keeps
+    the "are we logged in?" decision in :func:`ensure_authorised`.
+    """
+    await client.connect()
+    try:
+        yield client
+    finally:
+        await client.disconnect()
+
+
+async def ensure_authorised(client: TelegramClient, interactive: bool) -> None:
+    if await client.is_user_authorized():
+        return
+    if not interactive or not sys.stdin.isatty():
+        raise SystemExit(
+            "Not logged in. Run 'telegram-mcp-export login' in an interactive terminal first."
+        )
+    log("Authorising a NEW Telegram device; existing sessions stay untouched.")
+    await client.start()

--- a/telegram_mcp/export/session.py
+++ b/telegram_mcp/export/session.py
@@ -18,6 +18,8 @@ from typing import Optional
 
 from telethon import TelegramClient
 
+from telegram_mcp import client_factory
+
 from .util import log
 
 # The server's session strings are frequently present in a shared environment
@@ -67,13 +69,8 @@ def build_client(session: Optional[str] = None) -> TelegramClient:
             log(f"note: ignoring {name} from the environment - export uses its own session.")
     _check_credentials()
 
-    # Imported here, not at module import: runtime pulls in the MCP server and
-    # reads the credentials at import time, and the message above is friendlier
-    # than the TypeError that would raise.
-    from telegram_mcp import runtime
-
     path = session_path(session)
-    client = runtime._build_client(str(path.with_suffix("")), PROXY_LABEL)
+    client = client_factory.build_client(str(path.with_suffix("")), PROXY_LABEL)
     # Telethon sleeps through floods under this threshold by itself; anything
     # longer is surfaced instead of stalling a long export for hours.
     client.flood_sleep_threshold = 900

--- a/telegram_mcp/export/util.py
+++ b/telegram_mcp/export/util.py
@@ -1,0 +1,107 @@
+"""Small shared helpers: JSON encoding, filenames, dates, progress."""
+
+import base64
+import datetime as dt
+import re
+import sys
+import unicodedata
+from typing import Any, Optional
+
+
+def json_default(obj: Any) -> Any:
+    """Make Telethon's ``to_dict()`` output JSON-serializable without loss.
+
+    Telethon returns datetimes, raw bytes (file references, access hashes) and
+    enum-ish objects. Bytes become base64 rather than a lossy repr, so a raw
+    record can still be inspected byte for byte later.
+    """
+    if isinstance(obj, (dt.datetime, dt.date)):
+        return obj.isoformat()
+    if isinstance(obj, dt.timedelta):
+        return obj.total_seconds()
+    if isinstance(obj, (bytes, bytearray, memoryview)):
+        return {"__bytes_b64__": base64.b64encode(bytes(obj)).decode("ascii")}
+    if isinstance(obj, set):
+        return sorted(obj)
+    return str(obj)
+
+
+_UNSAFE = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+
+
+def safe_name(value: str, limit: int = 60) -> str:
+    """Filesystem-safe, human-readable slug. Keeps Cyrillic and spaces."""
+    value = unicodedata.normalize("NFC", value or "")
+    value = _UNSAFE.sub("_", value)
+    value = re.sub(r"\s+", " ", value).strip(" .")
+    if len(value) > limit:
+        value = value[:limit].rstrip(" .")
+    return value or "untitled"
+
+
+def parse_date(value: str) -> dt.datetime:
+    """``YYYY-MM-DD`` or a full ISO timestamp, always returned tz-aware (UTC)."""
+    raw = value.strip()
+    try:
+        parsed = dt.datetime.fromisoformat(raw)
+    except ValueError:
+        raise SystemExit(f"Cannot parse date '{value}'. Use YYYY-MM-DD or an ISO timestamp.")
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed
+
+
+def months_ago(months: int) -> dt.datetime:
+    """Approximate month arithmetic without pulling in dateutil."""
+    now = dt.datetime.now(dt.timezone.utc)
+    year = now.year
+    month = now.month - months
+    while month <= 0:
+        month += 12
+        year -= 1
+    day = min(
+        now.day,
+        [
+            31,
+            29 if year % 4 == 0 and (year % 100 != 0 or year % 400 == 0) else 28,
+            31,
+            30,
+            31,
+            30,
+            31,
+            31,
+            30,
+            31,
+            30,
+            31,
+        ][month - 1],
+    )
+    return now.replace(year=year, month=month, day=day)
+
+
+def human_size(num: Optional[int]) -> str:
+    if num is None:
+        return "?"
+    step = 1024.0
+    value = float(num)
+    for unit in ("B", "KB", "MB", "GB"):
+        if value < step or unit == "GB":
+            return f"{value:.0f} {unit}" if unit == "B" else f"{value:.1f} {unit}"
+        value /= step
+    return f"{value:.1f} GB"
+
+
+def format_duration(seconds: Optional[int]) -> str:
+    if seconds is None:
+        return "?:??"
+    seconds = int(seconds)
+    hours, rem = divmod(seconds, 3600)
+    minutes, secs = divmod(rem, 60)
+    if hours:
+        return f"{hours}:{minutes:02d}:{secs:02d}"
+    return f"{minutes}:{secs:02d}"
+
+
+def log(message: str) -> None:
+    """Progress goes to stderr so stdout stays pipeable."""
+    print(message, file=sys.stderr, flush=True)

--- a/telegram_mcp/premium.py
+++ b/telegram_mcp/premium.py
@@ -1,0 +1,50 @@
+"""Telegram Premium gating and rich-message payloads.
+
+Split out of ``runtime`` so callers that only need the Premium checks - voice
+transcription, and anything running outside the MCP server - do not import a
+module that builds a FastMCP server and exits the process when no Telegram
+session is configured.
+"""
+
+import json
+
+from telethon import types
+
+# Parse modes that request server-side rich formatting (tables, headings,
+# formulas, collapsible sections - the June 2026 "Rich Messages" feature).
+# Sending rich messages requires Telegram Premium on the account.
+RICH_PARSE_MODES = {"rich", "rich_md", "rich_markdown", "rich_html"}
+
+
+async def account_is_premium(client) -> bool:
+    """Fresh Premium check at call time - Premium can expire or be bought anytime."""
+    me = await client.get_me()
+    return bool(getattr(me, "premium", False))
+
+
+def make_rich_input(parse_mode: str, text: str):
+    """Build the InputRichMessage payload for a rich parse mode."""
+    if parse_mode == "rich_html":
+        return types.InputRichMessageHTML(html=text)
+    return types.InputRichMessageMarkdown(markdown=text)
+
+
+def premium_required_result(action: str) -> str:
+    """Structured refusal so the agent can degrade gracefully instead of sending garbage."""
+    return json.dumps(
+        {
+            "sent": False,
+            "reason": "telegram_premium_required",
+            "detail": (
+                f"{action} with rich formatting requires Telegram Premium on this account. "
+                "Nothing was sent. Reformat without rich-only blocks (tables, headings, "
+                "formulas) and retry with parse_mode='md' or 'html'."
+            ),
+        },
+        ensure_ascii=False,
+    )
+
+
+def is_premium_rpc_error(error: Exception) -> bool:
+    """True when Telegram rejected a call because the account lacks Premium."""
+    return "PREMIUM" in getattr(error, "message", str(error)).upper()

--- a/telegram_mcp/runner.py
+++ b/telegram_mcp/runner.py
@@ -10,6 +10,7 @@ except UnsafeInstallationError as exc:
 from telethon.errors import AuthKeyDuplicatedError
 
 from telegram_mcp import runtime as _runtime
+from telegram_mcp import transcription as _transcription
 from telegram_mcp.runtime import *
 from telegram_mcp.singleton import (
     DEFAULT_GRACE_SECONDS,
@@ -191,6 +192,7 @@ async def _main() -> None:
 def main() -> None:
     _configure_allowed_roots_from_cli(sys.argv[1:])
     _runtime._apply_exposed_tools_mode()
+    _transcription.validate_transcription_config()
     asyncio.run(_main())
 
 

--- a/telegram_mcp/runtime.py
+++ b/telegram_mcp/runtime.py
@@ -56,13 +56,16 @@ except ImportError:  # pragma: no cover - Windows fallback
 from functools import wraps
 import telethon.errors.rpcerrorlist
 from sanitize import sanitize_user_content, sanitize_name, sanitize_dict, format_tool_result
+from telegram_mcp import client_factory
 from telegram_mcp.client_identity import client_identity_kwargs
-
-
-class ValidationError(Exception):
-    """Custom exception for validation errors."""
-
-    pass
+from telegram_mcp.errors import ValidationError
+from telegram_mcp.premium import (
+    RICH_PARSE_MODES,
+    account_is_premium,
+    is_premium_rpc_error,
+    make_rich_input,
+    premium_required_result,
+)
 
 
 def json_serializer(obj):
@@ -229,107 +232,15 @@ def _apply_exposed_tools_mode(server: FastMCP = mcp, mode: Optional[str] = None)
 # ---------------------------------------------------------------------------
 
 
-_PROXY_TYPES_SOCKS_HTTP = {"socks5", "socks4", "http"}
-_PROXY_TYPES_ALL = _PROXY_TYPES_SOCKS_HTTP | {"mtproxy"}
-
-
-def _get_proxy_env(name: str, label: str) -> Optional[str]:
-    """Resolve a TELEGRAM_PROXY_* env var with optional ``_<LABEL>`` suffix.
-
-    Per-account values override the unsuffixed defaults so a global proxy can
-    coexist with per-label overrides.
-    """
-    suffixed = os.getenv(f"TELEGRAM_PROXY_{name}_{label.upper()}")
-    if suffixed:
-        return suffixed
-    return os.getenv(f"TELEGRAM_PROXY_{name}") or None
-
-
-def _parse_bool_env(value: Optional[str], default: bool) -> bool:
-    if value is None:
-        return default
-    return value.strip().lower() in {"1", "true", "yes", "on"}
-
-
-def _build_proxy_for_label(label: str) -> tuple[Optional[Any], Optional[Any]]:
-    """Return ``(proxy, connection)`` kwargs for ``TelegramClient`` for a label.
-
-    Reads ``TELEGRAM_PROXY_*`` env vars (with optional ``_<LABEL>`` suffix).
-    Returns ``(None, None)`` when no proxy is configured. Raises
-    :class:`ValidationError` for malformed configuration so the server fails
-    fast instead of silently bypassing the proxy.
-    """
-    proxy_type = _get_proxy_env("TYPE", label)
-    if not proxy_type:
-        return None, None
-
-    proxy_type = proxy_type.strip().lower()
-    if proxy_type not in _PROXY_TYPES_ALL:
-        raise ValidationError(
-            f"Invalid TELEGRAM_PROXY_TYPE '{proxy_type}'. "
-            f"Expected one of: {', '.join(sorted(_PROXY_TYPES_ALL))}."
-        )
-
-    host = _get_proxy_env("HOST", label)
-    port_raw = _get_proxy_env("PORT", label)
-    if not host or not port_raw:
-        raise ValidationError(
-            "TELEGRAM_PROXY_HOST and TELEGRAM_PROXY_PORT are required when "
-            "TELEGRAM_PROXY_TYPE is set."
-        )
-    try:
-        port = int(port_raw)
-    except ValueError as exc:
-        raise ValidationError(
-            f"TELEGRAM_PROXY_PORT must be an integer, got '{port_raw}'."
-        ) from exc
-
-    if proxy_type == "mtproxy":
-        secret = _get_proxy_env("SECRET", label)
-        if not secret:
-            raise ValidationError("TELEGRAM_PROXY_SECRET is required for mtproxy.")
-        try:
-            from telethon.network import ConnectionTcpMTProxyRandomizedIntermediate
-        except ImportError as exc:  # pragma: no cover - defensive guard
-            raise ValidationError(
-                "Telethon MTProxy connection class is unavailable; upgrade telethon."
-            ) from exc
-        return (host, port, secret), ConnectionTcpMTProxyRandomizedIntermediate
-
-    # SOCKS4/SOCKS5/HTTP via python-socks (Telethon's optional dependency).
-    try:
-        import python_socks  # noqa: F401
-    except ImportError as exc:
-        raise ValidationError(
-            f"Proxy type '{proxy_type}' requires the 'python-socks' package. "
-            "Install it with `pip install python-socks` or `uv sync --extra proxy`."
-        ) from exc
-
-    proxy: dict[str, Any] = {
-        "proxy_type": proxy_type,
-        "addr": host,
-        "port": port,
-        "rdns": _parse_bool_env(_get_proxy_env("RDNS", label), default=True),
-    }
-    username = _get_proxy_env("USERNAME", label)
-    password = _get_proxy_env("PASSWORD", label)
-    if username:
-        proxy["username"] = username
-    if password:
-        proxy["password"] = password
-    return proxy, None
-
-
-def _build_client(session: Any, label: str) -> TelegramClient:
-    """Construct a ``TelegramClient`` honoring per-label proxy configuration."""
-    proxy, connection = _build_proxy_for_label(label)
-    kwargs: dict[str, Any] = {}
-    if proxy is not None:
-        kwargs["proxy"] = proxy
-    if connection is not None:
-        kwargs["connection"] = connection
-    kwargs.update(client_identity_kwargs())
-    return TelegramClient(session, TELEGRAM_API_ID, TELEGRAM_API_HASH, **kwargs)
+# Client construction lives in client_factory: it must be usable without
+# importing this module, which builds the MCP server and discovers accounts
+# as an import side effect. These aliases keep the historic names working.
+_PROXY_TYPES_SOCKS_HTTP = client_factory.PROXY_TYPES_SOCKS_HTTP
+_PROXY_TYPES_ALL = client_factory.PROXY_TYPES_ALL
+_get_proxy_env = client_factory.get_proxy_env
+_parse_bool_env = client_factory.parse_bool_env
+_build_proxy_for_label = client_factory.build_proxy_for_label
+_build_client = client_factory.build_client
 
 
 # --- Session pool ------------------------------------------------------------
@@ -871,46 +782,6 @@ def format_entity(entity) -> Dict[str, Any]:
             result["phone"] = entity.phone
 
     return result
-
-
-# Parse modes that request server-side rich formatting (tables, headings,
-# formulas, collapsible sections — the June 2026 "Rich Messages" feature).
-# Sending rich messages requires Telegram Premium on the account.
-RICH_PARSE_MODES = {"rich", "rich_md", "rich_markdown", "rich_html"}
-
-
-async def account_is_premium(client) -> bool:
-    """Fresh Premium check at call time — Premium can expire or be bought anytime."""
-    me = await client.get_me()
-    return bool(getattr(me, "premium", False))
-
-
-def make_rich_input(parse_mode: str, text: str):
-    """Build the InputRichMessage payload for a rich parse mode."""
-    if parse_mode == "rich_html":
-        return types.InputRichMessageHTML(html=text)
-    return types.InputRichMessageMarkdown(markdown=text)
-
-
-def premium_required_result(action: str) -> str:
-    """Structured refusal so the agent can degrade gracefully instead of sending garbage."""
-    return json.dumps(
-        {
-            "sent": False,
-            "reason": "telegram_premium_required",
-            "detail": (
-                f"{action} with rich formatting requires Telegram Premium on this account. "
-                "Nothing was sent. Reformat without rich-only blocks (tables, headings, "
-                "formulas) and retry with parse_mode='md' or 'html'."
-            ),
-        },
-        ensure_ascii=False,
-    )
-
-
-def is_premium_rpc_error(error: Exception) -> bool:
-    """True when Telegram rejected a call because the account lacks Premium."""
-    return "PREMIUM" in getattr(error, "message", str(error)).upper()
 
 
 _ALIASES_ENV = "TELEGRAM_ALIASES_FILE"

--- a/telegram_mcp/tools/messages.py
+++ b/telegram_mcp/tools/messages.py
@@ -1,6 +1,7 @@
 """Messages MCP tools."""
 
 from telegram_mcp.runtime import *
+from telegram_mcp import transcription
 
 # Domain used to build message permalinks. Overridable because the default is a
 # single point of failure: on 2026-07-13 the .me registry put t.me on serverHold
@@ -116,13 +117,17 @@ def get_reply_quote(msg) -> Optional[dict]:
     return quote
 
 
-def message_to_dict(msg) -> dict:
+def message_to_dict(msg, chat_id: Optional[int] = None) -> dict:
     """API-complete but compact Telethon message view (omit empty fields).
 
     The goal is for the MCP output to match the API object in completeness, rather
     than losing data such as media, albums, forwards, edits, buttons, reactions,
     and so on. All these fields are already present in the message object returned
     by the same get_messages request.
+
+    chat_id (the numeric chat this message belongs to) enables voice/video-note
+    transcript enrichment via the cache - omit it to get the old text-only
+    behavior (used by existing tests with bare fake messages).
     """
     d = {"id": msg.id, "sender": get_sender_name(msg), "date": msg.date}
 
@@ -142,6 +147,18 @@ def message_to_dict(msg) -> dict:
     media_label = get_media_label(msg)
     if media_label:
         d["media"] = media_label
+
+    if not text:
+        voice_info = transcription.voice_attachment_info(msg, chat_id)
+        if voice_info is not None:
+            if voice_info["duration"] is not None:
+                d["duration"] = voice_info["duration"]
+            if voice_info["transcript_status"] == "ready":
+                d["transcript"] = voice_info["transcript"]
+                d["transcript_source"] = voice_info["transcript_source"]
+                d["transcript_note"] = "Machine transcript, not a verbatim quote."
+            elif voice_info["transcript_status"] == "pending":
+                d["transcript_status"] = "pending"
 
     grouped_id = getattr(msg, "grouped_id", None)
     if grouped_id:
@@ -185,9 +202,9 @@ def message_to_dict(msg) -> dict:
                 uname = getattr(chat, "username", None)
                 if uname:
                     finfo["from_username"] = uname
-            chat_id = getattr(fo, "chat_id", None)
-            if chat_id is not None:
-                finfo["from_chat_id"] = chat_id
+            fwd_chat_id = getattr(fo, "chat_id", None)
+            if fwd_chat_id is not None:
+                finfo["from_chat_id"] = fwd_chat_id
             sender = getattr(fo, "sender", None)
             if sender is not None:
                 sname = " ".join(
@@ -261,8 +278,12 @@ def message_to_dict(msg) -> dict:
     return d
 
 
-def format_message_line(msg) -> str:
-    """Single-line human-readable message representation with ALL key flags."""
+def format_message_line(msg, chat_id: Optional[int] = None) -> str:
+    """Single-line human-readable message representation with ALL key flags.
+
+    chat_id enables voice/video-note transcript enrichment via the cache -
+    see message_to_dict for why it's optional.
+    """
     parts = [f"ID: {msg.id}", get_sender_info(msg), f"Date: {msg.date}"]
 
     reply_to_id = (
@@ -306,7 +327,11 @@ def format_message_line(msg) -> str:
         parts.append(engagement_info)
 
     raw = sanitize_user_content(msg.message) if getattr(msg, "message", None) else ""
-    safe_text = raw.replace("\n", "\\n") if raw else "[empty]"
+    if raw:
+        safe_text = raw.replace("\n", "\\n")
+    else:
+        voice_info = transcription.voice_attachment_info(msg, chat_id)
+        safe_text = transcription.render_voice_text(voice_info) if voice_info else "[empty]"
     return " | ".join(parts) + f" | Message: {safe_text}"
 
 
@@ -332,7 +357,9 @@ async def get_messages(
         messages = await cl.get_messages(entity, limit=page_size, add_offset=offset)
         if not messages:
             return "No messages found for this page."
-        lines = [format_message_line(msg) for msg in messages]
+        numeric_chat_id = get_marked_id(entity)
+        await transcription.prefetch_transcripts(cl, entity, numeric_chat_id, messages)
+        lines = [format_message_line(msg, numeric_chat_id) for msg in messages]
         return "\n".join(lines)
     except Exception as e:
         return log_and_format_error(
@@ -919,6 +946,9 @@ async def list_messages(
         if not messages:
             return "No messages found matching the criteria."
 
+        numeric_chat_id = get_marked_id(entity)
+        await transcription.prefetch_transcripts(cl, entity, numeric_chat_id, messages)
+
         records = []
         for msg in messages:
             record = {
@@ -934,6 +964,18 @@ async def list_messages(
             media_label = get_media_label(msg)
             if media_label:
                 record["media"] = media_label
+
+            if not getattr(msg, "message", None):
+                voice_info = transcription.voice_attachment_info(msg, numeric_chat_id)
+                if voice_info is not None:
+                    if voice_info["duration"] is not None:
+                        record["duration"] = voice_info["duration"]
+                    if voice_info["transcript_status"] == "ready":
+                        record["transcript"] = voice_info["transcript"]
+                        record["transcript_source"] = voice_info["transcript_source"]
+                        record["transcript_note"] = "Machine transcript, not a verbatim quote."
+                    elif voice_info["transcript_status"] == "pending":
+                        record["transcript_status"] = "pending"
 
             grouped_id = getattr(msg, "grouped_id", None)
             if grouped_id is not None:
@@ -952,6 +994,135 @@ async def list_messages(
         return format_tool_result(records)
     except Exception as e:
         return log_and_format_error("list_messages", e, chat_id=chat_id)
+
+
+@mcp.tool(
+    annotations=ToolAnnotations(title="Transcribe Voice", openWorldHint=True, readOnlyHint=True)
+)
+@with_account(readonly=True)
+@validate_id("chat_id")
+async def transcribe_voice(
+    chat_id: Union[int, str],
+    message_id: int,
+    engine: str = None,
+    account: str = None,
+) -> str:
+    """
+    Transcribe a voice message or video note (video circle) to text.
+
+    Two engines behind one interface:
+    - "groq" (default, override with TELEGRAM_TRANSCRIBE_ENGINE): Groq-hosted
+      whisper-large-v3-turbo. Downloads the audio and sends it to Groq - not
+      free, and leaves the server. Does not drop the recording's last words.
+    - "telegram": native Telegram Premium transcription. Free, audio never
+      leaves Telegram, but empirically drops the last speech segment in
+      roughly 2 of 3 recordings (proven with per-segment timestamps). Use for
+      chats you don't want sent to a third party, or when Groq is unavailable.
+      Requires Telegram Premium on this account; polls briefly (up to ~20s)
+      while Telegram finishes a long recording.
+
+    Results are cached by (chat_id, message_id) - a repeat call for an
+    already-transcribed message returns the cached text without hitting
+    either API again.
+
+    The returned text is a machine transcript, not a verbatim quote: proper
+    names, punctuation and occasional words drift under both engines.
+
+    Args:
+        chat_id: The chat ID or username.
+        message_id: The message ID containing the voice/video-note media.
+        engine: "groq" or "telegram". Defaults to TELEGRAM_TRANSCRIBE_ENGINE
+            (groq unless configured otherwise).
+    """
+    try:
+        mode = transcription.transcribe_mode()
+        if mode == "off":
+            return json.dumps(
+                {"transcribed": False, "reason": "transcription_disabled"}, ensure_ascii=False
+            )
+
+        cl = get_client(account)
+        entity = await resolve_entity(chat_id, cl)
+        numeric_chat_id = get_marked_id(entity)
+
+        cached = transcription.get_cached_transcript(numeric_chat_id, message_id)
+        if cached is not None:
+            return json.dumps(
+                {
+                    "transcribed": True,
+                    "cached": True,
+                    "text": cached["text"],
+                    "source": cached["source"],
+                    "duration": cached["duration"],
+                    "note": "Machine transcript, not a verbatim quote.",
+                },
+                ensure_ascii=False,
+                default=json_serializer,
+            )
+
+        msg = await cl.get_messages(entity, ids=message_id)
+        if not msg:
+            return f"Message {message_id} not found."
+        if not transcription.is_transcribable(msg):
+            return f"Message {message_id} has no voice message or video note to transcribe."
+
+        chosen_engine = (engine or transcription.default_engine()).strip().lower()
+        if chosen_engine not in transcription.ENGINES:
+            return f"Invalid engine '{engine}'. Use 'telegram' or 'groq'."
+        if chosen_engine == "groq" and not os.getenv("GROQ_API_KEY"):
+            return (
+                "GROQ_API_KEY is not configured on this server. "
+                "Use engine='telegram' or set GROQ_API_KEY."
+            )
+
+        duration = transcription.voice_duration(msg)
+        result = await transcription.transcribe(cl, entity, msg, chosen_engine)
+
+        if result["status"] == "premium_required":
+            return premium_required_result("transcribe_voice (engine='telegram')")
+        if result["status"] == "pending":
+            return json.dumps(
+                {
+                    "transcribed": False,
+                    "reason": "pending",
+                    "duration": duration,
+                    "detail": "Telegram is still processing this recording. Retry shortly.",
+                },
+                ensure_ascii=False,
+            )
+        if result["status"] == "error":
+            return log_and_format_error(
+                "transcribe_voice",
+                RuntimeError(result.get("error", "unknown error")),
+                chat_id=chat_id,
+                message_id=message_id,
+                engine=chosen_engine,
+            )
+
+        transcription.save_transcript(
+            numeric_chat_id,
+            message_id,
+            chosen_engine,
+            result["text"],
+            duration=duration,
+            lang=result.get("lang"),
+        )
+        return json.dumps(
+            {
+                "transcribed": True,
+                "cached": False,
+                "text": result["text"],
+                "source": chosen_engine,
+                "duration": duration,
+                "note": "Machine transcript, not a verbatim quote.",
+            },
+            ensure_ascii=False,
+            default=json_serializer,
+        )
+    except Exception as e:
+        return log_and_format_error(
+            "transcribe_voice", e, chat_id=chat_id, message_id=message_id, engine=engine
+        )
 
 
 @mcp.tool(
@@ -1579,7 +1750,9 @@ async def get_history(chat_id: Union[int, str], limit: int = 100, account: str =
         entity = await resolve_entity(chat_id, cl)
         messages = await cl.get_messages(entity, limit=limit)
 
-        records = [message_to_dict(msg) for msg in messages]
+        numeric_chat_id = get_marked_id(entity)
+        await transcription.prefetch_transcripts(cl, entity, numeric_chat_id, messages)
+        records = [message_to_dict(msg, numeric_chat_id) for msg in messages]
         return format_tool_result(records)
     except Exception as e:
         return log_and_format_error("get_history", e, chat_id=chat_id, limit=limit)

--- a/telegram_mcp/tools/messages.py
+++ b/telegram_mcp/tools/messages.py
@@ -1021,9 +1021,11 @@ async def transcribe_voice(
       Requires Telegram Premium on this account; polls briefly (up to ~20s)
       while Telegram finishes a long recording.
 
-    Results are cached by (chat_id, message_id) - a repeat call for an
-    already-transcribed message returns the cached text without hitting
-    either API again.
+    Results are cached per engine, by (chat_id, message_id, engine) - a
+    repeat call with the same engine returns the cached text without
+    hitting either API again. Asking for an engine that has no cached
+    result transcribes with it, even when the other engine's text is
+    already cached.
 
     The returned text is a machine transcript, not a verbatim quote: proper
     names, punctuation and occasional words drift under both engines.
@@ -1045,7 +1047,16 @@ async def transcribe_voice(
         entity = await resolve_entity(chat_id, cl)
         numeric_chat_id = get_marked_id(entity)
 
-        cached = transcription.get_cached_transcript(numeric_chat_id, message_id)
+        chosen_engine = (engine or transcription.default_engine()).strip().lower()
+        if chosen_engine not in transcription.ENGINES:
+            return f"Invalid engine '{engine}'. Use 'telegram' or 'groq'."
+
+        # Pinned to the chosen engine on purpose: a cached telegram transcript
+        # must not answer a groq request. The native engine drops the last
+        # speech segment and the loss cannot be seen in the text.
+        cached = transcription.get_cached_transcript(
+            numeric_chat_id, message_id, source=chosen_engine
+        )
         if cached is not None:
             return json.dumps(
                 {
@@ -1066,9 +1077,6 @@ async def transcribe_voice(
         if not transcription.is_transcribable(msg):
             return f"Message {message_id} has no voice message or video note to transcribe."
 
-        chosen_engine = (engine or transcription.default_engine()).strip().lower()
-        if chosen_engine not in transcription.ENGINES:
-            return f"Invalid engine '{engine}'. Use 'telegram' or 'groq'."
         if chosen_engine == "groq" and not os.getenv("GROQ_API_KEY"):
             return (
                 "GROQ_API_KEY is not configured on this server. "

--- a/telegram_mcp/transcription.py
+++ b/telegram_mcp/transcription.py
@@ -1,0 +1,436 @@
+"""Voice/video-note transcription: engines, SQLite cache, and batch budget.
+
+Two engines behind one interface (see ``transcribe``):
+
+* ``telegram`` - native Premium ``messages.transcribeAudio``. Free, but drops
+  the last speech segment in roughly 2 of 3 real recordings (proven with
+  per-segment timestamps against a local Whisper run on 2026-08-20 - see
+  ``~/Workspace/AI Playground/docs/2026-08-20-telegram-voice-transcripts.md``).
+  Async: a long recording comes back ``pending=True`` and must be polled.
+* ``groq`` - Groq-hosted ``whisper-large-v3-turbo``. Does not drop the tail,
+  but costs a download+upload per voice message and sends the audio to a
+  third party. Primary engine by owner decision (2026-08-20); ``telegram``
+  is the free/private fallback.
+
+Every transcript is a machine reading, not a verbatim quote (proper names and
+punctuation drift under both engines) - callers must surface ``source``
+alongside ``text`` rather than presenting it as exact speech.
+"""
+
+import asyncio
+import os
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import httpx
+from telethon.tl import functions
+
+from telegram_mcp.runtime import account_is_premium, get_marked_id, is_premium_rpc_error
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_TRANSCRIBE_MODES = {"off", "on-demand", "auto"}
+ENGINES = {"telegram", "groq"}
+
+GROQ_TRANSCRIBE_URL = "https://api.groq.com/openai/v1/audio/transcriptions"
+GROQ_MODEL = "whisper-large-v3-turbo"
+
+
+def transcribe_mode() -> str:
+    """``TELEGRAM_TRANSCRIBE``: off | on-demand | auto (default on-demand).
+
+    ``off`` disables the dedicated tool and all auto-mixing. ``on-demand``
+    (default) keeps the dedicated tool and fills cache hits into listings,
+    but never spends a batch call fetching a new one. ``auto`` additionally
+    prefetches missing transcripts into listings, bounded by
+    :class:`TranscribeBudget`.
+    """
+    raw = os.getenv("TELEGRAM_TRANSCRIBE", "on-demand").strip().lower()
+    if raw not in _TRANSCRIBE_MODES:
+        accepted = ", ".join(sorted(_TRANSCRIBE_MODES))
+        raise SystemExit(f"Invalid TELEGRAM_TRANSCRIBE '{raw}'. Expected one of: {accepted}.")
+    return raw
+
+
+def default_engine() -> str:
+    """``TELEGRAM_TRANSCRIBE_ENGINE``: telegram | groq (default groq).
+
+    Groq is the primary engine (owner decision 2026-08-20: native Telegram
+    transcription drops the last speech segment in ~2 of 3 recordings).
+    Override to ``telegram`` for chats that should never leave the server,
+    or when GROQ_API_KEY / quota is unavailable. Per-call ``engine=`` on
+    transcribe_voice always takes precedence over this default.
+    """
+    raw = os.getenv("TELEGRAM_TRANSCRIBE_ENGINE", "groq").strip().lower()
+    if raw not in ENGINES:
+        accepted = ", ".join(sorted(ENGINES))
+        raise SystemExit(
+            f"Invalid TELEGRAM_TRANSCRIBE_ENGINE '{raw}'. Expected one of: {accepted}."
+        )
+    return raw
+
+
+def validate_transcription_config() -> None:
+    """Fail loudly at startup on a bad toggle, matching TELEGRAM_EXPOSED_TOOLS."""
+    transcribe_mode()
+    default_engine()
+
+
+# ---------------------------------------------------------------------------
+# SQLite cache
+# ---------------------------------------------------------------------------
+#
+# This is a personal-chat transcript store in plaintext on the VPS - mode 600,
+# its own directory (not the session/app directory), mounted as a volume so a
+# rebuild doesn't silently drop it (docker-compose.yml has no volume by
+# default).
+
+
+def cache_dir() -> Path:
+    raw = os.getenv("TELEGRAM_TRANSCRIPT_CACHE_DIR", "data/transcripts")
+    d = Path(raw)
+    d.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(d, 0o700)
+    except OSError:
+        pass
+    return d
+
+
+def _cache_db_path() -> Path:
+    return cache_dir() / "transcripts.db"
+
+
+def _connect() -> sqlite3.Connection:
+    path = _cache_db_path()
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS transcripts (
+            chat_id INTEGER NOT NULL,
+            message_id INTEGER NOT NULL,
+            source TEXT NOT NULL,
+            text TEXT NOT NULL,
+            duration INTEGER,
+            lang TEXT,
+            created_at TEXT NOT NULL,
+            PRIMARY KEY (chat_id, message_id)
+        )
+        """
+    )
+    conn.commit()
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+    return conn
+
+
+def get_cached_transcript(chat_id: int, message_id: int) -> Optional[dict]:
+    conn = _connect()
+    try:
+        row = conn.execute(
+            "SELECT source, text, duration, lang, created_at FROM transcripts "
+            "WHERE chat_id = ? AND message_id = ?",
+            (chat_id, message_id),
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        return None
+    source, text, duration, lang, created_at = row
+    return {
+        "source": source,
+        "text": text,
+        "duration": duration,
+        "lang": lang,
+        "created_at": created_at,
+    }
+
+
+def save_transcript(
+    chat_id: int,
+    message_id: int,
+    source: str,
+    text: str,
+    *,
+    duration: Optional[int] = None,
+    lang: Optional[str] = None,
+) -> None:
+    conn = _connect()
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO transcripts "
+            "(chat_id, message_id, source, text, duration, lang, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                chat_id,
+                message_id,
+                source,
+                text,
+                duration,
+                lang,
+                datetime.now(timezone.utc).isoformat(),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Voice/video-note detection and formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def is_transcribable(msg) -> bool:
+    """True for voice notes and video notes (video circles) - both go through
+    the same transcribeAudio/Groq path."""
+    return getattr(msg, "voice", None) is not None or getattr(msg, "video_note", None) is not None
+
+
+def voice_duration(msg) -> Optional[int]:
+    """Seconds, from the already-fetched message - no extra API call."""
+    f = getattr(msg, "file", None)
+    if f is None:
+        return None
+    d = getattr(f, "duration", None)
+    return int(d) if d is not None else None
+
+
+def format_duration(seconds: Optional[int]) -> str:
+    if seconds is None:
+        return "?:??"
+    seconds = int(seconds)
+    hours, rem = divmod(seconds, 3600)
+    minutes, secs = divmod(rem, 60)
+    if hours:
+        return f"{hours}:{minutes:02d}:{secs:02d}"
+    return f"{minutes}:{secs:02d}"
+
+
+# ---------------------------------------------------------------------------
+# Engines
+# ---------------------------------------------------------------------------
+
+_POLL_ATTEMPTS = 10
+_POLL_INTERVAL_SECONDS = 2.0
+
+
+async def _transcribe_via_telegram(cl, entity, msg) -> dict:
+    """Native Premium transcription. Polls while pending=True - proven live on
+    2026-08-20: an 83s recording matured after 3 polls (~6.6s); without
+    polling, long voice messages come back empty."""
+    if not await account_is_premium(cl):
+        return {"status": "premium_required"}
+    peer = await cl.get_input_entity(entity)
+    try:
+        result = await cl(functions.messages.TranscribeAudioRequest(peer=peer, msg_id=msg.id))
+    except Exception as e:
+        if is_premium_rpc_error(e):
+            return {"status": "premium_required"}
+        return {"status": "error", "error": str(e)}
+
+    attempts = 0
+    while getattr(result, "pending", False) and attempts < _POLL_ATTEMPTS:
+        await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+        attempts += 1
+        try:
+            result = await cl(functions.messages.TranscribeAudioRequest(peer=peer, msg_id=msg.id))
+        except Exception as e:
+            return {"status": "error", "error": str(e)}
+
+    if getattr(result, "pending", False):
+        return {"status": "pending"}
+    return {"status": "ok", "text": result.text}
+
+
+async def _transcribe_via_groq(cl, msg) -> dict:
+    """Groq whisper-large-v3-turbo. Downloads the voice note into memory
+    (never touches disk) and deletes the bytes as soon as the request
+    returns."""
+    api_key = os.getenv("GROQ_API_KEY")
+    if not api_key:
+        return {"status": "error", "error": "GROQ_API_KEY is not configured"}
+
+    try:
+        data = await cl.download_media(msg, file=bytes)
+    except Exception as e:
+        return {"status": "error", "error": f"download failed: {e}"}
+    if not data:
+        return {"status": "error", "error": "empty media download"}
+
+    file_attr = getattr(msg, "file", None)
+    ext = (getattr(file_attr, "ext", None) or ".oga").lstrip(".")
+    mime = getattr(file_attr, "mime_type", None) or "audio/ogg"
+
+    try:
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            resp = await client.post(
+                GROQ_TRANSCRIBE_URL,
+                headers={"Authorization": f"Bearer {api_key}"},
+                data={"model": GROQ_MODEL, "response_format": "verbose_json"},
+                files={"file": (f"voice.{ext}", bytes(data), mime)},
+            )
+        resp.raise_for_status()
+        payload = resp.json()
+    except Exception as e:
+        return {"status": "error", "error": f"groq request failed: {e}"}
+    finally:
+        del data
+
+    text = (payload.get("text") or "").strip()
+    if not text:
+        return {"status": "error", "error": "empty transcript from groq"}
+    return {"status": "ok", "text": text, "lang": payload.get("language")}
+
+
+async def transcribe(cl, entity, msg, engine: str) -> dict:
+    """Dispatch to one engine. Returns a status dict:
+    {"status": "ok", "text": ..., "lang": ...} |
+    {"status": "pending"} | {"status": "premium_required"} |
+    {"status": "error", "error": ...}
+    """
+    if engine == "telegram":
+        return await _transcribe_via_telegram(cl, entity, msg)
+    if engine == "groq":
+        return await _transcribe_via_groq(cl, msg)
+    return {"status": "error", "error": f"Unknown engine '{engine}'"}
+
+
+# ---------------------------------------------------------------------------
+# Batch budget for auto-mixing (mode="auto" only)
+# ---------------------------------------------------------------------------
+#
+# Groq is not a free call like native transcription: each voice message costs
+# a download + upload. Without a budget, get_history(limit=100) on a chat with
+# a few dozen voice messages would turn into a few dozen downloads/uploads on
+# every read. See TELEGRAM_TRANSCRIBE_MAX_VOICES / _MAX_SECONDS.
+
+
+class TranscribeBudget:
+    def __init__(
+        self,
+        max_voices: Optional[int] = None,
+        max_seconds: Optional[int] = None,
+    ):
+        self.max_voices = max_voices if max_voices is not None else _max_voices_env()
+        self.max_seconds = max_seconds if max_seconds is not None else _max_seconds_env()
+        self.used_voices = 0
+        self.used_seconds = 0
+
+    def can_afford(self, duration: Optional[int]) -> bool:
+        if self.used_voices >= self.max_voices:
+            return False
+        if self.used_seconds + (duration or 0) > self.max_seconds:
+            return False
+        return True
+
+    def charge(self, duration: Optional[int]) -> None:
+        self.used_voices += 1
+        self.used_seconds += duration or 0
+
+
+def _max_voices_env() -> int:
+    try:
+        return int(os.getenv("TELEGRAM_TRANSCRIBE_MAX_VOICES", "5"))
+    except ValueError:
+        return 5
+
+
+def _max_seconds_env() -> int:
+    try:
+        return int(os.getenv("TELEGRAM_TRANSCRIBE_MAX_SECONDS", "300"))
+    except ValueError:
+        return 300
+
+
+async def prefetch_transcripts(cl, entity, chat_id: int, messages) -> None:
+    """Fill the cache for cache-miss voice/video-note messages, within budget.
+
+    Only called for TELEGRAM_TRANSCRIBE=auto. on-demand mode leaves cache
+    misses to render as "transcript pending" - callers must invoke
+    transcribe_voice explicitly to pay for them.
+    """
+    if transcribe_mode() != "auto":
+        return
+    budget = TranscribeBudget()
+    engine = default_engine()
+    for msg in messages:
+        if not is_transcribable(msg):
+            continue
+        if getattr(msg, "message", None):
+            continue  # already has text, nothing to fill
+        if get_cached_transcript(chat_id, msg.id) is not None:
+            continue
+        duration = voice_duration(msg)
+        if not budget.can_afford(duration):
+            continue
+        budget.charge(duration)
+        try:
+            result = await transcribe(cl, entity, msg, engine)
+        except Exception:
+            continue
+        if result.get("status") == "ok":
+            save_transcript(
+                chat_id,
+                msg.id,
+                engine,
+                result["text"],
+                duration=duration,
+                lang=result.get("lang"),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Render helper shared by message_to_dict / format_message_line / list_messages
+# ---------------------------------------------------------------------------
+
+
+def voice_attachment_info(msg, chat_id: Optional[int]) -> Optional[dict]:
+    """None for non-voice-like messages. Otherwise:
+    {"duration": int|None,
+     "transcript": str|None, "transcript_source": str|None,
+     "transcript_status": "ready"|"pending"|None}
+
+    transcript_status is None when transcription is off or no chat_id is
+    available (duration still fills in - it's free, already on the fetched
+    message). "pending" covers both "never attempted" (on-demand mode,
+    budget exhausted) and "attempted but Telegram is still processing" -
+    callers don't need to tell those apart, both mean "call transcribe_voice
+    later".
+    """
+    if not is_transcribable(msg):
+        return None
+    info = {
+        "duration": voice_duration(msg),
+        "transcript": None,
+        "transcript_source": None,
+        "transcript_status": None,
+    }
+    if chat_id is None or transcribe_mode() == "off":
+        return info
+    cached = get_cached_transcript(chat_id, msg.id)
+    if cached is not None:
+        info["transcript"] = cached["text"]
+        info["transcript_source"] = cached["source"]
+        info["transcript_status"] = "ready"
+    else:
+        info["transcript_status"] = "pending"
+    return info
+
+
+def render_voice_text(info: dict) -> str:
+    """`voice 0:23` / `voice 0:23 | transcript: ... (source: groq)` / with a
+    pending marker - never presented as a verbatim quote."""
+    label = f"voice {format_duration(info['duration'])}"
+    status = info["transcript_status"]
+    if status == "ready":
+        return f"{label} | transcript ({info['transcript_source']}, not verbatim): {info['transcript']}"
+    if status == "pending":
+        return f"{label} | transcript pending"
+    return label

--- a/telegram_mcp/transcription.py
+++ b/telegram_mcp/transcription.py
@@ -27,7 +27,7 @@ from typing import Optional
 import httpx
 from telethon.tl import functions
 
-from telegram_mcp.runtime import account_is_premium, get_marked_id, is_premium_rpc_error
+from telegram_mcp.premium import account_is_premium, is_premium_rpc_error
 
 # ---------------------------------------------------------------------------
 # Configuration

--- a/telegram_mcp/transcription.py
+++ b/telegram_mcp/transcription.py
@@ -118,10 +118,11 @@ def _connect() -> sqlite3.Connection:
             duration INTEGER,
             lang TEXT,
             created_at TEXT NOT NULL,
-            PRIMARY KEY (chat_id, message_id)
+            PRIMARY KEY (chat_id, message_id, source)
         )
         """
     )
+    _migrate_source_into_key(conn)
     conn.commit()
     try:
         os.chmod(path, 0o600)
@@ -130,14 +131,65 @@ def _connect() -> sqlite3.Connection:
     return conn
 
 
-def get_cached_transcript(chat_id: int, message_id: int) -> Optional[dict]:
+def _migrate_source_into_key(conn: sqlite3.Connection) -> None:
+    """Older builds keyed the cache on (chat_id, message_id) alone, so a cheap
+    telegram transcript permanently shadowed the groq one - including for
+    callers that asked for groq explicitly. Rebuild such a table in place."""
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'transcripts'"
+    ).fetchone()
+    if not row or not row[0]:
+        return
+    if "PRIMARY KEY (chat_id, message_id, source)" in row[0]:
+        return
+    conn.executescript(
+        """
+        ALTER TABLE transcripts RENAME TO transcripts_legacy;
+        CREATE TABLE transcripts (
+            chat_id INTEGER NOT NULL,
+            message_id INTEGER NOT NULL,
+            source TEXT NOT NULL,
+            text TEXT NOT NULL,
+            duration INTEGER,
+            lang TEXT,
+            created_at TEXT NOT NULL,
+            PRIMARY KEY (chat_id, message_id, source)
+        );
+        INSERT OR IGNORE INTO transcripts
+            (chat_id, message_id, source, text, duration, lang, created_at)
+        SELECT chat_id, message_id, source, text, duration, lang, created_at
+        FROM transcripts_legacy;
+        DROP TABLE transcripts_legacy;
+        """
+    )
+
+
+def get_cached_transcript(
+    chat_id: int, message_id: int, source: Optional[str] = None
+) -> Optional[dict]:
+    """Cached transcript for a message.
+
+    ``source`` pins the engine: asking for groq must never be answered with a
+    telegram transcript, because the native engine drops the recording's last
+    segment and the loss is invisible in the text. Callers that only want to
+    display whatever exists (listings, backfill skip checks) pass None and get
+    the default engine's row when there is one, any row otherwise.
+    """
     conn = _connect()
     try:
-        row = conn.execute(
-            "SELECT source, text, duration, lang, created_at FROM transcripts "
-            "WHERE chat_id = ? AND message_id = ?",
-            (chat_id, message_id),
-        ).fetchone()
+        if source is not None:
+            row = conn.execute(
+                "SELECT source, text, duration, lang, created_at FROM transcripts "
+                "WHERE chat_id = ? AND message_id = ? AND source = ?",
+                (chat_id, message_id, source),
+            ).fetchone()
+        else:
+            row = conn.execute(
+                "SELECT source, text, duration, lang, created_at FROM transcripts "
+                "WHERE chat_id = ? AND message_id = ? "
+                "ORDER BY source = ? DESC, created_at DESC LIMIT 1",
+                (chat_id, message_id, default_engine()),
+            ).fetchone()
     finally:
         conn.close()
     if row is None:

--- a/telegram_mcp/transcription.py
+++ b/telegram_mcp/transcription.py
@@ -108,8 +108,7 @@ def _cache_db_path() -> Path:
 def _connect() -> sqlite3.Connection:
     path = _cache_db_path()
     conn = sqlite3.connect(str(path))
-    conn.execute(
-        """
+    conn.execute("""
         CREATE TABLE IF NOT EXISTS transcripts (
             chat_id INTEGER NOT NULL,
             message_id INTEGER NOT NULL,
@@ -120,8 +119,7 @@ def _connect() -> sqlite3.Connection:
             created_at TEXT NOT NULL,
             PRIMARY KEY (chat_id, message_id, source)
         )
-        """
-    )
+        """)
     _migrate_source_into_key(conn)
     conn.commit()
     try:
@@ -142,8 +140,7 @@ def _migrate_source_into_key(conn: sqlite3.Connection) -> None:
         return
     if "PRIMARY KEY (chat_id, message_id, source)" in row[0]:
         return
-    conn.executescript(
-        """
+    conn.executescript("""
         ALTER TABLE transcripts RENAME TO transcripts_legacy;
         CREATE TABLE transcripts (
             chat_id INTEGER NOT NULL,
@@ -160,8 +157,7 @@ def _migrate_source_into_key(conn: sqlite3.Connection) -> None:
         SELECT chat_id, message_id, source, text, duration, lang, created_at
         FROM transcripts_legacy;
         DROP TABLE transcripts_legacy;
-        """
-    )
+        """)
 
 
 def get_cached_transcript(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,16 @@
 
 import os
 
+import pytest
+
 os.environ.setdefault("TELEGRAM_API_ID", "12345")
 os.environ.setdefault("TELEGRAM_API_HASH", "dummy_hash")
 os.environ.setdefault("TELEGRAM_SESSION_NAME", "test_session")
+
+
+@pytest.fixture
+def transcript_cache_dir(tmp_path, monkeypatch):
+    """Isolated, per-test SQLite transcript cache directory."""
+    d = tmp_path / "transcripts"
+    monkeypatch.setenv("TELEGRAM_TRANSCRIPT_CACHE_DIR", str(d))
+    return d

--- a/tests/test_export_media.py
+++ b/tests/test_export_media.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from telethon.tl import types as tl_types
 
 from telegram_mcp.export import media as media_mod
 
@@ -63,18 +64,31 @@ class _Client:
 # ---------------------------------------------------------------------------
 
 
+def _preview(webpage, **kwargs):
+    return _message(media=tl_types.MessageMediaWebPage(webpage=webpage), **kwargs)
+
+
 def test_a_link_preview_is_not_the_chats_media():
     # Telethon surfaces the preview's own photo through `.photo`, so a message
     # that is only a link looks exactly like a photo message.
-    preview = _message(web_preview=object(), photo=object())
-    assert media_mod.classify(preview) is None
+    page = tl_types.WebPageEmpty(id=0)
+    assert media_mod.classify(_preview(page, web_preview=page, photo=object())) is None
 
 
 def test_a_link_preview_of_a_video_is_not_downloaded_as_a_photo():
-    preview = _message(web_preview=object(), photo=object(), document=object())
+    page = tl_types.WebPageEmpty(id=0)
+    preview = _preview(page, web_preview=page, photo=object(), document=object())
     # The bug this pins: classified as "photo", the export downloaded the whole
     # linked video and saved 25 MB of MP4 under a .jpg name.
     assert media_mod.classify(preview) != "photo"
+
+
+def test_an_unresolved_link_preview_is_not_media_either():
+    # Telegram had not fetched the page yet, so Telethon's `.web_preview` is
+    # None. The message is still nothing but a link, and calling it "other"
+    # hangs a media note on plain text.
+    unresolved = _preview(tl_types.WebPageEmpty(id=0), web_preview=None)
+    assert media_mod.classify(unresolved) is None
 
 
 def test_a_real_photo_is_still_a_photo():

--- a/tests/test_export_media.py
+++ b/tests/test_export_media.py
@@ -1,0 +1,162 @@
+"""Tests for what the export downloads and what it refuses to download.
+
+Both of these were found by running a real export, not by reading the code:
+a chat full of links pulled the linked videos down as "photos", and the size
+limit did nothing to stop a 25 MB file because the message declared 48 KB.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from telegram_mcp.export import media as media_mod
+
+
+def _message(**kwargs):
+    """A message with every media attribute absent unless named."""
+    fields = dict(
+        id=1,
+        media=object(),
+        photo=None,
+        voice=None,
+        video_note=None,
+        sticker=None,
+        gif=None,
+        video=None,
+        audio=None,
+        contact=None,
+        document=None,
+        web_preview=None,
+        file=SimpleNamespace(mime_type=None, size=None, name=None, ext=None),
+    )
+    fields.update(kwargs)
+    return SimpleNamespace(**fields)
+
+
+class _Client:
+    """A client that writes ``payload`` and reports progress the way Telethon does."""
+
+    def __init__(self, payload: bytes, chunk: int = 1024, fail=None):
+        self.payload = payload
+        self.chunk = chunk
+        self.fail = fail
+
+    async def download_media(self, message, file, progress_callback=None):
+        if self.fail is not None:
+            Path(file).write_bytes(self.payload[: self.chunk])  # a partial file
+            raise self.fail
+        written = 0
+        with open(file, "wb") as handle:
+            for start in range(0, len(self.payload), self.chunk):
+                block = self.payload[start : start + self.chunk]
+                handle.write(block)
+                handle.flush()
+                written += len(block)
+                if progress_callback is not None:
+                    progress_callback(written, len(self.payload))
+        return file
+
+
+# ---------------------------------------------------------------------------
+# What counts as the chat's media
+# ---------------------------------------------------------------------------
+
+
+def test_a_link_preview_is_not_the_chats_media():
+    # Telethon surfaces the preview's own photo through `.photo`, so a message
+    # that is only a link looks exactly like a photo message.
+    preview = _message(web_preview=object(), photo=object())
+    assert media_mod.classify(preview) is None
+
+
+def test_a_link_preview_of_a_video_is_not_downloaded_as_a_photo():
+    preview = _message(web_preview=object(), photo=object(), document=object())
+    # The bug this pins: classified as "photo", the export downloaded the whole
+    # linked video and saved 25 MB of MP4 under a .jpg name.
+    assert media_mod.classify(preview) != "photo"
+
+
+def test_a_real_photo_is_still_a_photo():
+    assert media_mod.classify(_message(photo=object())) == "photo"
+
+
+def test_a_text_only_message_has_no_media():
+    assert media_mod.classify(_message(media=None)) is None
+
+
+# ---------------------------------------------------------------------------
+# The size limit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_media_that_understates_its_size_is_still_capped(tmp_path):
+    root = tmp_path / "export" / "media"
+    info = {"kind": "photo", "size": 48405, "ext": ".jpg", "name": None, "skipped": None}
+    client = _Client(b"x" * (5 * 1024 * 1024))
+
+    out = await media_mod.download(client, _message(), info, root, max_bytes=1024 * 1024)
+
+    assert not out.get("file")
+    assert "larger than limit" in out["skipped"]
+    # Nothing oversized is left behind pretending to be the media.
+    assert not any(p.is_file() for p in root.rglob("*"))
+
+
+@pytest.mark.asyncio
+async def test_a_download_under_the_limit_is_kept(tmp_path):
+    root = tmp_path / "export" / "media"
+    info = {"kind": "photo", "size": 2048, "ext": ".jpg", "name": None, "skipped": None}
+    client = _Client(b"x" * 2048)
+
+    out = await media_mod.download(client, _message(), info, root, max_bytes=1024 * 1024)
+
+    assert out["skipped"] is None
+    assert (root.parent / out["file"]).stat().st_size == 2048
+
+
+@pytest.mark.asyncio
+async def test_a_declared_size_over_the_limit_costs_no_download(tmp_path):
+    root = tmp_path / "export" / "media"
+    info = {"kind": "video", "size": 9_000_000, "ext": ".mp4", "name": None, "skipped": None}
+
+    class _Refuses:
+        async def download_media(self, *args, **kwargs):
+            raise AssertionError("the limit should have been decided before the network")
+
+    out = await media_mod.download(_Refuses(), _message(), info, root, max_bytes=1024 * 1024)
+
+    assert "larger than limit" in out["skipped"]
+
+
+@pytest.mark.asyncio
+async def test_a_failed_download_leaves_no_partial_file(tmp_path):
+    root = tmp_path / "export" / "media"
+    info = {"kind": "photo", "size": 2048, "ext": ".jpg", "name": None, "skipped": None}
+    client = _Client(b"x" * 2048, fail=OSError("connection reset"))
+
+    out = await media_mod.download(client, _message(), info, root, max_bytes=None)
+
+    assert "download failed" in out["skipped"]
+    # A leftover stub would be taken for the real file by the next resume.
+    assert not any(p.is_file() for p in root.rglob("*"))
+
+
+@pytest.mark.asyncio
+async def test_no_limit_means_no_progress_guard(tmp_path):
+    """Without a limit the download must not pay for a per-chunk callback."""
+    root = tmp_path / "export" / "media"
+    info = {"kind": "photo", "size": None, "ext": ".jpg", "name": None, "skipped": None}
+    seen = {}
+
+    class _Records:
+        async def download_media(self, message, file, progress_callback=None):
+            seen["callback"] = progress_callback
+            Path(file).parent.mkdir(parents=True, exist_ok=True)
+            Path(file).write_bytes(b"ok")
+            return file
+
+    await media_mod.download(_Records(), _message(), info, root, max_bytes=None)
+
+    assert seen["callback"] is None

--- a/tests/test_export_render.py
+++ b/tests/test_export_render.py
@@ -1,0 +1,212 @@
+"""Tests for telegram_mcp/export: entity formatting and the JSONL renderers.
+
+The load-bearing case is UTF-16. Telegram counts entity offsets in UTF-16 code
+units, so one emoji earlier in a line shifts every later offset by one; slicing
+the Python string instead is the classic exporter bug and it corrupts formatting
+silently, in exactly the messages people quote. ``test_utf16_mutant_is_caught``
+reintroduces that bug on purpose and asserts the check goes red, so the check
+above it cannot quietly become decorative.
+"""
+
+import json
+import re
+
+import pytest
+
+from telegram_mcp.export import entities
+from telegram_mcp.export.render import render
+
+EMOJI_TEXT = "🔥 это важное слово"
+# The emoji is two UTF-16 code units but one Python character: "важное" starts
+# at code unit 7 and at Python index 6.
+BOLD_ON_VAZHNOE = [{"type": "bold", "class": "MessageEntityBold", "offset": 7, "length": 6}]
+
+
+def _bold_spans(html: str) -> list:
+    return re.findall(r"<strong>([^<]*)</strong>", html)
+
+
+# --- entity formatting -------------------------------------------------------
+
+
+def test_bold_survives_a_leading_emoji():
+    assert _bold_spans(entities.to_html(EMOJI_TEXT, BOLD_ON_VAZHNOE)) == ["важное"]
+
+
+def test_markdown_bold_survives_a_leading_emoji():
+    assert "**важное**" in entities.to_markdown(EMOJI_TEXT, BOLD_ON_VAZHNOE)
+
+
+def test_utf16_mutant_is_caught(monkeypatch):
+    """Slice Python characters instead of UTF-16 units: the check must fail."""
+    monkeypatch.setattr(entities, "_slice", lambda buf, a, b: buf.decode("utf-16-le")[a:b])
+    assert _bold_spans(entities.to_html(EMOJI_TEXT, BOLD_ON_VAZHNOE)) != ["важное"]
+
+
+def test_message_text_is_escaped_not_emitted():
+    html = entities.to_html("<b>raw</b> & co", [])
+    assert "&lt;b&gt;raw&lt;/b&gt;" in html
+    assert "<b>" not in html
+
+
+def test_text_url_becomes_an_anchor():
+    html = entities.to_html(
+        "смотри ссылку",
+        [
+            {
+                "type": "text_url",
+                "class": "MessageEntityTextUrl",
+                "offset": 7,
+                "length": 6,
+                "url": "https://example.com",
+            }
+        ],
+    )
+    assert '<a href="https://example.com">ссылку</a>' in html
+
+
+def test_nested_entities_do_not_cross_tags():
+    html = entities.to_html(
+        "bold link",
+        [
+            {
+                "type": "text_url",
+                "class": "MessageEntityTextUrl",
+                "offset": 0,
+                "length": 9,
+                "url": "https://example.com",
+            },
+            {"type": "bold", "class": "MessageEntityBold", "offset": 0, "length": 4},
+        ],
+    )
+    assert html.count("<a ") == html.count("</a>")
+    assert "<strong>bold</strong>" in html
+
+
+def test_entities_to_json_keeps_urls_and_survives_unknown_types():
+    class MessageEntityBold:
+        offset, length = 0, 4
+
+    class SomeFutureEntity:
+        offset, length = 4, 2
+
+    payload = entities.entities_to_json([MessageEntityBold(), SomeFutureEntity()])
+    assert payload[0]["type"] == "bold"
+    assert payload[1]["type"] == "plain"  # degrades instead of raising
+
+
+# --- rendering ---------------------------------------------------------------
+
+
+@pytest.fixture
+def export_dir(tmp_path):
+    """A minimal export folder: text, media, a transcript and a service event."""
+    records = [
+        {
+            "id": 1,
+            "date": "2026-08-20T10:00:00+00:00",
+            "from_id": 111,
+            "from_name": "Иван Петров",
+            "outgoing": False,
+            "text": EMOJI_TEXT,
+            "entities": BOLD_ON_VAZHNOE,
+            "reply": None,
+            "forward": None,
+            "reactions": [{"reaction": "👍", "count": 2}],
+            "service": None,
+            "media": None,
+            "transcript": None,
+            "edit_date": None,
+        },
+        {
+            "id": 2,
+            "date": "2026-08-20T10:01:00+00:00",
+            "from_id": 222,
+            "from_name": "Тимур",
+            "outgoing": True,
+            "text": "ответ",
+            "entities": [],
+            "reply": {"reply_to_msg_id": 1, "top_msg_id": None, "forum_topic": False},
+            "forward": None,
+            "reactions": [],
+            "service": None,
+            "media": {
+                "kind": "voice",
+                "duration": 23,
+                "size": 41000,
+                "file": None,
+                "name": None,
+                "mime": "audio/ogg",
+                "skipped": None,
+            },
+            "transcript": {
+                "text": "тестовая расшифровка",
+                "engine": "groq",
+                "lang": "ru",
+                "duration": 23,
+            },
+            "edit_date": "2026-08-20T10:02:00+00:00",
+        },
+        {
+            "id": 3,
+            "date": "2026-08-21T09:00:00+00:00",
+            "from_id": None,
+            "from_name": None,
+            "outgoing": False,
+            "text": "",
+            "entities": [],
+            "reply": None,
+            "forward": None,
+            "reactions": [],
+            "service": {"action": "MessageActionChatAddUser", "title": None},
+            "media": None,
+            "transcript": None,
+            "edit_date": None,
+        },
+    ]
+    with (tmp_path / "messages.jsonl").open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+    meta = {
+        "chat": {
+            "id": -100123,
+            "title": "Тестовый чат",
+            "type": "supergroup",
+            "username": "testchat",
+        },
+        "message_count": len(records),
+        "window": {"first": "2026-08-20", "last": "2026-08-21"},
+    }
+    (tmp_path / "meta.json").write_text(json.dumps(meta, ensure_ascii=False), encoding="utf-8")
+    return tmp_path, meta
+
+
+def test_html_render(export_dir):
+    path, meta = export_dir
+    render(path, meta, ["jsonl", "html"])
+    html = (path / "messages.html").read_text(encoding="utf-8")
+    assert _bold_spans(html) == ["важное"]
+    assert 'class="service"' in html
+    assert 'href="#msg1"' in html  # the reply links to the quoted message
+    assert "not downloaded" in html  # undownloaded media is still described
+    assert "engine: groq" in html
+    assert "not a verbatim quote" in html  # a transcript is never passed off as speech
+
+
+def test_markdown_and_text_render(export_dir):
+    path, meta = export_dir
+    render(path, meta, ["jsonl", "md", "txt"])
+    markdown = (path / "messages.md").read_text(encoding="utf-8")
+    assert "🔥 это **важное** слово" in markdown
+    assert "transcript (groq)" in markdown
+    text = (path / "messages.txt").read_text(encoding="utf-8")
+    assert "Иван Петров, [20.08.2026 10:00]" in text
+
+
+def test_html_paginates(export_dir):
+    path, meta = export_dir
+    render_pages = __import__("telegram_mcp.export.render", fromlist=["render_html"])
+    render_pages.render_html(path, meta, page_size=1)
+    assert (path / "messages.html").exists()
+    assert (path / "messages2.html").exists()
+    assert 'href="messages2.html"' in (path / "messages.html").read_text(encoding="utf-8")

--- a/tests/test_export_session.py
+++ b/tests/test_export_session.py
@@ -1,0 +1,126 @@
+"""Tests for telegram_mcp/export/session.py: no server session, no server import.
+
+Two failures found in live use are pinned here:
+
+* ``telegram_mcp.runtime`` discovers accounts at import time and calls
+  ``sys.exit(1)`` when none is configured. Export authorises its own device and
+  deliberately has no server session, so importing runtime killed the process
+  before login could start.
+* The same import reads the API credentials at import time, which made
+  ``--help`` and the offline ``render`` command crash without a .env.
+
+Both reduce to one structural rule: nothing under ``telegram_mcp.export`` may
+import ``telegram_mcp.runtime``. ``test_export_cli_does_not_import_runtime``
+enforces it in a subprocess, because once runtime is in ``sys.modules`` from
+another test the in-process check would pass for the wrong reason.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from telegram_mcp import client_factory
+from telegram_mcp.export import session as export_session
+
+SESSION_ENV = (
+    "TELEGRAM_SESSION_STRING",
+    "TELEGRAM_SESSION_STRINGS",
+    "TELEGRAM_SESSION_STRING_PERSONAL",
+    "TELEGRAM_SESSION_NAME",
+)
+
+
+class _FakeTelegramClient:
+    def __init__(self, session, api_id, api_hash, **kwargs):
+        self.session = session
+        self.api_id = api_id
+        self.kwargs = kwargs
+        self.flood_sleep_threshold = 60
+
+
+@pytest.fixture
+def no_server_session(monkeypatch, tmp_path):
+    for name in SESSION_ENV:
+        monkeypatch.delenv(name, raising=False)
+    for name in list(os.environ):
+        if name.startswith("TELEGRAM_PROXY_"):
+            monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("TELEGRAM_API_ID", "12345")
+    monkeypatch.setenv("TELEGRAM_API_HASH", "dummy_hash")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(client_factory, "TelegramClient", _FakeTelegramClient)
+    return tmp_path
+
+
+def test_build_client_without_any_server_session(no_server_session):
+    """The reported failure: 'No Telegram session configured', exit code 1."""
+    client = export_session.build_client()
+    assert client.api_id == 12345
+
+
+def test_build_client_drops_server_session_strings(no_server_session, monkeypatch):
+    """Sharing one auth key with the server is what gets it revoked."""
+    monkeypatch.setenv("TELEGRAM_SESSION_STRING", "server-session")
+    monkeypatch.setenv("TELEGRAM_SESSION_STRING_PERSONAL", "server-session-2")
+
+    export_session.build_client()
+
+    assert "TELEGRAM_SESSION_STRING" not in os.environ
+    assert "TELEGRAM_SESSION_STRING_PERSONAL" not in os.environ
+
+
+def test_build_client_uses_its_own_session_file(no_server_session):
+    client = export_session.build_client()
+    assert str(client.session).endswith("telegram-mcp/export")
+
+
+def test_build_client_honours_proxy_configuration(no_server_session, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_PROXY_TYPE", "mtproxy")
+    monkeypatch.setenv("TELEGRAM_PROXY_HOST", "mtproxy.example")
+    monkeypatch.setenv("TELEGRAM_PROXY_PORT", "443")
+    monkeypatch.setenv("TELEGRAM_PROXY_SECRET", "ee0123456789abcdef")
+
+    client = export_session.build_client()
+
+    assert client.kwargs["proxy"] == ("mtproxy.example", 443, "ee0123456789abcdef")
+
+
+def test_missing_credentials_are_reported_not_raised_as_typeerror(no_server_session, monkeypatch):
+    monkeypatch.delenv("TELEGRAM_API_ID", raising=False)
+    with pytest.raises(SystemExit, match="TELEGRAM_API_ID"):
+        export_session.build_client()
+
+
+def test_export_cli_does_not_import_runtime(tmp_path):
+    """Structural guard for both crashes: no runtime anywhere under export."""
+    script = textwrap.dedent("""
+        import sys
+        import telegram_mcp.export.cli  # noqa: F401
+        assert "telegram_mcp.runtime" not in sys.modules, "export imported the MCP runtime"
+        print("clean")
+        """)
+    env = {k: v for k, v in os.environ.items() if not k.startswith("TELEGRAM_")}
+    env["PYTHONPATH"] = os.getcwd()
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, env=env, cwd=os.getcwd()
+    )
+    assert result.returncode == 0, result.stderr
+    assert "clean" in result.stdout
+
+
+def test_export_help_works_without_any_configuration():
+    """--help must not need credentials or a session."""
+    env = {k: v for k, v in os.environ.items() if not k.startswith("TELEGRAM_")}
+    env["PYTHONPATH"] = os.getcwd()
+    result = subprocess.run(
+        [sys.executable, "-m", "telegram_mcp.export.cli", "export", "--help"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=os.getcwd(),
+    )
+    assert result.returncode == 0, result.stderr
+    assert "--transcribe" in result.stdout

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -11,7 +11,7 @@ from mcp.types import ErrorData, ToolAnnotations
 from telethon.tl.types import Channel, Chat, PeerUser, User
 
 import main
-from telegram_mcp import runtime
+from telegram_mcp import client_factory, runtime
 
 
 def _clear_session_env(monkeypatch):
@@ -139,7 +139,7 @@ def test_discover_accounts_supports_suffixed_and_default_sessions(monkeypatch):
     monkeypatch.setenv("TELEGRAM_SESSION_STRING_WORK", "work-session")
     monkeypatch.setenv("TELEGRAM_SESSION_NAME_PERSONAL", "personal.session")
     monkeypatch.setenv("TELEGRAM_SESSION_STRING", "default-session")
-    monkeypatch.setattr(runtime, "TelegramClient", _FakeTelegramClient)
+    monkeypatch.setattr(client_factory, "TelegramClient", _FakeTelegramClient)
     monkeypatch.setattr(runtime, "StringSession", lambda value: f"StringSession:{value}")
 
     accounts = runtime._discover_accounts()
@@ -300,7 +300,7 @@ def test_discover_accounts_passes_proxy_kwargs_to_client(monkeypatch):
     monkeypatch.setenv("TELEGRAM_PROXY_HOST", "mtproxy.example")
     monkeypatch.setenv("TELEGRAM_PROXY_PORT", "443")
     monkeypatch.setenv("TELEGRAM_PROXY_SECRET", "ee0123456789abcdef")
-    monkeypatch.setattr(runtime, "TelegramClient", _FakeTelegramClient)
+    monkeypatch.setattr(client_factory, "TelegramClient", _FakeTelegramClient)
     monkeypatch.setattr(runtime, "StringSession", lambda value: f"StringSession:{value}")
 
     accounts = runtime._discover_accounts()
@@ -320,7 +320,7 @@ def test_discover_accounts_passes_device_identity_kwargs_to_client(monkeypatch):
     monkeypatch.setenv("TELEGRAM_SESSION_STRING", "default-session")
     monkeypatch.setenv("TELEGRAM_DEVICE_MODEL", "Telegram MCP")
     monkeypatch.setenv("TELEGRAM_APP_VERSION", "3.1")
-    monkeypatch.setattr(runtime, "TelegramClient", _FakeTelegramClient)
+    monkeypatch.setattr(client_factory, "TelegramClient", _FakeTelegramClient)
     monkeypatch.setattr(runtime, "StringSession", lambda value: f"StringSession:{value}")
 
     accounts = runtime._discover_accounts()

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -133,8 +133,7 @@ def test_legacy_cache_keyed_without_engine_is_migrated_in_place(transcript_cache
     path = transcription._cache_db_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(str(path))
-    conn.executescript(
-        """
+    conn.executescript("""
         CREATE TABLE transcripts (
             chat_id INTEGER NOT NULL,
             message_id INTEGER NOT NULL,
@@ -146,8 +145,7 @@ def test_legacy_cache_keyed_without_engine_is_migrated_in_place(transcript_cache
             PRIMARY KEY (chat_id, message_id)
         );
         INSERT INTO transcripts VALUES (1, 2, 'telegram', 'old row', 23, 'ru', '2026-08-20');
-        """
-    )
+        """)
     conn.commit()
     conn.close()
 

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -107,6 +107,57 @@ def test_cache_keyed_by_chat_and_message_independently(transcript_cache_dir):
     assert transcription.get_cached_transcript(1, 999) is None
 
 
+def test_cache_pinned_to_an_engine_never_serves_the_other_engines_text(transcript_cache_dir):
+    """The whole point of choosing groq is that the native engine drops the
+    recording's last segment. A telegram transcript answering a groq request
+    would hand back that truncated text with no way to tell."""
+    transcription.save_transcript(1, 2, "telegram", "truncated tail")
+    assert transcription.get_cached_transcript(1, 2, source="groq") is None
+    assert transcription.get_cached_transcript(1, 2, source="telegram")["text"] == (
+        "truncated tail"
+    )
+
+
+def test_cache_keeps_both_engines_side_by_side(transcript_cache_dir):
+    transcription.save_transcript(1, 2, "telegram", "native text")
+    transcription.save_transcript(1, 2, "groq", "groq text")
+    assert transcription.get_cached_transcript(1, 2, source="telegram")["text"] == "native text"
+    assert transcription.get_cached_transcript(1, 2, source="groq")["text"] == "groq text"
+
+
+def test_legacy_cache_keyed_without_engine_is_migrated_in_place(transcript_cache_dir):
+    """Builds before the fix keyed on (chat_id, message_id) alone. Rows must
+    survive the rebuild, and the pinned lookup must start working on them."""
+    import sqlite3
+
+    path = transcription._cache_db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE transcripts (
+            chat_id INTEGER NOT NULL,
+            message_id INTEGER NOT NULL,
+            source TEXT NOT NULL,
+            text TEXT NOT NULL,
+            duration INTEGER,
+            lang TEXT,
+            created_at TEXT NOT NULL,
+            PRIMARY KEY (chat_id, message_id)
+        );
+        INSERT INTO transcripts VALUES (1, 2, 'telegram', 'old row', 23, 'ru', '2026-08-20');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    assert transcription.get_cached_transcript(1, 2, source="telegram")["text"] == "old row"
+    assert transcription.get_cached_transcript(1, 2, source="groq") is None
+    transcription.save_transcript(1, 2, "groq", "new row")
+    assert transcription.get_cached_transcript(1, 2, source="groq")["text"] == "new row"
+    assert transcription.get_cached_transcript(1, 2, source="telegram")["text"] == "old row"
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX permissions only")
 def test_cache_file_and_directory_get_restrictive_permissions(transcript_cache_dir):
     transcription.save_transcript(1, 2, "groq", "hi")

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -1,0 +1,549 @@
+"""Tests for telegram_mcp/transcription.py: config, cache, engines, budget, render."""
+
+import os
+import stat
+from types import SimpleNamespace
+
+import pytest
+
+from telegram_mcp import transcription
+
+
+def _async_return(value):
+    async def _inner(*args, **kwargs):
+        return value
+
+    return _inner
+
+
+def _voice_msg(**overrides):
+    base = dict(
+        id=1,
+        message=None,
+        voice=SimpleNamespace(),
+        video_note=None,
+        file=SimpleNamespace(duration=23, ext=".oga", mime_type="audio/ogg"),
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+# ---------------------------------------------------------------------------
+# Config toggles
+# ---------------------------------------------------------------------------
+
+
+def test_transcribe_mode_defaults_to_on_demand(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_TRANSCRIBE", raising=False)
+    assert transcription.transcribe_mode() == "on-demand"
+
+
+@pytest.mark.parametrize("value", ["off", "on-demand", "auto", "AUTO", " off "])
+def test_transcribe_mode_accepts_known_values_case_and_space_insensitive(monkeypatch, value):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", value)
+    assert transcription.transcribe_mode() == value.strip().lower()
+
+
+def test_transcribe_mode_rejects_unknown_value(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "sometimes")
+    with pytest.raises(SystemExit):
+        transcription.transcribe_mode()
+
+
+def test_default_engine_defaults_to_groq(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_TRANSCRIBE_ENGINE", raising=False)
+    assert transcription.default_engine() == "groq"
+
+
+def test_default_engine_accepts_telegram(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE_ENGINE", "telegram")
+    assert transcription.default_engine() == "telegram"
+
+
+def test_default_engine_rejects_unknown_value(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE_ENGINE", "whisper-local")
+    with pytest.raises(SystemExit):
+        transcription.default_engine()
+
+
+def test_validate_transcription_config_raises_on_bad_mode(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "always")
+    with pytest.raises(SystemExit):
+        transcription.validate_transcription_config()
+
+
+# ---------------------------------------------------------------------------
+# SQLite cache
+# ---------------------------------------------------------------------------
+
+
+def test_cache_miss_returns_none(transcript_cache_dir):
+    assert transcription.get_cached_transcript(1, 2) is None
+
+
+def test_cache_round_trip(transcript_cache_dir):
+    transcription.save_transcript(1, 2, "groq", "hello world", duration=23, lang="ru")
+    cached = transcription.get_cached_transcript(1, 2)
+    assert cached["text"] == "hello world"
+    assert cached["source"] == "groq"
+    assert cached["duration"] == 23
+    assert cached["lang"] == "ru"
+    assert cached["created_at"]
+
+
+def test_cache_upsert_overwrites_previous_entry(transcript_cache_dir):
+    transcription.save_transcript(1, 2, "telegram", "first pass")
+    transcription.save_transcript(1, 2, "groq", "second pass")
+    cached = transcription.get_cached_transcript(1, 2)
+    assert cached["text"] == "second pass"
+    assert cached["source"] == "groq"
+
+
+def test_cache_keyed_by_chat_and_message_independently(transcript_cache_dir):
+    transcription.save_transcript(1, 100, "groq", "chat one")
+    transcription.save_transcript(2, 100, "groq", "chat two")
+    assert transcription.get_cached_transcript(1, 100)["text"] == "chat one"
+    assert transcription.get_cached_transcript(2, 100)["text"] == "chat two"
+    assert transcription.get_cached_transcript(1, 999) is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permissions only")
+def test_cache_file_and_directory_get_restrictive_permissions(transcript_cache_dir):
+    transcription.save_transcript(1, 2, "groq", "hi")
+    db_path = transcription.cache_dir() / "transcripts.db"
+    assert stat.S_IMODE(db_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(transcript_cache_dir.stat().st_mode) == 0o700
+
+
+# ---------------------------------------------------------------------------
+# Voice/video-note detection and formatting
+# ---------------------------------------------------------------------------
+
+
+def test_is_transcribable_true_for_voice():
+    assert transcription.is_transcribable(_voice_msg())
+
+
+def test_is_transcribable_true_for_video_note():
+    assert transcription.is_transcribable(_voice_msg(voice=None, video_note=SimpleNamespace()))
+
+
+def test_is_transcribable_false_for_plain_message():
+    assert not transcription.is_transcribable(_voice_msg(voice=None, file=None))
+
+
+def test_voice_duration_reads_file_attribute():
+    assert transcription.voice_duration(_voice_msg()) == 23
+
+
+def test_voice_duration_none_without_file():
+    assert transcription.voice_duration(_voice_msg(file=None)) is None
+
+
+@pytest.mark.parametrize(
+    "seconds,expected",
+    [(0, "0:00"), (23, "0:23"), (83, "1:23"), (3661, "1:01:01"), (None, "?:??")],
+)
+def test_format_duration(seconds, expected):
+    assert transcription.format_duration(seconds) == expected
+
+
+# ---------------------------------------------------------------------------
+# Batch budget
+# ---------------------------------------------------------------------------
+
+
+def test_budget_reads_defaults_from_env(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE_MAX_VOICES", "2")
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE_MAX_SECONDS", "60")
+    budget = transcription.TranscribeBudget()
+    assert budget.max_voices == 2
+    assert budget.max_seconds == 60
+
+
+def test_budget_voice_count_cap():
+    budget = transcription.TranscribeBudget(max_voices=2, max_seconds=10_000)
+    assert budget.can_afford(10)
+    budget.charge(10)
+    assert budget.can_afford(10)
+    budget.charge(10)
+    assert not budget.can_afford(1)
+
+
+def test_budget_seconds_cap():
+    budget = transcription.TranscribeBudget(max_voices=10, max_seconds=50)
+    assert budget.can_afford(40)
+    budget.charge(40)
+    assert not budget.can_afford(20)  # 40 + 20 > 50
+    assert budget.can_afford(10)  # 40 + 10 <= 50
+
+
+# ---------------------------------------------------------------------------
+# voice_attachment_info / render_voice_text
+# ---------------------------------------------------------------------------
+
+
+def test_voice_attachment_info_none_for_non_voice_message():
+    msg = SimpleNamespace(id=1, voice=None, video_note=None, file=None)
+    assert transcription.voice_attachment_info(msg, chat_id=1) is None
+
+
+def test_voice_attachment_info_shows_duration_only_without_chat_id(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    info = transcription.voice_attachment_info(_voice_msg(), chat_id=None)
+    assert info == {
+        "duration": 23,
+        "transcript": None,
+        "transcript_source": None,
+        "transcript_status": None,
+    }
+
+
+def test_voice_attachment_info_disabled_when_mode_off(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "off")
+    transcription.save_transcript(1, 1, "groq", "should not surface")
+    info = transcription.voice_attachment_info(_voice_msg(id=1), chat_id=1)
+    assert info["transcript_status"] is None
+    assert info["transcript"] is None
+    assert info["duration"] == 23  # duration is free, shown regardless of the toggle
+
+
+def test_voice_attachment_info_cache_hit_is_ready(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    transcription.save_transcript(1, 1, "groq", "hello", duration=23)
+    info = transcription.voice_attachment_info(_voice_msg(id=1), chat_id=1)
+    assert info["transcript_status"] == "ready"
+    assert info["transcript"] == "hello"
+    assert info["transcript_source"] == "groq"
+
+
+def test_voice_attachment_info_cache_miss_is_pending(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    info = transcription.voice_attachment_info(_voice_msg(id=99), chat_id=1)
+    assert info["transcript_status"] == "pending"
+    assert info["transcript"] is None
+
+
+def test_render_voice_text_ready_marks_source_and_not_verbatim():
+    info = {
+        "duration": 23,
+        "transcript": "hi there",
+        "transcript_source": "groq",
+        "transcript_status": "ready",
+    }
+    assert (
+        transcription.render_voice_text(info)
+        == "voice 0:23 | transcript (groq, not verbatim): hi there"
+    )
+
+
+def test_render_voice_text_pending():
+    info = {
+        "duration": 23,
+        "transcript": None,
+        "transcript_source": None,
+        "transcript_status": "pending",
+    }
+    assert transcription.render_voice_text(info) == "voice 0:23 | transcript pending"
+
+
+def test_render_voice_text_disabled_shows_duration_only():
+    info = {
+        "duration": 23,
+        "transcript": None,
+        "transcript_source": None,
+        "transcript_status": None,
+    }
+    assert transcription.render_voice_text(info) == "voice 0:23"
+
+
+# ---------------------------------------------------------------------------
+# Telegram engine: pending must be polled, not silently dropped
+# ---------------------------------------------------------------------------
+
+
+class _FakeTelegramClient:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = 0
+
+    async def get_input_entity(self, entity):
+        return "peer"
+
+    async def __call__(self, request):
+        self.calls += 1
+        resp = self._responses.pop(0)
+        if isinstance(resp, Exception):
+            raise resp
+        return resp
+
+
+@pytest.mark.asyncio
+async def test_transcribe_via_telegram_polls_until_ready(monkeypatch):
+    monkeypatch.setattr(transcription, "account_is_premium", _async_return(True))
+    monkeypatch.setattr(transcription.asyncio, "sleep", _async_return(None))
+    client = _FakeTelegramClient(
+        [
+            SimpleNamespace(pending=True, text=None),
+            SimpleNamespace(pending=True, text=None),
+            SimpleNamespace(pending=False, text="full text, no dropped tail"),
+        ]
+    )
+
+    result = await transcription._transcribe_via_telegram(client, object(), SimpleNamespace(id=42))
+
+    assert result == {"status": "ok", "text": "full text, no dropped tail"}
+    assert client.calls == 3  # 1 initial + 2 polls, matches the live 83s-recording measurement
+
+
+@pytest.mark.asyncio
+async def test_transcribe_via_telegram_first_call_ready_needs_no_poll(monkeypatch):
+    monkeypatch.setattr(transcription, "account_is_premium", _async_return(True))
+    monkeypatch.setattr(transcription.asyncio, "sleep", _async_return(None))
+    client = _FakeTelegramClient([SimpleNamespace(pending=False, text="instant")])
+
+    result = await transcription._transcribe_via_telegram(client, object(), SimpleNamespace(id=1))
+
+    assert result == {"status": "ok", "text": "instant"}
+    assert client.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_transcribe_via_telegram_gives_up_after_poll_budget_and_degrades(monkeypatch):
+    monkeypatch.setattr(transcription, "account_is_premium", _async_return(True))
+    monkeypatch.setattr(transcription.asyncio, "sleep", _async_return(None))
+    monkeypatch.setattr(transcription, "_POLL_ATTEMPTS", 2)
+    client = _FakeTelegramClient([SimpleNamespace(pending=True, text=None)] * 10)
+
+    result = await transcription._transcribe_via_telegram(client, object(), SimpleNamespace(id=1))
+
+    assert result == {"status": "pending"}  # honest degradation, not a crash
+
+
+@pytest.mark.asyncio
+async def test_transcribe_via_telegram_requires_premium(monkeypatch):
+    monkeypatch.setattr(transcription, "account_is_premium", _async_return(False))
+    client = _FakeTelegramClient([])
+
+    result = await transcription._transcribe_via_telegram(client, object(), SimpleNamespace(id=1))
+
+    assert result == {"status": "premium_required"}
+    assert client.calls == 0  # never even attempted the RPC
+
+
+@pytest.mark.asyncio
+async def test_transcribe_via_telegram_rpc_error_maps_to_premium_required(monkeypatch):
+    monkeypatch.setattr(transcription, "account_is_premium", _async_return(True))
+    monkeypatch.setattr(transcription, "is_premium_rpc_error", lambda e: True)
+    client = _FakeTelegramClient([RuntimeError("PREMIUM_ACCOUNT_REQUIRED")])
+
+    result = await transcription._transcribe_via_telegram(client, object(), SimpleNamespace(id=1))
+
+    assert result == {"status": "premium_required"}
+
+
+# ---------------------------------------------------------------------------
+# Groq engine: in-memory download, never touches disk
+# ---------------------------------------------------------------------------
+
+
+class _FakeGroqResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+class _FakeHttpxClient:
+    def __init__(self, response, capture):
+        self._response = response
+        self._capture = capture
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def post(self, url, headers=None, data=None, files=None):
+        self._capture.append({"url": url, "headers": headers, "data": data, "files": files})
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_transcribe_via_groq_success(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    calls = []
+    response = _FakeGroqResponse({"text": " hello world ", "language": "ru"})
+    monkeypatch.setattr(
+        transcription.httpx, "AsyncClient", lambda **kw: _FakeHttpxClient(response, calls)
+    )
+
+    msg = _voice_msg()
+
+    async def _download_media(m, file=None):
+        assert m is msg
+        assert file is bytes  # in-memory download, no disk path
+        return b"raw-audio-bytes"
+
+    client = SimpleNamespace(download_media=_download_media)
+
+    result = await transcription._transcribe_via_groq(client, msg)
+
+    assert result == {"status": "ok", "text": "hello world", "lang": "ru"}
+    assert calls[0]["headers"]["Authorization"] == "Bearer test-key"
+    assert calls[0]["files"]["file"][0] == "voice.oga"
+    assert calls[0]["data"]["model"] == transcription.GROQ_MODEL
+
+
+@pytest.mark.asyncio
+async def test_transcribe_via_groq_requires_api_key(monkeypatch):
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+
+    result = await transcription._transcribe_via_groq(SimpleNamespace(), _voice_msg())
+
+    assert result["status"] == "error"
+    assert "GROQ_API_KEY" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_transcribe_via_groq_empty_download_is_error(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "k")
+
+    async def _download_media(m, file=None):
+        return b""
+
+    client = SimpleNamespace(download_media=_download_media)
+    result = await transcription._transcribe_via_groq(client, _voice_msg())
+
+    assert result["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_transcribe_via_groq_empty_transcript_is_error(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    response = _FakeGroqResponse({"text": "", "language": "ru"})
+    monkeypatch.setattr(
+        transcription.httpx, "AsyncClient", lambda **kw: _FakeHttpxClient(response, [])
+    )
+
+    async def _download_media(m, file=None):
+        return b"raw-audio-bytes"
+
+    client = SimpleNamespace(download_media=_download_media)
+    result = await transcription._transcribe_via_groq(client, _voice_msg())
+
+    assert result["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# transcribe() dispatcher
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_transcribe_dispatches_to_telegram_engine(monkeypatch):
+    monkeypatch.setattr(
+        transcription, "_transcribe_via_telegram", _async_return({"status": "ok", "text": "tg"})
+    )
+    result = await transcription.transcribe(None, None, None, "telegram")
+    assert result["text"] == "tg"
+
+
+@pytest.mark.asyncio
+async def test_transcribe_dispatches_to_groq_engine(monkeypatch):
+    monkeypatch.setattr(
+        transcription, "_transcribe_via_groq", _async_return({"status": "ok", "text": "groq"})
+    )
+    result = await transcription.transcribe(None, None, None, "groq")
+    assert result["text"] == "groq"
+
+
+@pytest.mark.asyncio
+async def test_transcribe_unknown_engine_is_an_error():
+    result = await transcription.transcribe(None, None, None, "bogus")
+    assert result["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Batch prefetch (mode="auto")
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prefetch_is_noop_outside_auto_mode(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    monkeypatch.setattr(transcription, "transcribe", _async_return({"status": "ok", "text": "x"}))
+
+    await transcription.prefetch_transcripts(None, None, 1, [_voice_msg(id=1)])
+
+    assert transcription.get_cached_transcript(1, 1) is None
+
+
+@pytest.mark.asyncio
+async def test_prefetch_fills_cache_up_to_voice_budget(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "auto")
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE_MAX_VOICES", "1")
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE_MAX_SECONDS", "1000")
+
+    calls = []
+
+    async def _fake_transcribe(cl, entity, msg, engine):
+        calls.append(msg.id)
+        return {"status": "ok", "text": f"text-{msg.id}", "lang": "ru"}
+
+    monkeypatch.setattr(transcription, "transcribe", _fake_transcribe)
+
+    await transcription.prefetch_transcripts(None, None, 7, [_voice_msg(id=1), _voice_msg(id=2)])
+
+    assert calls == [1]  # budget exhausted after the first voice message
+    assert transcription.get_cached_transcript(7, 1)["text"] == "text-1"
+    assert transcription.get_cached_transcript(7, 2) is None  # left for next explicit call
+
+
+@pytest.mark.asyncio
+async def test_prefetch_skips_cached_and_already_texted_messages(
+    monkeypatch, transcript_cache_dir
+):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "auto")
+    transcription.save_transcript(7, 1, "telegram", "already have it")
+    calls = []
+
+    async def _fake_transcribe(cl, entity, msg, engine):
+        calls.append(msg.id)
+        return {"status": "ok", "text": "new"}
+
+    monkeypatch.setattr(transcription, "transcribe", _fake_transcribe)
+
+    messages = [_voice_msg(id=1), _voice_msg(id=2, message="already has text")]
+    await transcription.prefetch_transcripts(None, None, 7, messages)
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_prefetch_swallows_engine_errors_without_raising(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "auto")
+
+    async def _boom(cl, entity, msg, engine):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(transcription, "transcribe", _boom)
+
+    await transcription.prefetch_transcripts(None, None, 7, [_voice_msg(id=5)])  # must not raise
+
+    assert transcription.get_cached_transcript(7, 5) is None
+
+
+@pytest.mark.asyncio
+async def test_prefetch_does_not_cache_pending_results(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "auto")
+    monkeypatch.setattr(transcription, "transcribe", _async_return({"status": "pending"}))
+
+    await transcription.prefetch_transcripts(None, None, 7, [_voice_msg(id=5)])
+
+    assert transcription.get_cached_transcript(7, 5) is None

--- a/tests/test_voice_transcripts.py
+++ b/tests/test_voice_transcripts.py
@@ -1,0 +1,487 @@
+"""Integration tests: transcript mixing into message_to_dict / format_message_line /
+list_messages, plus the transcribe_voice tool.
+
+message_to_dict/format_message_line are also exercised directly (without a
+chat_id) by test_reply_quote.py and test_forward_attribution.py with bare fake
+messages that have no voice/video_note attribute - those keep passing
+unmodified, which is the backward-compatibility contract these tests pin down
+explicitly for the voice case.
+"""
+
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from telegram_mcp import transcription
+from telegram_mcp.tools import messages
+from telegram_mcp.tools.messages import format_message_line, message_to_dict
+
+
+def _async_return(value):
+    async def _inner(*args, **kwargs):
+        return value
+
+    return _inner
+
+
+def _msg(**overrides):
+    base = dict(
+        id=200,
+        sender=None,
+        sender_id=42,
+        date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        message=None,
+        reply_to=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _voice_msg(**overrides):
+    base = dict(
+        voice=SimpleNamespace(),
+        video_note=None,
+        file=SimpleNamespace(duration=23, ext=".oga", mime_type="audio/ogg"),
+    )
+    base.update(overrides)
+    return _msg(**base)
+
+
+class _FakeClient:
+    def __init__(self, messages_list=None, messages_by_id=None):
+        self._list = messages_list or []
+        self._by_id = messages_by_id or {}
+        self.download_calls = []
+
+    async def get_messages(self, entity, limit=None, ids=None, **kwargs):
+        if ids is not None:
+            return self._by_id.get(ids)
+        return self._list[:limit] if limit else list(self._list)
+
+    async def get_input_entity(self, entity):
+        return "peer"
+
+    async def __call__(self, request):
+        raise AssertionError("no raw RPC expected in this test")
+
+    async def download_media(self, msg, file=None):
+        self.download_calls.append(msg.id)
+        return b"audio-bytes"
+
+
+def _patch_client(monkeypatch, client, entity, numeric_chat_id):
+    monkeypatch.setattr(messages, "get_client", lambda account=None: client)
+    monkeypatch.setattr(messages, "resolve_entity", _async_return(entity))
+    monkeypatch.setattr(messages, "get_marked_id", lambda e: numeric_chat_id)
+
+
+# ---------------------------------------------------------------------------
+# message_to_dict
+# ---------------------------------------------------------------------------
+
+
+def test_message_to_dict_voice_without_chat_id_is_backward_compatible():
+    d = message_to_dict(_voice_msg())  # no chat_id, as existing callers use it
+    assert d["media"] == "voice"
+    assert d["duration"] == 23
+    assert "transcript" not in d
+    assert "transcript_status" not in d
+
+
+def test_message_to_dict_voice_cache_miss_is_pending(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    d = message_to_dict(_voice_msg(id=5), chat_id=1)
+    assert d["duration"] == 23
+    assert d["transcript_status"] == "pending"
+    assert "transcript" not in d
+
+
+def test_message_to_dict_voice_cache_hit_includes_source_and_note(
+    monkeypatch, transcript_cache_dir
+):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    transcription.save_transcript(1, 5, "groq", "hello there", duration=23)
+
+    d = message_to_dict(_voice_msg(id=5), chat_id=1)
+
+    assert d["transcript"] == "hello there"
+    assert d["transcript_source"] == "groq"
+    assert "not a verbatim quote" in d["transcript_note"]
+    assert "transcript_status" not in d
+
+
+def test_message_to_dict_voice_off_mode_shows_duration_only(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "off")
+    transcription.save_transcript(1, 5, "groq", "must not surface")
+
+    d = message_to_dict(_voice_msg(id=5), chat_id=1)
+
+    assert d["duration"] == 23
+    assert "transcript" not in d
+    assert "transcript_status" not in d
+
+
+def test_message_to_dict_text_message_untouched():
+    d = message_to_dict(_msg(message="hello"))
+    assert d["text"] == "hello"
+    assert "duration" not in d
+    assert "transcript" not in d
+
+
+# ---------------------------------------------------------------------------
+# format_message_line
+# ---------------------------------------------------------------------------
+
+
+def test_format_message_line_voice_without_chat_id_shows_duration_only():
+    line = format_message_line(
+        _voice_msg(file=SimpleNamespace(duration=83, ext=".oga", mime_type="audio/ogg"))
+    )
+    assert "Message: voice 1:23" in line
+    assert "transcript" not in line
+
+
+def test_format_message_line_voice_ready_includes_transcript_and_source(
+    monkeypatch, transcript_cache_dir
+):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    transcription.save_transcript(1, 5, "telegram", "we should ship this")
+
+    line = format_message_line(_voice_msg(id=5), chat_id=1)
+
+    assert "voice 0:23 | transcript (telegram, not verbatim): we should ship this" in line
+
+
+def test_format_message_line_voice_pending(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+
+    line = format_message_line(_voice_msg(id=5), chat_id=1)
+
+    assert "Message: voice 0:23 | transcript pending" in line
+
+
+def test_format_message_line_text_message_still_shows_empty_literal():
+    line = format_message_line(_msg(message=None))
+    assert "Message: [empty]" in line
+
+
+# ---------------------------------------------------------------------------
+# list_messages: media-label bugfix + transcript mixing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_messages_photo_shows_media_label(monkeypatch, transcript_cache_dir):
+    """Upstream bug: list_messages built its record by hand and never called
+    get_media_label, so any media-with-no-caption message looked exactly like
+    an empty text message. Independent of transcription."""
+    entity = SimpleNamespace()
+    photo_msg = _msg(id=8, photo=SimpleNamespace())
+    client = _FakeClient(messages_list=[photo_msg])
+    _patch_client(monkeypatch, client, entity, 555)
+
+    result = await messages.list_messages(chat_id=555, limit=10, account=None)
+
+    rec = json.loads(result)["results"][0]
+    assert rec["media"] == "photo"
+
+
+@pytest.mark.asyncio
+async def test_list_messages_voice_shows_media_label_and_cached_transcript(
+    monkeypatch, transcript_cache_dir
+):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    entity = SimpleNamespace()
+    voice_msg = _voice_msg(id=7)
+    transcription.save_transcript(555, 7, "groq", "we should ship this", duration=23)
+    client = _FakeClient(messages_list=[voice_msg])
+    _patch_client(monkeypatch, client, entity, 555)
+
+    result = await messages.list_messages(chat_id=555, limit=10, account=None)
+
+    rec = json.loads(result)["results"][0]
+    assert rec["media"] == "voice"
+    assert rec["transcript"] == "we should ship this"
+    assert rec["transcript_source"] == "groq"
+
+
+@pytest.mark.asyncio
+async def test_list_messages_voice_cache_miss_is_pending_on_demand(
+    monkeypatch, transcript_cache_dir
+):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_list=[_voice_msg(id=7)])
+    _patch_client(monkeypatch, client, entity, 555)
+
+    result = await messages.list_messages(chat_id=555, limit=10, account=None)
+
+    rec = json.loads(result)["results"][0]
+    assert rec["transcript_status"] == "pending"
+    assert "transcript" not in rec
+
+
+@pytest.mark.asyncio
+async def test_list_messages_auto_mode_prefetches_and_caches(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "auto")
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE_MAX_VOICES", "5")
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE_MAX_SECONDS", "500")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_list=[_voice_msg(id=9)])
+    _patch_client(monkeypatch, client, entity, 555)
+    monkeypatch.setattr(
+        transcription,
+        "transcribe",
+        _async_return({"status": "ok", "text": "prefetched text", "lang": "ru"}),
+    )
+
+    result = await messages.list_messages(chat_id=555, limit=10, account=None)
+
+    rec = json.loads(result)["results"][0]
+    assert rec["transcript"] == "prefetched text"
+    assert transcription.get_cached_transcript(555, 9)["text"] == "prefetched text"
+
+
+@pytest.mark.asyncio
+async def test_list_messages_on_demand_mode_never_prefetches(monkeypatch, transcript_cache_dir):
+    """The expensive Groq path must never fire on a plain listing call - only
+    auto mode (or an explicit transcribe_voice call) is allowed to spend it."""
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_list=[_voice_msg(id=9)])
+    _patch_client(monkeypatch, client, entity, 555)
+
+    async def _must_not_be_called(*a, **kw):
+        raise AssertionError("on-demand mode must not call the transcription engine")
+
+    monkeypatch.setattr(transcription, "transcribe", _must_not_be_called)
+
+    await messages.list_messages(chat_id=555, limit=10, account=None)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# get_history / get_messages threading chat_id through to the cache
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_history_fills_cached_transcript(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_list=[_voice_msg(id=7)])
+    _patch_client(monkeypatch, client, entity, 555)
+    transcription.save_transcript(555, 7, "telegram", "hello from cache")
+
+    result = await messages.get_history(chat_id=555, limit=10, account=None)
+
+    rec = json.loads(result)["results"][0]
+    assert rec["transcript"] == "hello from cache"
+
+
+@pytest.mark.asyncio
+async def test_get_messages_fills_cached_transcript_in_text_line(
+    monkeypatch, transcript_cache_dir
+):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_list=[_voice_msg(id=7)])
+    _patch_client(monkeypatch, client, entity, 555)
+    transcription.save_transcript(555, 7, "groq", "cached line text")
+
+    result = await messages.get_messages(chat_id=555, page=1, page_size=10, account=None)
+
+    assert "cached line text" in result
+    assert "(groq, not verbatim)" in result
+
+
+# ---------------------------------------------------------------------------
+# transcribe_voice tool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_transcribe_voice_disabled_by_toggle(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "off")
+
+    result = await messages.transcribe_voice(chat_id=1, message_id=1, account=None)
+
+    payload = json.loads(result)
+    assert payload["transcribed"] is False
+    assert payload["reason"] == "transcription_disabled"
+
+
+@pytest.mark.asyncio
+async def test_transcribe_voice_returns_cached_without_calling_engine(
+    monkeypatch, transcript_cache_dir
+):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    transcription.save_transcript(555, 42, "groq", "cached text", duration=23)
+    entity = SimpleNamespace()
+    client = _FakeClient()
+    _patch_client(monkeypatch, client, entity, 555)
+
+    async def _must_not_be_called(*a, **kw):
+        raise AssertionError("must not call the engine on a cache hit")
+
+    monkeypatch.setattr(transcription, "transcribe", _must_not_be_called)
+
+    result = await messages.transcribe_voice(chat_id=555, message_id=42, account=None)
+
+    payload = json.loads(result)
+    assert payload == {
+        "transcribed": True,
+        "cached": True,
+        "text": "cached text",
+        "source": "groq",
+        "duration": 23,
+        "note": "Machine transcript, not a verbatim quote.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_transcribe_voice_rejects_non_voice_message(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    entity = SimpleNamespace()
+    text_msg = _msg(id=9, message="hi")
+    client = _FakeClient(messages_by_id={9: text_msg})
+    _patch_client(monkeypatch, client, entity, 1)
+
+    result = await messages.transcribe_voice(chat_id=1, message_id=9, account=None)
+
+    assert "no voice message" in result
+
+
+@pytest.mark.asyncio
+async def test_transcribe_voice_rejects_unknown_engine(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_by_id={5: _voice_msg(id=5)})
+    _patch_client(monkeypatch, client, entity, 1)
+
+    result = await messages.transcribe_voice(
+        chat_id=1, message_id=5, engine="whisper-cloud", account=None
+    )
+
+    assert "Invalid engine" in result
+
+
+@pytest.mark.asyncio
+async def test_transcribe_voice_groq_without_api_key(monkeypatch, transcript_cache_dir):
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_by_id={5: _voice_msg(id=5)})
+    _patch_client(monkeypatch, client, entity, 1)
+
+    result = await messages.transcribe_voice(chat_id=1, message_id=5, engine="groq", account=None)
+
+    assert "GROQ_API_KEY" in result
+
+
+@pytest.mark.asyncio
+async def test_transcribe_voice_pending_degrades_gracefully_without_caching(
+    monkeypatch, transcript_cache_dir
+):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_by_id={5: _voice_msg(id=5)})
+    _patch_client(monkeypatch, client, entity, 1)
+    monkeypatch.setattr(transcription, "transcribe", _async_return({"status": "pending"}))
+
+    result = await messages.transcribe_voice(
+        chat_id=1, message_id=5, engine="telegram", account=None
+    )
+
+    payload = json.loads(result)
+    assert payload["transcribed"] is False
+    assert payload["reason"] == "pending"
+    assert transcription.get_cached_transcript(1, 5) is None
+
+
+@pytest.mark.asyncio
+async def test_transcribe_voice_premium_required_degrades_gracefully(
+    monkeypatch, transcript_cache_dir
+):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_by_id={5: _voice_msg(id=5)})
+    _patch_client(monkeypatch, client, entity, 1)
+    monkeypatch.setattr(transcription, "transcribe", _async_return({"status": "premium_required"}))
+
+    result = await messages.transcribe_voice(
+        chat_id=1, message_id=5, engine="telegram", account=None
+    )
+
+    payload = json.loads(result)
+    assert payload["sent"] is False
+    assert payload["reason"] == "telegram_premium_required"
+
+
+@pytest.mark.asyncio
+async def test_transcribe_voice_success_caches_result(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_by_id={5: _voice_msg(id=5)})
+    _patch_client(monkeypatch, client, entity, 1)
+    monkeypatch.setattr(
+        transcription, "transcribe", _async_return({"status": "ok", "text": "hi", "lang": "ru"})
+    )
+
+    result = await messages.transcribe_voice(
+        chat_id=1, message_id=5, engine="telegram", account=None
+    )
+
+    payload = json.loads(result)
+    assert payload["transcribed"] is True
+    assert payload["cached"] is False
+    assert payload["text"] == "hi"
+    assert payload["source"] == "telegram"
+    cached = transcription.get_cached_transcript(1, 5)
+    assert cached["text"] == "hi"
+    assert cached["lang"] == "ru"
+
+
+@pytest.mark.asyncio
+async def test_transcribe_voice_defaults_to_configured_engine(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE_ENGINE", "telegram")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_by_id={5: _voice_msg(id=5)})
+    _patch_client(monkeypatch, client, entity, 1)
+
+    seen_engine = {}
+
+    async def _fake_transcribe(cl, ent, msg, engine):
+        seen_engine["engine"] = engine
+        return {"status": "ok", "text": "x"}
+
+    monkeypatch.setattr(transcription, "transcribe", _fake_transcribe)
+
+    await messages.transcribe_voice(chat_id=1, message_id=5, account=None)  # no engine= passed
+
+    assert seen_engine["engine"] == "telegram"
+
+
+@pytest.mark.asyncio
+async def test_transcribe_voice_explicit_engine_overrides_default(
+    monkeypatch, transcript_cache_dir
+):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE_ENGINE", "groq")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_by_id={5: _voice_msg(id=5)})
+    _patch_client(monkeypatch, client, entity, 1)
+
+    seen_engine = {}
+
+    async def _fake_transcribe(cl, ent, msg, engine):
+        seen_engine["engine"] = engine
+        return {"status": "ok", "text": "x"}
+
+    monkeypatch.setattr(transcription, "transcribe", _fake_transcribe)
+
+    await messages.transcribe_voice(chat_id=1, message_id=5, engine="telegram", account=None)
+
+    assert seen_engine["engine"] == "telegram"


### PR DESCRIPTION
## What

Adds a bulk chat export CLI: `telegram-mcp-export`. It dumps whole chats to local files - JSONL by default, plus HTML in the shape Telegram Desktop produces, Markdown, and plain text.

```bash
telegram-mcp-export login
telegram-mcp-export chats
telegram-mcp-export export "Some Chat" --months 6 --format jsonl,html --media
telegram-mcp-export export @channel --all --transcribe groq
```

Depth is set per run and is mandatory - one of `--all`, `--months N`, `--since DATE`, optionally bounded by `--until`. Media (`--media`, `--media-max-mb`) and voice transcription (`--transcribe [engine]`) are opt-in. `--resume` continues an interrupted run, and `render` re-renders an existing JSONL into another format without touching the network.

## Why a CLI and not an MCP tool

An export writes hundreds of megabytes to the machine that runs the client and takes minutes to hours. An MCP tool would have to stream all of that through the model's context, and a tool call that runs for an hour is not a tool call. The MCP server keeps its read tools for reading; the export is a separate entry point over the same code.

## Session isolation

The export never touches the server's session. It keeps its own session file at `~/.config/telegram-mcp/export.session` and hard-pops `TELEGRAM_SESSION_STRING`, `TELEGRAM_SESSION_STRINGS` and `TELEGRAM_SESSION_STRING_<LABEL>` out of the environment before connecting. Reusing one auth key from two places is exactly what raises `AuthKeyDuplicatedError`, and Telegram revokes the key when it happens - the export would take the running server down with it.

## Refactor it needed

`telegram_mcp/runtime.py` discovers accounts at import time and calls `sys.exit(1)` when no session is configured, so importing the package as a library was impossible. Client construction, Premium helpers and the validation error moved to `telegram_mcp/client_factory.py`, `telegram_mcp/premium.py` and `telegram_mcp/errors.py`; `runtime` imports them back under its old private names, so nothing that used `runtime._build_client` breaks. Credentials are now read when a client is built, not when the module is imported.

## Correctness note: entity offsets are UTF-16

Telegram counts entity offsets in UTF-16 code units. Slicing the Python string works right up until someone sends an emoji, and then every span after it silently shifts. The renderer encodes to `utf-16-le` and slices there, and splits text at entity boundaries so nested entities never produce crossing tags.

## Tests

17 new tests (`tests/test_export_render.py`, `tests/test_export_session.py`). Two of them are guards rather than examples:

* `test_utf16_mutant_is_caught` monkeypatches the slicer back to naive Python slicing and asserts the suite notices.
* `test_export_cli_does_not_import_runtime` imports the CLI in a subprocess and fails if `telegram_mcp.runtime` ends up in `sys.modules` - that is the regression that made `login` exit 1 before the refactor.

Full suite passes, `black --check` and `flake8 --select=E9,F63,F7,F82` are clean.
