### PR TITLE
feat(rich): read rich messages and stream rich drafts (closes #159)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,3 +86,36 @@ TELEGRAM_SESSION_NAME=telegram_session
 # --- Remembered contacts (optional) ---
 # TELEGRAM_ALIASES_FILE=/path/to/aliases.json
 # TELEGRAM_CONTACT_FUZZY=0   # exact-match aliases only
+
+# --- Voice/video-note transcription (optional) ---
+# off: transcribe_voice tool disabled, listings never show transcripts.
+# on-demand (default): transcribe_voice works; get_history/get_messages/
+#   list_messages fill in already-cached transcripts but never spend an API
+#   call fetching a new one during a listing.
+# auto: also prefetches missing transcripts during a listing, bounded by
+#   TELEGRAM_TRANSCRIBE_MAX_VOICES / _MAX_SECONDS per call.
+# TELEGRAM_TRANSCRIBE=on-demand
+#
+# Which engine transcribe_voice and auto-mode prefetch use by default (the
+# per-call engine= argument always overrides this):
+# - groq (default): Groq-hosted whisper-large-v3-turbo. Requires GROQ_API_KEY.
+#   Downloads the voice note and sends it to Groq - leaves the server, not
+#   free, but does not drop the recording's last words the way native
+#   Telegram transcription does (proven 2026-08-20, see docs).
+# - telegram: native Telegram Premium transcription. Free, audio never
+#   leaves Telegram, but empirically drops the last speech segment in
+#   roughly 2 of 3 recordings. Requires Telegram Premium on the account.
+#   Use for chats that should never be sent to a third party.
+# TELEGRAM_TRANSCRIBE_ENGINE=groq
+# GROQ_API_KEY=<groq api key, required when engine=groq is ever used>
+#
+# Per-call budget for TELEGRAM_TRANSCRIBE=auto prefetch (ignored otherwise;
+# transcribe_voice itself is never budget-limited since it's an explicit call).
+# TELEGRAM_TRANSCRIBE_MAX_VOICES=5
+# TELEGRAM_TRANSCRIBE_MAX_SECONDS=300
+#
+# Where the SQLite transcript cache lives. This is personal-chat text in
+# plaintext on disk - keep it on a mounted volume (see docker-compose.yml) and
+# in its own directory, not shared with backups of anything else. The file
+# gets mode 600; the directory 700.
+# TELEGRAM_TRANSCRIPT_CACHE_DIR=data/transcripts

--- a/README.md
+++ b/README.md
@@ -57,7 +57,24 @@ The server currently includes 80+ MCP tools grouped into these areas:
 When a reference is unknown, resembles one contact, matches several, or points at a contact that no longer resolves, tools send nothing and return a structured instruction telling the agent exactly what to ask you, to save the answer with `set_contact_alias`, and to retry once. `list_contact_aliases` shows one row per person with all their aliases (use it to spot a wrong memory), `delete_contact_alias` forgets one, and repointing an alias at someone else requires `replace=True`. The save path itself refuses a target it would have to guess at: contacts are saved by @username, phone, numeric ID, or an alias already confirmed for them.
 
 Aliases live in `${XDG_STATE_HOME:-~/.local/state}/telegram-mcp/aliases.json` (owner-only, written atomically); `TELEGRAM_ALIASES_FILE` overrides the path, and a pre-existing `aliases.json` next to the code is still read as a fallback.
-- **Media:** send files, download media, upload files, send voice notes, stickers, GIFs, and inspect message media.
+- **Media:** send files, download media, upload files, send voice notes, stickers, GIFs, inspect message media, and transcribe voice messages/video notes (see below).
+
+### Voice transcription
+
+`transcribe_voice(chat_id, message_id, engine=None)` turns a voice message or video note into text. Two engines are available:
+
+- `groq` (default): uploads the recording to Groq's hosted `whisper-large-v3-turbo`. Leaves the server and costs a download+upload per call, but doesn't drop the recording's last few words the way native transcription does. Requires `GROQ_API_KEY`.
+- `telegram`: native Telegram Premium transcription (`messages.TranscribeAudioRequest`). Free and never leaves Telegram, but empirically drops the last speech segment in roughly 2 of 3 recordings and requires Telegram Premium on the account. Long recordings come back `pending` and are polled automatically.
+
+The engine is chosen per call via the `engine` argument, or otherwise defaults to `TELEGRAM_TRANSCRIBE_ENGINE` (`groq` or `telegram`). Results are cached by `(chat_id, message_id)` in a local SQLite file so repeat reads and repeat listings never re-transcribe the same message. Every transcript is returned with a `note` marking it as a machine transcript, not a verbatim quote — treat it as a paraphrase, not exact wording.
+
+`get_history`, `get_messages`, and `list_messages` fill in already-cached transcripts for voice messages instead of leaving the text empty, controlled by `TELEGRAM_TRANSCRIBE`:
+
+- `off`: `transcribe_voice` is disabled and listings never show transcripts.
+- `on-demand` (default): listings show cached transcripts but never spend an API call fetching a new one.
+- `auto`: listings also prefetch missing transcripts, bounded per call by `TELEGRAM_TRANSCRIBE_MAX_VOICES`/`TELEGRAM_TRANSCRIBE_MAX_SECONDS` (Groq isn't free, so this prefetch is budgeted rather than unbounded).
+
+The cache lives in `TELEGRAM_TRANSCRIPT_CACHE_DIR` (default `data/transcripts`), written as a 700 directory / 600 file since it holds personal-chat text in plaintext — see [Docker](#docker) for why this needs its own volume mount in a container.
 - **Profile and privacy:** get your own account info, update profile fields, set or delete profile photos, inspect privacy settings, get user info/photos/status, and manage bot commands.
 - **Folders and drafts:** list, create, update, reorder, and delete Telegram folders; save, list, and clear drafts.
 - **Events:** wait for incoming messages with debounce (`wait_for_new_message`, `wait_for_settled_message`), optionally for one chat only via `chat_id` — without it any unrelated conversation wakes the wait — or enable the opt-in incoming event feed for callback-style delivery (see below).
@@ -160,6 +177,23 @@ reduced Telegram account permission. The Telegram session string still has its
 normal authority inside the server process; read-only mode only prevents
 non-read-only tools from being registered and exposed through MCP. Accepted
 values are `all` (the default), `read-only`, and `read-only+<tool>,<tool>`.
+
+Voice transcription (see [Voice transcription](#voice-transcription) above) is
+off by default in the sense that no transcript is ever fetched unless you ask
+for one — `transcribe_voice` is always available, and listings only pick up
+already-cached transcripts. Enable prefetching or pick an engine explicitly:
+
+```env
+TELEGRAM_TRANSCRIBE=on-demand       # off / on-demand (default) / auto
+TELEGRAM_TRANSCRIBE_ENGINE=groq     # groq (default) or telegram
+GROQ_API_KEY=your_groq_api_key_here # required whenever engine=groq is used
+```
+
+`engine=groq` requires `GROQ_API_KEY`; `engine=telegram` requires Telegram
+Premium on the account. `TELEGRAM_TRANSCRIBE_MAX_VOICES` (default 5) and
+`TELEGRAM_TRANSCRIBE_MAX_SECONDS` (default 300) bound how much `auto` mode
+prefetches per listing call; `TELEGRAM_TRANSCRIPT_CACHE_DIR` (default
+`data/transcripts`) sets where the SQLite cache is written.
 
 Run the server locally:
 
@@ -496,6 +530,16 @@ The bundled Compose file runs the same setup:
 
 ```bash
 docker compose up --build -d
+```
+
+It also mounts `./transcript_cache` into the container at
+`/app/data/transcripts` so the voice-transcription SQLite cache (see
+[Voice transcription](#voice-transcription)) survives a rebuild instead of
+living in the container's writable layer. Create it once, owned by the
+container's `appuser` (uid 1000), before starting:
+
+```bash
+mkdir -p ./transcript_cache && chown 1000:1000 ./transcript_cache
 ```
 
 ### One container per client (stdio)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,30 @@ The server currently includes 80+ MCP tools grouped into these areas:
 
 - **Accounts:** list configured accounts and route tool calls by account label.
 - **Chats and groups:** list chats, inspect metadata, create groups/channels, join or leave chats, invite users, manage admins, bans, default permissions, slow mode, topics, invite links, common chats, read receipts, and message links.
-- **Messages:** send, schedule, edit, delete, forward, pin, unpin, mark read, reply, search, inspect context, create polls, manage reactions, inspect inline buttons, and press inline callbacks. `send_message`, `reply_to_message`, and `edit_message` support classic formatting (`parse_mode='md'`/`'html'`) and server-side rich formatting (`parse_mode='rich'`/`'rich_markdown'`/`'rich_html'` — full Markdown/HTML with tables, headings, formulas, and collapsible sections). Rich modes require Telegram Premium on the account; Premium is re-checked on every call, and without it nothing is sent — the tool returns a structured `telegram_premium_required` result so the agent can reformat with classic modes and retry.
+- **Messages:** send, schedule, edit, delete, forward, pin, unpin, mark read, reply, search, inspect context, create polls, manage reactions, inspect inline buttons, and press inline callbacks. `send_message`, `reply_to_message`, and `edit_message` support classic formatting (`parse_mode='md'`/`'html'`) and server-side rich formatting (`parse_mode='rich'`/`'rich_markdown'`/`'rich_html'` — full Markdown/HTML with tables, headings, formulas, and collapsible sections). Rich modes require Telegram Premium on the account; Premium is re-checked on every call, and without it nothing is sent — the tool returns a structured `telegram_premium_required` result so the agent can reformat with classic modes and retry. Rich messages are also readable and can be streamed as a live draft with `stream_rich_draft` (see below).
+### Rich messages
+
+Rich formatting is a Telegram Premium feature, and it works in both directions.
+
+**Reading.** A rich message keeps its content in page blocks rather than in the plain `message` field, so a client that only reads `message` shows it as empty. Every tool that returns messages (`list_messages`, `get_messages`, `search_messages`, `get_message_context`, ...) renders those blocks to Markdown and returns them as `rich_message`:
+
+```json
+{
+  "id": 4821,
+  "text": "# Release notes\n\n* tables\n* collapsible sections",
+  "rich_message": {
+    "blocks": 4,
+    "photos": 1,
+    "documents": 0,
+    "rtl": false
+  }
+}
+```
+
+When the message also carries plain text, that text stays in `text` and the rendering moves to `rich_message.markdown` instead of overwriting it. Headings, lists, tables, blockquotes, code blocks with a language, formulas, collapsible sections, and anchors all survive the round trip; a partially loaded message is flagged with `"partial": true`. Block types Telegram adds in a future layer degrade to a labelled placeholder (`[unsupported: PageBlockWhatever]`) instead of silently disappearing.
+
+**Streaming drafts.** `stream_rich_draft(chat_id, text, parse_mode="rich_md", draft_id=None)` shows the recipient a live rich draft, the way Telegram's own AI features type into a chat. It sends a typing action, not a message: nothing lands in the history, and the draft disappears on its own. Pass the `draft_id` returned by the first call into the next ones to keep updating the same draft; omit it to start a new one. Requires Premium, and the tool is excluded from read-only mode.
+
 - **Contacts:** list, search, add, delete, block, unblock, import, export, inspect direct chats, find recent contact interactions, and remember contacts by the names you actually use (see below).
 
 ### Remembered contacts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,4 +23,13 @@ services:
     # Replace './telegram_sessions' with your desired host path.
     # volumes:
     #   - ./telegram_sessions:/app
+    volumes:
+      # Voice/video-note transcript cache (SQLite, see telegram_mcp/transcription.py).
+      # Without this mount the cache lives only in the container's writable
+      # layer and is lost on every `docker compose build`. It holds plaintext
+      # personal-chat transcripts, so this directory should get its own
+      # backup/retention policy rather than riding along with a general backup.
+      # Host directory must be readable/writable by uid 1000 (appuser):
+      #   mkdir -p ./transcript_cache && chown 1000:1000 ./transcript_cache
+      - ./transcript_cache:/app/data/transcripts
     restart: unless-stopped

--- a/telegram_mcp/rich_messages.py
+++ b/telegram_mcp/rich_messages.py
@@ -1,0 +1,247 @@
+"""Reading Telegram Rich Messages.
+
+Rich messages (Telegram, June 2026) carry their content as Instant View page
+blocks in ``Message.rich_message``, not in ``Message.message``. A reader that
+only looks at ``.message`` therefore shows a rich message as **empty** - the
+tables, headings, formulas and collapsible sections are simply lost. This
+module renders those blocks back to Markdown so listings and exports show what
+was actually sent.
+
+Sending is the other half and lives in ``premium`` (``make_rich_input``); it
+requires Premium. Reading does not.
+
+Dispatch is by class name rather than ``isinstance`` so a block type added by a
+newer Telegram layer degrades to a labelled placeholder instead of raising.
+"""
+
+from typing import Any, Optional
+
+# Rich text nodes that wrap an inner node and map onto Markdown emphasis.
+_TEXT_WRAPPERS = {
+    "TextBold": ("**", "**"),
+    "TextItalic": ("_", "_"),
+    "TextUnderline": ("__", "__"),
+    "TextStrike": ("~~", "~~"),
+    "TextFixed": ("`", "`"),
+    "TextSpoiler": ("||", "||"),
+    "TextMarked": ("==", "=="),
+    "TextSubscript": ("~", "~"),
+    "TextSuperscript": ("^", "^"),
+}
+
+# Heading blocks, in Markdown heading depth.
+_HEADINGS = {
+    "PageBlockTitle": 1,
+    "PageBlockHeader": 1,
+    "PageBlockHeading1": 1,
+    "PageBlockSubtitle": 2,
+    "PageBlockSubheader": 2,
+    "PageBlockHeading2": 2,
+    "PageBlockHeading3": 3,
+    "PageBlockHeading4": 4,
+    "PageBlockHeading5": 5,
+    "PageBlockHeading6": 6,
+}
+
+# Blocks whose payload is a media object we do not inline when reading.
+_MEDIA_PLACEHOLDERS = {
+    "PageBlockPhoto": "photo",
+    "PageBlockVideo": "video",
+    "PageBlockAudio": "audio",
+    "PageBlockCollage": "collage",
+    "PageBlockSlideshow": "slideshow",
+    "PageBlockEmbed": "embedded content",
+    "PageBlockEmbedPost": "embedded post",
+    "PageBlockMap": "map",
+    "PageBlockCover": "cover",
+    "PageBlockChannel": "channel",
+    "PageBlockRelatedArticles": "related articles",
+}
+
+
+def rich_text_to_markdown(node: Any) -> str:
+    """Render a ``TypeRichText`` tree to Markdown."""
+    if node is None:
+        return ""
+    name = type(node).__name__
+
+    if name in ("TextEmpty",):
+        return ""
+    if name == "TextPlain":
+        return getattr(node, "text", "") or ""
+    if name == "TextConcat":
+        return "".join(rich_text_to_markdown(part) for part in getattr(node, "texts", []) or [])
+
+    inner = rich_text_to_markdown(getattr(node, "text", None))
+
+    if name in _TEXT_WRAPPERS:
+        if not inner:
+            return ""
+        open_tag, close_tag = _TEXT_WRAPPERS[name]
+        return f"{open_tag}{inner}{close_tag}"
+    if name == "TextUrl":
+        url = getattr(node, "url", "") or ""
+        return f"[{inner}]({url})" if url else inner
+    if name == "TextEmail":
+        return f"[{inner}](mailto:{getattr(node, 'email', '')})"
+    if name == "TextPhone":
+        return f"[{inner}](tel:{getattr(node, 'phone', '')})"
+    if name == "TextMath":
+        return f"${inner}$"
+    if name == "TextImage":
+        return "[image]"
+
+    # TextAnchor, TextMention, TextHashtag, TextUrl-ish autodetected nodes and
+    # anything newer: the inner text is the content, the decoration is not.
+    return inner
+
+
+def _list_items_to_markdown(items: list, ordered: bool) -> list[str]:
+    lines: list[str] = []
+    for index, item in enumerate(items or [], start=1):
+        marker = f"{index}." if ordered else "*"
+        if getattr(item, "blocks", None):
+            nested = "\n".join(page_block_to_markdown(block) for block in item.blocks).strip()
+            first, _, rest = nested.partition("\n")
+            lines.append(f"{marker} {first}")
+            for line in rest.splitlines():
+                lines.append(f"  {line}")
+        else:
+            text = rich_text_to_markdown(getattr(item, "text", None))
+            lines.append(f"{marker} {text}")
+    return lines
+
+
+def _table_to_markdown(block: Any) -> str:
+    rows = getattr(block, "rows", []) or []
+    if not rows:
+        return ""
+    rendered: list[list[str]] = []
+    header_index: Optional[int] = None
+    for row_index, row in enumerate(rows):
+        cells = getattr(row, "cells", []) or []
+        rendered.append([rich_text_to_markdown(getattr(c, "text", None)) for c in cells])
+        if header_index is None and any(getattr(c, "header", False) for c in cells):
+            header_index = row_index
+
+    width = max(len(row) for row in rendered)
+    rendered = [row + [""] * (width - len(row)) for row in rendered]
+
+    lines = []
+    title = rich_text_to_markdown(getattr(block, "title", None))
+    if title:
+        lines.append(f"**{title}**")
+        lines.append("")
+
+    # Markdown needs a header row; a table sent without header cells gets an
+    # empty one rather than losing its first row of data.
+    if header_index is None:
+        lines.append("| " + " | ".join([""] * width) + " |")
+        lines.append("|" + "|".join([" --- "] * width) + "|")
+        body = rendered
+    else:
+        lines.append("| " + " | ".join(rendered[header_index]) + " |")
+        lines.append("|" + "|".join([" --- "] * width) + "|")
+        body = [row for i, row in enumerate(rendered) if i != header_index]
+    for row in body:
+        lines.append("| " + " | ".join(row) + " |")
+    return "\n".join(lines)
+
+
+def page_block_to_markdown(block: Any) -> str:
+    """Render one ``TypePageBlock`` to Markdown."""
+    if block is None:
+        return ""
+    name = type(block).__name__
+
+    if name in _HEADINGS:
+        text = rich_text_to_markdown(getattr(block, "text", None))
+        return f"{'#' * _HEADINGS[name]} {text}" if text else ""
+    if name in ("PageBlockParagraph", "PageBlockKicker", "PageBlockFooter"):
+        return rich_text_to_markdown(getattr(block, "text", None))
+    if name == "PageBlockPreformatted":
+        language = getattr(block, "language", "") or ""
+        return f"```{language}\n{rich_text_to_markdown(getattr(block, 'text', None))}\n```"
+    if name in ("PageBlockBlockquote", "PageBlockPullquote"):
+        text = rich_text_to_markdown(getattr(block, "text", None))
+        quoted = "\n".join(f"> {line}" for line in text.splitlines()) or "> "
+        caption = rich_text_to_markdown(getattr(block, "caption", None))
+        return f"{quoted}\n> - {caption}" if caption else quoted
+    if name == "PageBlockBlockquoteBlocks":
+        inner = "\n".join(page_block_to_markdown(b) for b in getattr(block, "blocks", []) or [])
+        return "\n".join(f"> {line}" for line in inner.splitlines())
+    if name == "PageBlockList":
+        return "\n".join(_list_items_to_markdown(getattr(block, "items", []), ordered=False))
+    if name == "PageBlockOrderedList":
+        return "\n".join(_list_items_to_markdown(getattr(block, "items", []), ordered=True))
+    if name == "PageBlockTable":
+        return _table_to_markdown(block)
+    if name == "PageBlockDivider":
+        return "---"
+    if name == "PageBlockDetails":
+        # A collapsible section. Its open/closed state is preserved because the
+        # sender chose it, and a reader that flattens it loses that intent.
+        title = rich_text_to_markdown(getattr(block, "title", None)) or "Details"
+        state = "open" if getattr(block, "open", False) else "collapsed"
+        inner = "\n".join(page_block_to_markdown(b) for b in getattr(block, "blocks", []) or [])
+        return f"**{title}** ({state})\n{inner}".rstrip()
+    if name == "PageBlockMath":
+        return f"$$\n{rich_text_to_markdown(getattr(block, 'text', None))}\n$$"
+    if name == "PageBlockThinking":
+        inner = rich_text_to_markdown(getattr(block, "text", None))
+        if not inner:
+            inner = "\n".join(
+                page_block_to_markdown(b) for b in getattr(block, "blocks", []) or []
+            )
+        return f"_[thinking]_ {inner}".rstrip()
+    if name == "PageBlockAnchor":
+        return ""
+    if name in _MEDIA_PLACEHOLDERS:
+        caption = getattr(block, "caption", None)
+        caption_text = rich_text_to_markdown(getattr(caption, "text", None)) if caption else ""
+        label = f"[{_MEDIA_PLACEHOLDERS[name]}]"
+        return f"{label} {caption_text}".strip()
+    if name == "PageBlockAuthorDate":
+        author = rich_text_to_markdown(getattr(block, "author", None))
+        return f"_{author}_" if author else ""
+
+    # Unknown or explicitly unsupported: say so rather than dropping content
+    # silently, so a new Telegram layer shows up as a visible gap.
+    text = rich_text_to_markdown(getattr(block, "text", None))
+    label = name.replace("PageBlock", "").lower()
+    return f"[{label}] {text}".strip() if text else f"[{label}]"
+
+
+def rich_message_to_markdown(rich: Any) -> str:
+    """Render ``Message.rich_message`` to a Markdown document."""
+    blocks = getattr(rich, "blocks", None) or []
+    rendered = [page_block_to_markdown(block) for block in blocks]
+    return "\n\n".join(part for part in rendered if part).strip()
+
+
+def rich_message_to_dict(rich: Any) -> dict:
+    """Compact view of a rich message for tool output.
+
+    ``part`` marks a partial (streaming) rich message: the sender is still
+    producing it, so the text is not final.
+    """
+    payload: dict[str, Any] = {"markdown": rich_message_to_markdown(rich)}
+    photos = getattr(rich, "photos", None) or []
+    documents = getattr(rich, "documents", None) or []
+    if photos:
+        payload["photos"] = len(photos)
+    if documents:
+        payload["documents"] = len(documents)
+    if getattr(rich, "rtl", False):
+        payload["rtl"] = True
+    if getattr(rich, "part", False):
+        payload["partial"] = True
+    return payload
+
+
+def message_rich_payload(msg: Any) -> Optional[dict]:
+    """``rich_message`` view for a message, or None when it carries none."""
+    rich = getattr(msg, "rich_message", None)
+    if rich is None:
+        return None
+    return rich_message_to_dict(rich)

--- a/telegram_mcp/rich_messages.py
+++ b/telegram_mcp/rich_messages.py
@@ -245,3 +245,30 @@ def message_rich_payload(msg: Any) -> Optional[dict]:
     if rich is None:
         return None
     return rich_message_to_dict(rich)
+
+
+def attach_to_record(
+    record: dict, msg: Any, text_key: str = "text", transform: Optional[Any] = None
+) -> dict:
+    """Put a message's rich content into a plain record, in place.
+
+    One rule for every reader, so they cannot drift: the rendering fills the
+    text field only when the message has no plain text of its own. A rich
+    message has none, and without this it reads as empty.
+
+    ``transform`` is applied to the rendering before it is stored - the MCP
+    tools sanitize user-controlled content before returning it.
+    """
+    payload = message_rich_payload(msg)
+    if payload is None:
+        return record
+    markdown = payload.pop("markdown", "")
+    if markdown and transform is not None:
+        markdown = transform(markdown)
+    if markdown:
+        if record.get(text_key):
+            payload["markdown"] = markdown
+        else:
+            record[text_key] = markdown
+    record["rich_message"] = payload
+    return record

--- a/telegram_mcp/runner.py
+++ b/telegram_mcp/runner.py
@@ -10,6 +10,7 @@ except UnsafeInstallationError as exc:
 from telethon.errors import AuthKeyDuplicatedError
 
 from telegram_mcp import runtime as _runtime
+from telegram_mcp import transcription as _transcription
 from telegram_mcp.runtime import *
 from telegram_mcp.singleton import (
     DEFAULT_GRACE_SECONDS,
@@ -191,6 +192,7 @@ async def _main() -> None:
 def main() -> None:
     _configure_allowed_roots_from_cli(sys.argv[1:])
     _runtime._apply_exposed_tools_mode()
+    _transcription.validate_transcription_config()
     asyncio.run(_main())
 
 

--- a/telegram_mcp/runtime.py
+++ b/telegram_mcp/runtime.py
@@ -57,6 +57,7 @@ from functools import wraps
 import telethon.errors.rpcerrorlist
 from sanitize import sanitize_user_content, sanitize_name, sanitize_dict, format_tool_result
 from telegram_mcp.client_identity import client_identity_kwargs
+from telegram_mcp import rich_messages
 
 
 class ValidationError(Exception):
@@ -1363,6 +1364,24 @@ async def resolve_input_entity(identifier: Union[int, str], client=None) -> Any:
     return await _resolve("get_input_entity", identifier, client, "input entity")
 
 
+def attach_message_text(record: dict, message: Any, key: str = "text") -> dict:
+    """Put a message's readable content into ``record[key]``, in place.
+
+    Sanitizing ``message.message`` is not enough on its own: a rich message
+    keeps its content in page blocks, so that field is empty and the sanitizer
+    turns it into the "[empty]" marker - a message full of tables and headings
+    reads as an empty one. Every reader has to render the blocks before it
+    decides a message is empty, and there are eight readers, so the rule lives
+    here rather than being retyped (and forgotten) in each of them.
+    """
+    text = sanitize_user_content(message.message) if getattr(message, "message", None) else ""
+    if text:
+        record[key] = text
+    rich_messages.attach_to_record(record, message, text_key=key, transform=sanitize_user_content)
+    record.setdefault(key, sanitize_user_content(None))
+    return record
+
+
 def format_message(message) -> Dict[str, Any]:
     """Helper function to format message information consistently.
 
@@ -1371,8 +1390,8 @@ def format_message(message) -> Dict[str, Any]:
     result = {
         "id": message.id,
         "date": message.date.isoformat(),
-        "text": sanitize_user_content(message.message),
     }
+    attach_message_text(result, message)
 
     if message.from_id:
         result["from_id"] = utils.get_peer_id(message.from_id)

--- a/telegram_mcp/tools/chats.py
+++ b/telegram_mcp/tools/chats.py
@@ -678,11 +678,12 @@ async def get_chat(chat_id: Union[int, str], account: str = None) -> str:
                     if getattr(sender, "last_name", None):
                         sender_name += f" {sender.last_name}"
                 sender_name = sanitize_name(sender_name.strip() or "Unknown")
-                record["last_message"] = {
+                last_message = {
                     "sender": sender_name,
                     "date": last_msg.date,
-                    "text": sanitize_user_content(last_msg.message),
                 }
+                attach_message_text(last_message, last_msg)
+                record["last_message"] = last_message
         except Exception as diag_ex:
             logger.warning(f"Could not get dialog info for {chat_id}: {diag_ex}")
 

--- a/telegram_mcp/tools/contacts.py
+++ b/telegram_mcp/tools/contacts.py
@@ -280,13 +280,12 @@ async def get_last_interaction(contact_id: Union[int, str], account: Optional[st
 
         records = []
         for msg in messages:
-            records.append(
-                {
-                    "date": msg.date,
-                    "from": "You" if msg.out else contact_name,
-                    "text": sanitize_user_content(msg.message),
-                }
-            )
+            record = {
+                "date": msg.date,
+                "from": "You" if msg.out else contact_name,
+            }
+            attach_message_text(record, msg)
+            records.append(record)
 
         return format_tool_result(
             records,

--- a/telegram_mcp/tools/messages.py
+++ b/telegram_mcp/tools/messages.py
@@ -1,7 +1,7 @@
 """Messages MCP tools."""
 
 from telegram_mcp.runtime import *
-from telegram_mcp import transcription
+from telegram_mcp import rich_messages, transcription
 
 # Domain used to build message permalinks. Overridable because the default is a
 # single point of failure: on 2026-07-13 the .me registry put t.me on serverHold
@@ -147,6 +147,19 @@ def message_to_dict(msg, chat_id: Optional[int] = None) -> dict:
     media_label = get_media_label(msg)
     if media_label:
         d["media"] = media_label
+
+    # A rich message keeps its content in page blocks, not in msg.message: without
+    # this the whole message reads as empty. The rendered Markdown goes where a
+    # reader looks for content, and is not repeated inside rich_message.
+    rich_payload = rich_messages.message_rich_payload(msg)
+    if rich_payload is not None:
+        markdown = rich_payload.pop("markdown", "")
+        if markdown:
+            if text:
+                rich_payload["markdown"] = markdown
+            else:
+                d["text"] = sanitize_user_content(markdown)
+        d["rich_message"] = rich_payload
 
     if not text:
         voice_info = transcription.voice_attachment_info(msg, chat_id)
@@ -415,6 +428,38 @@ async def _edit_rich(cl, entity, message_id: int, text: str, parse_mode: str):
     )
 
 
+async def _send_rich_draft(cl, entity, text: str, parse_mode: str, draft_id: Optional[int]):
+    """Push one state of a streaming rich draft. Returns a JSON result string.
+
+    Telegram carries a live, still-being-written rich message as a typing
+    action rather than as a message: peers see it update in place and nothing
+    is added to the history. Successive calls sharing one random_id are states
+    of the same draft, which is why the id is returned and accepted back.
+    """
+    import random
+
+    if not await account_is_premium(cl):
+        return premium_required_result("stream_rich_draft")
+    random_id = draft_id if draft_id is not None else random.randint(0, 2**62)
+    try:
+        await cl(
+            functions.messages.SetTypingRequest(
+                peer=entity,
+                action=types.InputSendMessageRichMessageDraftAction(
+                    rich_message=make_rich_input(parse_mode, text),
+                    random_id=random_id,
+                ),
+            )
+        )
+    except telethon.errors.RPCError as e:
+        if is_premium_rpc_error(e):
+            return premium_required_result("stream_rich_draft")
+        raise
+    return json.dumps(
+        {"sent": True, "rich": True, "draft": True, "draft_id": random_id}, ensure_ascii=False
+    )
+
+
 @mcp.tool(
     annotations=ToolAnnotations(title="Send Message", openWorldHint=True, destructiveHint=True)
 )
@@ -450,6 +495,66 @@ async def send_message(
         return "Message sent successfully."
     except Exception as e:
         return log_and_format_error("send_message", e, chat_id=chat_id)
+
+
+@mcp.tool(
+    annotations=ToolAnnotations(
+        title="Stream Rich Message Draft",
+        openWorldHint=True,
+        destructiveHint=False,
+        idempotentHint=False,
+    )
+)
+@with_account(readonly=False)
+@validate_id("chat_id")
+async def stream_rich_draft(
+    chat_id: Union[int, str],
+    text: str,
+    parse_mode: str = "rich_md",
+    draft_id: Optional[int] = None,
+    account: str = None,
+) -> str:
+    """
+    Show a live, still-being-written rich message in a chat without posting it.
+
+    Peers see the draft update in place, the way a streamed answer appears; it
+    is a typing action, so nothing is written to the chat history and there is
+    nothing to delete. Send the finished text with send_message(parse_mode=
+    'rich') when it is ready.
+
+    Args:
+        chat_id: The ID or username of the chat.
+        text: The draft content so far, in the syntax named by parse_mode.
+        parse_mode: 'rich'/'rich_md'/'rich_markdown' for server-side Markdown,
+            or 'rich_html' for HTML. Plain 'md'/'html' are not draft formats.
+        draft_id: Pass the draft_id returned by the previous call to keep
+            updating the same draft. Omit it to start a new one.
+        account: Account label in multi-account mode.
+
+    Returns:
+        JSON with the draft_id to pass to the next call, or a structured
+        {"sent": false, "reason": "telegram_premium_required"} refusal - rich
+        drafts need Telegram Premium, re-checked on every call.
+    """
+    try:
+        mode = (parse_mode or "").lower()
+        if mode not in RICH_PARSE_MODES:
+            return json.dumps(
+                {
+                    "sent": False,
+                    "reason": "invalid_parse_mode",
+                    "detail": (
+                        f"stream_rich_draft needs a rich parse mode, got '{parse_mode}'. "
+                        f"Use one of: {', '.join(sorted(RICH_PARSE_MODES))}."
+                    ),
+                },
+                ensure_ascii=False,
+            )
+        cl = get_client(account)
+        entity = await resolve_entity(chat_id, cl)
+        return await _send_rich_draft(cl, entity, text, mode, draft_id)
+    except Exception as e:
+        return log_and_format_error("stream_rich_draft", e, chat_id=chat_id)
 
 
 @mcp.tool(

--- a/telegram_mcp/tools/messages.py
+++ b/telegram_mcp/tools/messages.py
@@ -1060,8 +1060,8 @@ async def list_messages(
                 "id": msg.id,
                 "sender": get_sender_info(msg),
                 "date": msg.date,
-                "text": sanitize_user_content(msg.message),
             }
+            attach_message_text(record, msg)
             # Upstream bug: this hand-built record never called get_media_label,
             # so a voice/photo/etc. with no caption was indistinguishable from
             # an actually-empty message. message_to_dict (used by get_history)
@@ -1286,8 +1286,8 @@ async def get_message_context(
                 "sender": sender_name,
                 "date": msg.date,
                 "is_target": msg.id == message_id,
-                "text": sanitize_user_content(msg.message),
             }
+            attach_message_text(record, msg)
             if getattr(msg, "sender_id", None):
                 record["sender_id"] = msg.sender_id
             _username = get_sender_username(msg)
@@ -1308,8 +1308,8 @@ async def get_message_context(
                     if replied_msg:
                         replied_record = {
                             "sender": get_sender_name(replied_msg),
-                            "text": sanitize_user_content(replied_msg.message),
                         }
+                        attach_message_text(replied_record, replied_msg)
                         if getattr(replied_msg, "sender_id", None):
                             replied_record["sender_id"] = replied_msg.sender_id
                         _r_username = get_sender_username(replied_msg)
@@ -1785,8 +1785,8 @@ async def search_messages(
                 "id": msg.id,
                 "sender": get_sender_info(msg),
                 "date": msg.date,
-                "text": sanitize_user_content(msg.message),
             }
+            attach_message_text(record, msg)
             if msg.reply_to and msg.reply_to.reply_to_msg_id:
                 record["reply_to"] = msg.reply_to.reply_to_msg_id
             reply_quote = get_reply_quote(msg)
@@ -1831,16 +1831,15 @@ async def search_global(
             chat_name = (
                 getattr(chat, "title", None) or getattr(chat, "first_name", "") or str(msg.chat_id)
             )
-            records.append(
-                {
-                    "chat_name": sanitize_name(chat_name),
-                    "chat_id": msg.chat_id,
-                    "id": msg.id,
-                    "sender": get_sender_info(msg),
-                    "date": msg.date,
-                    "text": sanitize_user_content(msg.message),
-                }
-            )
+            record = {
+                "chat_name": sanitize_name(chat_name),
+                "chat_id": msg.chat_id,
+                "id": msg.id,
+                "sender": get_sender_info(msg),
+                "date": msg.date,
+            }
+            attach_message_text(record, msg)
+            records.append(record)
 
         return format_tool_result(records)
     except Exception as e:
@@ -1906,8 +1905,8 @@ async def get_pinned_messages(chat_id: Union[int, str], account: str = None) -> 
                 "id": msg.id,
                 "sender": get_sender_info(msg),
                 "date": msg.date,
-                "text": sanitize_user_content(msg.message),
             }
+            attach_message_text(record, msg)
             if msg.reply_to and msg.reply_to.reply_to_msg_id:
                 record["reply_to"] = msg.reply_to.reply_to_msg_id
             reply_quote = get_reply_quote(msg)

--- a/telegram_mcp/tools/messages.py
+++ b/telegram_mcp/tools/messages.py
@@ -1,6 +1,7 @@
 """Messages MCP tools."""
 
 from telegram_mcp.runtime import *
+from telegram_mcp import transcription
 
 # Domain used to build message permalinks. Overridable because the default is a
 # single point of failure: on 2026-07-13 the .me registry put t.me on serverHold
@@ -116,13 +117,17 @@ def get_reply_quote(msg) -> Optional[dict]:
     return quote
 
 
-def message_to_dict(msg) -> dict:
+def message_to_dict(msg, chat_id: Optional[int] = None) -> dict:
     """API-complete but compact Telethon message view (omit empty fields).
 
     The goal is for the MCP output to match the API object in completeness, rather
     than losing data such as media, albums, forwards, edits, buttons, reactions,
     and so on. All these fields are already present in the message object returned
     by the same get_messages request.
+
+    chat_id (the numeric chat this message belongs to) enables voice/video-note
+    transcript enrichment via the cache - omit it to get the old text-only
+    behavior (used by existing tests with bare fake messages).
     """
     d = {"id": msg.id, "sender": get_sender_name(msg), "date": msg.date}
 
@@ -142,6 +147,18 @@ def message_to_dict(msg) -> dict:
     media_label = get_media_label(msg)
     if media_label:
         d["media"] = media_label
+
+    if not text:
+        voice_info = transcription.voice_attachment_info(msg, chat_id)
+        if voice_info is not None:
+            if voice_info["duration"] is not None:
+                d["duration"] = voice_info["duration"]
+            if voice_info["transcript_status"] == "ready":
+                d["transcript"] = voice_info["transcript"]
+                d["transcript_source"] = voice_info["transcript_source"]
+                d["transcript_note"] = "Machine transcript, not a verbatim quote."
+            elif voice_info["transcript_status"] == "pending":
+                d["transcript_status"] = "pending"
 
     grouped_id = getattr(msg, "grouped_id", None)
     if grouped_id:
@@ -185,9 +202,9 @@ def message_to_dict(msg) -> dict:
                 uname = getattr(chat, "username", None)
                 if uname:
                     finfo["from_username"] = uname
-            chat_id = getattr(fo, "chat_id", None)
-            if chat_id is not None:
-                finfo["from_chat_id"] = chat_id
+            fwd_chat_id = getattr(fo, "chat_id", None)
+            if fwd_chat_id is not None:
+                finfo["from_chat_id"] = fwd_chat_id
             sender = getattr(fo, "sender", None)
             if sender is not None:
                 sname = " ".join(
@@ -261,8 +278,12 @@ def message_to_dict(msg) -> dict:
     return d
 
 
-def format_message_line(msg) -> str:
-    """Single-line human-readable message representation with ALL key flags."""
+def format_message_line(msg, chat_id: Optional[int] = None) -> str:
+    """Single-line human-readable message representation with ALL key flags.
+
+    chat_id enables voice/video-note transcript enrichment via the cache -
+    see message_to_dict for why it's optional.
+    """
     parts = [f"ID: {msg.id}", get_sender_info(msg), f"Date: {msg.date}"]
 
     reply_to_id = (
@@ -306,7 +327,11 @@ def format_message_line(msg) -> str:
         parts.append(engagement_info)
 
     raw = sanitize_user_content(msg.message) if getattr(msg, "message", None) else ""
-    safe_text = raw.replace("\n", "\\n") if raw else "[empty]"
+    if raw:
+        safe_text = raw.replace("\n", "\\n")
+    else:
+        voice_info = transcription.voice_attachment_info(msg, chat_id)
+        safe_text = transcription.render_voice_text(voice_info) if voice_info else "[empty]"
     return " | ".join(parts) + f" | Message: {safe_text}"
 
 
@@ -332,7 +357,9 @@ async def get_messages(
         messages = await cl.get_messages(entity, limit=page_size, add_offset=offset)
         if not messages:
             return "No messages found for this page."
-        lines = [format_message_line(msg) for msg in messages]
+        numeric_chat_id = get_marked_id(entity)
+        await transcription.prefetch_transcripts(cl, entity, numeric_chat_id, messages)
+        lines = [format_message_line(msg, numeric_chat_id) for msg in messages]
         return "\n".join(lines)
     except Exception as e:
         return log_and_format_error(
@@ -919,6 +946,9 @@ async def list_messages(
         if not messages:
             return "No messages found matching the criteria."
 
+        numeric_chat_id = get_marked_id(entity)
+        await transcription.prefetch_transcripts(cl, entity, numeric_chat_id, messages)
+
         records = []
         for msg in messages:
             record = {
@@ -934,6 +964,18 @@ async def list_messages(
             media_label = get_media_label(msg)
             if media_label:
                 record["media"] = media_label
+
+            if not getattr(msg, "message", None):
+                voice_info = transcription.voice_attachment_info(msg, numeric_chat_id)
+                if voice_info is not None:
+                    if voice_info["duration"] is not None:
+                        record["duration"] = voice_info["duration"]
+                    if voice_info["transcript_status"] == "ready":
+                        record["transcript"] = voice_info["transcript"]
+                        record["transcript_source"] = voice_info["transcript_source"]
+                        record["transcript_note"] = "Machine transcript, not a verbatim quote."
+                    elif voice_info["transcript_status"] == "pending":
+                        record["transcript_status"] = "pending"
 
             grouped_id = getattr(msg, "grouped_id", None)
             if grouped_id is not None:
@@ -952,6 +994,135 @@ async def list_messages(
         return format_tool_result(records)
     except Exception as e:
         return log_and_format_error("list_messages", e, chat_id=chat_id)
+
+
+@mcp.tool(
+    annotations=ToolAnnotations(title="Transcribe Voice", openWorldHint=True, readOnlyHint=True)
+)
+@with_account(readonly=True)
+@validate_id("chat_id")
+async def transcribe_voice(
+    chat_id: Union[int, str],
+    message_id: int,
+    engine: str = None,
+    account: str = None,
+) -> str:
+    """
+    Transcribe a voice message or video note (video circle) to text.
+
+    Two engines behind one interface:
+    - "groq" (default, override with TELEGRAM_TRANSCRIBE_ENGINE): Groq-hosted
+      whisper-large-v3-turbo. Downloads the audio and sends it to Groq - not
+      free, and leaves the server. Does not drop the recording's last words.
+    - "telegram": native Telegram Premium transcription. Free, audio never
+      leaves Telegram, but empirically drops the last speech segment in
+      roughly 2 of 3 recordings (proven with per-segment timestamps). Use for
+      chats you don't want sent to a third party, or when Groq is unavailable.
+      Requires Telegram Premium on this account; polls briefly (up to ~20s)
+      while Telegram finishes a long recording.
+
+    Results are cached by (chat_id, message_id) - a repeat call for an
+    already-transcribed message returns the cached text without hitting
+    either API again.
+
+    The returned text is a machine transcript, not a verbatim quote: proper
+    names, punctuation and occasional words drift under both engines.
+
+    Args:
+        chat_id: The chat ID or username.
+        message_id: The message ID containing the voice/video-note media.
+        engine: "groq" or "telegram". Defaults to TELEGRAM_TRANSCRIBE_ENGINE
+            (groq unless configured otherwise).
+    """
+    try:
+        mode = transcription.transcribe_mode()
+        if mode == "off":
+            return json.dumps(
+                {"transcribed": False, "reason": "transcription_disabled"}, ensure_ascii=False
+            )
+
+        cl = get_client(account)
+        entity = await resolve_entity(chat_id, cl)
+        numeric_chat_id = get_marked_id(entity)
+
+        cached = transcription.get_cached_transcript(numeric_chat_id, message_id)
+        if cached is not None:
+            return json.dumps(
+                {
+                    "transcribed": True,
+                    "cached": True,
+                    "text": cached["text"],
+                    "source": cached["source"],
+                    "duration": cached["duration"],
+                    "note": "Machine transcript, not a verbatim quote.",
+                },
+                ensure_ascii=False,
+                default=json_serializer,
+            )
+
+        msg = await cl.get_messages(entity, ids=message_id)
+        if not msg:
+            return f"Message {message_id} not found."
+        if not transcription.is_transcribable(msg):
+            return f"Message {message_id} has no voice message or video note to transcribe."
+
+        chosen_engine = (engine or transcription.default_engine()).strip().lower()
+        if chosen_engine not in transcription.ENGINES:
+            return f"Invalid engine '{engine}'. Use 'telegram' or 'groq'."
+        if chosen_engine == "groq" and not os.getenv("GROQ_API_KEY"):
+            return (
+                "GROQ_API_KEY is not configured on this server. "
+                "Use engine='telegram' or set GROQ_API_KEY."
+            )
+
+        duration = transcription.voice_duration(msg)
+        result = await transcription.transcribe(cl, entity, msg, chosen_engine)
+
+        if result["status"] == "premium_required":
+            return premium_required_result("transcribe_voice (engine='telegram')")
+        if result["status"] == "pending":
+            return json.dumps(
+                {
+                    "transcribed": False,
+                    "reason": "pending",
+                    "duration": duration,
+                    "detail": "Telegram is still processing this recording. Retry shortly.",
+                },
+                ensure_ascii=False,
+            )
+        if result["status"] == "error":
+            return log_and_format_error(
+                "transcribe_voice",
+                RuntimeError(result.get("error", "unknown error")),
+                chat_id=chat_id,
+                message_id=message_id,
+                engine=chosen_engine,
+            )
+
+        transcription.save_transcript(
+            numeric_chat_id,
+            message_id,
+            chosen_engine,
+            result["text"],
+            duration=duration,
+            lang=result.get("lang"),
+        )
+        return json.dumps(
+            {
+                "transcribed": True,
+                "cached": False,
+                "text": result["text"],
+                "source": chosen_engine,
+                "duration": duration,
+                "note": "Machine transcript, not a verbatim quote.",
+            },
+            ensure_ascii=False,
+            default=json_serializer,
+        )
+    except Exception as e:
+        return log_and_format_error(
+            "transcribe_voice", e, chat_id=chat_id, message_id=message_id, engine=engine
+        )
 
 
 @mcp.tool(
@@ -1579,7 +1750,9 @@ async def get_history(chat_id: Union[int, str], limit: int = 100, account: str =
         entity = await resolve_entity(chat_id, cl)
         messages = await cl.get_messages(entity, limit=limit)
 
-        records = [message_to_dict(msg) for msg in messages]
+        numeric_chat_id = get_marked_id(entity)
+        await transcription.prefetch_transcripts(cl, entity, numeric_chat_id, messages)
+        records = [message_to_dict(msg, numeric_chat_id) for msg in messages]
         return format_tool_result(records)
     except Exception as e:
         return log_and_format_error("get_history", e, chat_id=chat_id, limit=limit)

--- a/telegram_mcp/tools/messages.py
+++ b/telegram_mcp/tools/messages.py
@@ -1021,9 +1021,11 @@ async def transcribe_voice(
       Requires Telegram Premium on this account; polls briefly (up to ~20s)
       while Telegram finishes a long recording.
 
-    Results are cached by (chat_id, message_id) - a repeat call for an
-    already-transcribed message returns the cached text without hitting
-    either API again.
+    Results are cached per engine, by (chat_id, message_id, engine) - a
+    repeat call with the same engine returns the cached text without
+    hitting either API again. Asking for an engine that has no cached
+    result transcribes with it, even when the other engine's text is
+    already cached.
 
     The returned text is a machine transcript, not a verbatim quote: proper
     names, punctuation and occasional words drift under both engines.
@@ -1045,7 +1047,16 @@ async def transcribe_voice(
         entity = await resolve_entity(chat_id, cl)
         numeric_chat_id = get_marked_id(entity)
 
-        cached = transcription.get_cached_transcript(numeric_chat_id, message_id)
+        chosen_engine = (engine or transcription.default_engine()).strip().lower()
+        if chosen_engine not in transcription.ENGINES:
+            return f"Invalid engine '{engine}'. Use 'telegram' or 'groq'."
+
+        # Pinned to the chosen engine on purpose: a cached telegram transcript
+        # must not answer a groq request. The native engine drops the last
+        # speech segment and the loss cannot be seen in the text.
+        cached = transcription.get_cached_transcript(
+            numeric_chat_id, message_id, source=chosen_engine
+        )
         if cached is not None:
             return json.dumps(
                 {
@@ -1066,9 +1077,6 @@ async def transcribe_voice(
         if not transcription.is_transcribable(msg):
             return f"Message {message_id} has no voice message or video note to transcribe."
 
-        chosen_engine = (engine or transcription.default_engine()).strip().lower()
-        if chosen_engine not in transcription.ENGINES:
-            return f"Invalid engine '{engine}'. Use 'telegram' or 'groq'."
         if chosen_engine == "groq" and not os.getenv("GROQ_API_KEY"):
             return (
                 "GROQ_API_KEY is not configured on this server. "

--- a/telegram_mcp/transcription.py
+++ b/telegram_mcp/transcription.py
@@ -1,0 +1,436 @@
+"""Voice/video-note transcription: engines, SQLite cache, and batch budget.
+
+Two engines behind one interface (see ``transcribe``):
+
+* ``telegram`` - native Premium ``messages.transcribeAudio``. Free, but drops
+  the last speech segment in roughly 2 of 3 real recordings (proven with
+  per-segment timestamps against a local Whisper run on 2026-08-20 - see
+  ``~/Workspace/AI Playground/docs/2026-08-20-telegram-voice-transcripts.md``).
+  Async: a long recording comes back ``pending=True`` and must be polled.
+* ``groq`` - Groq-hosted ``whisper-large-v3-turbo``. Does not drop the tail,
+  but costs a download+upload per voice message and sends the audio to a
+  third party. Primary engine by owner decision (2026-08-20); ``telegram``
+  is the free/private fallback.
+
+Every transcript is a machine reading, not a verbatim quote (proper names and
+punctuation drift under both engines) - callers must surface ``source``
+alongside ``text`` rather than presenting it as exact speech.
+"""
+
+import asyncio
+import os
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import httpx
+from telethon.tl import functions
+
+from telegram_mcp.runtime import account_is_premium, get_marked_id, is_premium_rpc_error
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_TRANSCRIBE_MODES = {"off", "on-demand", "auto"}
+ENGINES = {"telegram", "groq"}
+
+GROQ_TRANSCRIBE_URL = "https://api.groq.com/openai/v1/audio/transcriptions"
+GROQ_MODEL = "whisper-large-v3-turbo"
+
+
+def transcribe_mode() -> str:
+    """``TELEGRAM_TRANSCRIBE``: off | on-demand | auto (default on-demand).
+
+    ``off`` disables the dedicated tool and all auto-mixing. ``on-demand``
+    (default) keeps the dedicated tool and fills cache hits into listings,
+    but never spends a batch call fetching a new one. ``auto`` additionally
+    prefetches missing transcripts into listings, bounded by
+    :class:`TranscribeBudget`.
+    """
+    raw = os.getenv("TELEGRAM_TRANSCRIBE", "on-demand").strip().lower()
+    if raw not in _TRANSCRIBE_MODES:
+        accepted = ", ".join(sorted(_TRANSCRIBE_MODES))
+        raise SystemExit(f"Invalid TELEGRAM_TRANSCRIBE '{raw}'. Expected one of: {accepted}.")
+    return raw
+
+
+def default_engine() -> str:
+    """``TELEGRAM_TRANSCRIBE_ENGINE``: telegram | groq (default groq).
+
+    Groq is the primary engine (owner decision 2026-08-20: native Telegram
+    transcription drops the last speech segment in ~2 of 3 recordings).
+    Override to ``telegram`` for chats that should never leave the server,
+    or when GROQ_API_KEY / quota is unavailable. Per-call ``engine=`` on
+    transcribe_voice always takes precedence over this default.
+    """
+    raw = os.getenv("TELEGRAM_TRANSCRIBE_ENGINE", "groq").strip().lower()
+    if raw not in ENGINES:
+        accepted = ", ".join(sorted(ENGINES))
+        raise SystemExit(
+            f"Invalid TELEGRAM_TRANSCRIBE_ENGINE '{raw}'. Expected one of: {accepted}."
+        )
+    return raw
+
+
+def validate_transcription_config() -> None:
+    """Fail loudly at startup on a bad toggle, matching TELEGRAM_EXPOSED_TOOLS."""
+    transcribe_mode()
+    default_engine()
+
+
+# ---------------------------------------------------------------------------
+# SQLite cache
+# ---------------------------------------------------------------------------
+#
+# This is a personal-chat transcript store in plaintext on the VPS - mode 600,
+# its own directory (not the session/app directory), mounted as a volume so a
+# rebuild doesn't silently drop it (docker-compose.yml has no volume by
+# default).
+
+
+def cache_dir() -> Path:
+    raw = os.getenv("TELEGRAM_TRANSCRIPT_CACHE_DIR", "data/transcripts")
+    d = Path(raw)
+    d.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(d, 0o700)
+    except OSError:
+        pass
+    return d
+
+
+def _cache_db_path() -> Path:
+    return cache_dir() / "transcripts.db"
+
+
+def _connect() -> sqlite3.Connection:
+    path = _cache_db_path()
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS transcripts (
+            chat_id INTEGER NOT NULL,
+            message_id INTEGER NOT NULL,
+            source TEXT NOT NULL,
+            text TEXT NOT NULL,
+            duration INTEGER,
+            lang TEXT,
+            created_at TEXT NOT NULL,
+            PRIMARY KEY (chat_id, message_id)
+        )
+        """
+    )
+    conn.commit()
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+    return conn
+
+
+def get_cached_transcript(chat_id: int, message_id: int) -> Optional[dict]:
+    conn = _connect()
+    try:
+        row = conn.execute(
+            "SELECT source, text, duration, lang, created_at FROM transcripts "
+            "WHERE chat_id = ? AND message_id = ?",
+            (chat_id, message_id),
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        return None
+    source, text, duration, lang, created_at = row
+    return {
+        "source": source,
+        "text": text,
+        "duration": duration,
+        "lang": lang,
+        "created_at": created_at,
+    }
+
+
+def save_transcript(
+    chat_id: int,
+    message_id: int,
+    source: str,
+    text: str,
+    *,
+    duration: Optional[int] = None,
+    lang: Optional[str] = None,
+) -> None:
+    conn = _connect()
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO transcripts "
+            "(chat_id, message_id, source, text, duration, lang, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                chat_id,
+                message_id,
+                source,
+                text,
+                duration,
+                lang,
+                datetime.now(timezone.utc).isoformat(),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Voice/video-note detection and formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def is_transcribable(msg) -> bool:
+    """True for voice notes and video notes (video circles) - both go through
+    the same transcribeAudio/Groq path."""
+    return getattr(msg, "voice", None) is not None or getattr(msg, "video_note", None) is not None
+
+
+def voice_duration(msg) -> Optional[int]:
+    """Seconds, from the already-fetched message - no extra API call."""
+    f = getattr(msg, "file", None)
+    if f is None:
+        return None
+    d = getattr(f, "duration", None)
+    return int(d) if d is not None else None
+
+
+def format_duration(seconds: Optional[int]) -> str:
+    if seconds is None:
+        return "?:??"
+    seconds = int(seconds)
+    hours, rem = divmod(seconds, 3600)
+    minutes, secs = divmod(rem, 60)
+    if hours:
+        return f"{hours}:{minutes:02d}:{secs:02d}"
+    return f"{minutes}:{secs:02d}"
+
+
+# ---------------------------------------------------------------------------
+# Engines
+# ---------------------------------------------------------------------------
+
+_POLL_ATTEMPTS = 10
+_POLL_INTERVAL_SECONDS = 2.0
+
+
+async def _transcribe_via_telegram(cl, entity, msg) -> dict:
+    """Native Premium transcription. Polls while pending=True - proven live on
+    2026-08-20: an 83s recording matured after 3 polls (~6.6s); without
+    polling, long voice messages come back empty."""
+    if not await account_is_premium(cl):
+        return {"status": "premium_required"}
+    peer = await cl.get_input_entity(entity)
+    try:
+        result = await cl(functions.messages.TranscribeAudioRequest(peer=peer, msg_id=msg.id))
+    except Exception as e:
+        if is_premium_rpc_error(e):
+            return {"status": "premium_required"}
+        return {"status": "error", "error": str(e)}
+
+    attempts = 0
+    while getattr(result, "pending", False) and attempts < _POLL_ATTEMPTS:
+        await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+        attempts += 1
+        try:
+            result = await cl(functions.messages.TranscribeAudioRequest(peer=peer, msg_id=msg.id))
+        except Exception as e:
+            return {"status": "error", "error": str(e)}
+
+    if getattr(result, "pending", False):
+        return {"status": "pending"}
+    return {"status": "ok", "text": result.text}
+
+
+async def _transcribe_via_groq(cl, msg) -> dict:
+    """Groq whisper-large-v3-turbo. Downloads the voice note into memory
+    (never touches disk) and deletes the bytes as soon as the request
+    returns."""
+    api_key = os.getenv("GROQ_API_KEY")
+    if not api_key:
+        return {"status": "error", "error": "GROQ_API_KEY is not configured"}
+
+    try:
+        data = await cl.download_media(msg, file=bytes)
+    except Exception as e:
+        return {"status": "error", "error": f"download failed: {e}"}
+    if not data:
+        return {"status": "error", "error": "empty media download"}
+
+    file_attr = getattr(msg, "file", None)
+    ext = (getattr(file_attr, "ext", None) or ".oga").lstrip(".")
+    mime = getattr(file_attr, "mime_type", None) or "audio/ogg"
+
+    try:
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            resp = await client.post(
+                GROQ_TRANSCRIBE_URL,
+                headers={"Authorization": f"Bearer {api_key}"},
+                data={"model": GROQ_MODEL, "response_format": "verbose_json"},
+                files={"file": (f"voice.{ext}", bytes(data), mime)},
+            )
+        resp.raise_for_status()
+        payload = resp.json()
+    except Exception as e:
+        return {"status": "error", "error": f"groq request failed: {e}"}
+    finally:
+        del data
+
+    text = (payload.get("text") or "").strip()
+    if not text:
+        return {"status": "error", "error": "empty transcript from groq"}
+    return {"status": "ok", "text": text, "lang": payload.get("language")}
+
+
+async def transcribe(cl, entity, msg, engine: str) -> dict:
+    """Dispatch to one engine. Returns a status dict:
+    {"status": "ok", "text": ..., "lang": ...} |
+    {"status": "pending"} | {"status": "premium_required"} |
+    {"status": "error", "error": ...}
+    """
+    if engine == "telegram":
+        return await _transcribe_via_telegram(cl, entity, msg)
+    if engine == "groq":
+        return await _transcribe_via_groq(cl, msg)
+    return {"status": "error", "error": f"Unknown engine '{engine}'"}
+
+
+# ---------------------------------------------------------------------------
+# Batch budget for auto-mixing (mode="auto" only)
+# ---------------------------------------------------------------------------
+#
+# Groq is not a free call like native transcription: each voice message costs
+# a download + upload. Without a budget, get_history(limit=100) on a chat with
+# a few dozen voice messages would turn into a few dozen downloads/uploads on
+# every read. See TELEGRAM_TRANSCRIBE_MAX_VOICES / _MAX_SECONDS.
+
+
+class TranscribeBudget:
+    def __init__(
+        self,
+        max_voices: Optional[int] = None,
+        max_seconds: Optional[int] = None,
+    ):
+        self.max_voices = max_voices if max_voices is not None else _max_voices_env()
+        self.max_seconds = max_seconds if max_seconds is not None else _max_seconds_env()
+        self.used_voices = 0
+        self.used_seconds = 0
+
+    def can_afford(self, duration: Optional[int]) -> bool:
+        if self.used_voices >= self.max_voices:
+            return False
+        if self.used_seconds + (duration or 0) > self.max_seconds:
+            return False
+        return True
+
+    def charge(self, duration: Optional[int]) -> None:
+        self.used_voices += 1
+        self.used_seconds += duration or 0
+
+
+def _max_voices_env() -> int:
+    try:
+        return int(os.getenv("TELEGRAM_TRANSCRIBE_MAX_VOICES", "5"))
+    except ValueError:
+        return 5
+
+
+def _max_seconds_env() -> int:
+    try:
+        return int(os.getenv("TELEGRAM_TRANSCRIBE_MAX_SECONDS", "300"))
+    except ValueError:
+        return 300
+
+
+async def prefetch_transcripts(cl, entity, chat_id: int, messages) -> None:
+    """Fill the cache for cache-miss voice/video-note messages, within budget.
+
+    Only called for TELEGRAM_TRANSCRIBE=auto. on-demand mode leaves cache
+    misses to render as "transcript pending" - callers must invoke
+    transcribe_voice explicitly to pay for them.
+    """
+    if transcribe_mode() != "auto":
+        return
+    budget = TranscribeBudget()
+    engine = default_engine()
+    for msg in messages:
+        if not is_transcribable(msg):
+            continue
+        if getattr(msg, "message", None):
+            continue  # already has text, nothing to fill
+        if get_cached_transcript(chat_id, msg.id) is not None:
+            continue
+        duration = voice_duration(msg)
+        if not budget.can_afford(duration):
+            continue
+        budget.charge(duration)
+        try:
+            result = await transcribe(cl, entity, msg, engine)
+        except Exception:
+            continue
+        if result.get("status") == "ok":
+            save_transcript(
+                chat_id,
+                msg.id,
+                engine,
+                result["text"],
+                duration=duration,
+                lang=result.get("lang"),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Render helper shared by message_to_dict / format_message_line / list_messages
+# ---------------------------------------------------------------------------
+
+
+def voice_attachment_info(msg, chat_id: Optional[int]) -> Optional[dict]:
+    """None for non-voice-like messages. Otherwise:
+    {"duration": int|None,
+     "transcript": str|None, "transcript_source": str|None,
+     "transcript_status": "ready"|"pending"|None}
+
+    transcript_status is None when transcription is off or no chat_id is
+    available (duration still fills in - it's free, already on the fetched
+    message). "pending" covers both "never attempted" (on-demand mode,
+    budget exhausted) and "attempted but Telegram is still processing" -
+    callers don't need to tell those apart, both mean "call transcribe_voice
+    later".
+    """
+    if not is_transcribable(msg):
+        return None
+    info = {
+        "duration": voice_duration(msg),
+        "transcript": None,
+        "transcript_source": None,
+        "transcript_status": None,
+    }
+    if chat_id is None or transcribe_mode() == "off":
+        return info
+    cached = get_cached_transcript(chat_id, msg.id)
+    if cached is not None:
+        info["transcript"] = cached["text"]
+        info["transcript_source"] = cached["source"]
+        info["transcript_status"] = "ready"
+    else:
+        info["transcript_status"] = "pending"
+    return info
+
+
+def render_voice_text(info: dict) -> str:
+    """`voice 0:23` / `voice 0:23 | transcript: ... (source: groq)` / with a
+    pending marker - never presented as a verbatim quote."""
+    label = f"voice {format_duration(info['duration'])}"
+    status = info["transcript_status"]
+    if status == "ready":
+        return f"{label} | transcript ({info['transcript_source']}, not verbatim): {info['transcript']}"
+    if status == "pending":
+        return f"{label} | transcript pending"
+    return label

--- a/telegram_mcp/transcription.py
+++ b/telegram_mcp/transcription.py
@@ -118,10 +118,11 @@ def _connect() -> sqlite3.Connection:
             duration INTEGER,
             lang TEXT,
             created_at TEXT NOT NULL,
-            PRIMARY KEY (chat_id, message_id)
+            PRIMARY KEY (chat_id, message_id, source)
         )
         """
     )
+    _migrate_source_into_key(conn)
     conn.commit()
     try:
         os.chmod(path, 0o600)
@@ -130,14 +131,65 @@ def _connect() -> sqlite3.Connection:
     return conn
 
 
-def get_cached_transcript(chat_id: int, message_id: int) -> Optional[dict]:
+def _migrate_source_into_key(conn: sqlite3.Connection) -> None:
+    """Older builds keyed the cache on (chat_id, message_id) alone, so a cheap
+    telegram transcript permanently shadowed the groq one - including for
+    callers that asked for groq explicitly. Rebuild such a table in place."""
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'transcripts'"
+    ).fetchone()
+    if not row or not row[0]:
+        return
+    if "PRIMARY KEY (chat_id, message_id, source)" in row[0]:
+        return
+    conn.executescript(
+        """
+        ALTER TABLE transcripts RENAME TO transcripts_legacy;
+        CREATE TABLE transcripts (
+            chat_id INTEGER NOT NULL,
+            message_id INTEGER NOT NULL,
+            source TEXT NOT NULL,
+            text TEXT NOT NULL,
+            duration INTEGER,
+            lang TEXT,
+            created_at TEXT NOT NULL,
+            PRIMARY KEY (chat_id, message_id, source)
+        );
+        INSERT OR IGNORE INTO transcripts
+            (chat_id, message_id, source, text, duration, lang, created_at)
+        SELECT chat_id, message_id, source, text, duration, lang, created_at
+        FROM transcripts_legacy;
+        DROP TABLE transcripts_legacy;
+        """
+    )
+
+
+def get_cached_transcript(
+    chat_id: int, message_id: int, source: Optional[str] = None
+) -> Optional[dict]:
+    """Cached transcript for a message.
+
+    ``source`` pins the engine: asking for groq must never be answered with a
+    telegram transcript, because the native engine drops the recording's last
+    segment and the loss is invisible in the text. Callers that only want to
+    display whatever exists (listings, backfill skip checks) pass None and get
+    the default engine's row when there is one, any row otherwise.
+    """
     conn = _connect()
     try:
-        row = conn.execute(
-            "SELECT source, text, duration, lang, created_at FROM transcripts "
-            "WHERE chat_id = ? AND message_id = ?",
-            (chat_id, message_id),
-        ).fetchone()
+        if source is not None:
+            row = conn.execute(
+                "SELECT source, text, duration, lang, created_at FROM transcripts "
+                "WHERE chat_id = ? AND message_id = ? AND source = ?",
+                (chat_id, message_id, source),
+            ).fetchone()
+        else:
+            row = conn.execute(
+                "SELECT source, text, duration, lang, created_at FROM transcripts "
+                "WHERE chat_id = ? AND message_id = ? "
+                "ORDER BY source = ? DESC, created_at DESC LIMIT 1",
+                (chat_id, message_id, default_engine()),
+            ).fetchone()
     finally:
         conn.close()
     if row is None:

--- a/telegram_mcp/transcription.py
+++ b/telegram_mcp/transcription.py
@@ -108,8 +108,7 @@ def _cache_db_path() -> Path:
 def _connect() -> sqlite3.Connection:
     path = _cache_db_path()
     conn = sqlite3.connect(str(path))
-    conn.execute(
-        """
+    conn.execute("""
         CREATE TABLE IF NOT EXISTS transcripts (
             chat_id INTEGER NOT NULL,
             message_id INTEGER NOT NULL,
@@ -120,8 +119,7 @@ def _connect() -> sqlite3.Connection:
             created_at TEXT NOT NULL,
             PRIMARY KEY (chat_id, message_id, source)
         )
-        """
-    )
+        """)
     _migrate_source_into_key(conn)
     conn.commit()
     try:
@@ -142,8 +140,7 @@ def _migrate_source_into_key(conn: sqlite3.Connection) -> None:
         return
     if "PRIMARY KEY (chat_id, message_id, source)" in row[0]:
         return
-    conn.executescript(
-        """
+    conn.executescript("""
         ALTER TABLE transcripts RENAME TO transcripts_legacy;
         CREATE TABLE transcripts (
             chat_id INTEGER NOT NULL,
@@ -160,8 +157,7 @@ def _migrate_source_into_key(conn: sqlite3.Connection) -> None:
         SELECT chat_id, message_id, source, text, duration, lang, created_at
         FROM transcripts_legacy;
         DROP TABLE transcripts_legacy;
-        """
-    )
+        """)
 
 
 def get_cached_transcript(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,16 @@
 
 import os
 
+import pytest
+
 os.environ.setdefault("TELEGRAM_API_ID", "12345")
 os.environ.setdefault("TELEGRAM_API_HASH", "dummy_hash")
 os.environ.setdefault("TELEGRAM_SESSION_NAME", "test_session")
+
+
+@pytest.fixture
+def transcript_cache_dir(tmp_path, monkeypatch):
+    """Isolated, per-test SQLite transcript cache directory."""
+    d = tmp_path / "transcripts"
+    monkeypatch.setenv("TELEGRAM_TRANSCRIPT_CACHE_DIR", str(d))
+    return d

--- a/tests/test_rich_message_reading.py
+++ b/tests/test_rich_message_reading.py
@@ -1,0 +1,224 @@
+"""Tests for reading Telegram Rich Messages and for streaming rich drafts.
+
+The gap these pin: a rich message keeps its content in ``rich_message`` page
+blocks, and ``Message.message`` is empty. Before this, every reading tool
+reported such a message as an empty line - the failure is silent, which is why
+``test_rich_message_without_plain_text_is_not_empty`` asserts on the text a
+reader actually gets rather than on the renderer alone.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from telethon.tl import types
+
+from telegram_mcp import rich_messages
+from telegram_mcp.tools import messages
+
+
+def _plain(text):
+    return types.TextPlain(text=text)
+
+
+def _rich(blocks, **kwargs):
+    return types.RichMessage(blocks=blocks, photos=[], documents=[], **kwargs)
+
+
+# --- rich text ---------------------------------------------------------------
+
+
+def test_rich_text_nesting_and_links():
+    node = types.TextConcat(
+        texts=[
+            _plain("see "),
+            types.TextBold(
+                text=types.TextUrl(text=_plain("the docs"), url="https://x.dev", webpage_id=0)
+            ),
+            _plain(" now"),
+        ]
+    )
+    assert rich_messages.rich_text_to_markdown(node) == "see **[the docs](https://x.dev)** now"
+
+
+def test_rich_text_empty_and_unknown_degrade_quietly():
+    assert rich_messages.rich_text_to_markdown(types.TextEmpty()) == ""
+    assert rich_messages.rich_text_to_markdown(None) == ""
+    # An anchor contributes its inner text, not its decoration.
+    anchor = types.TextAnchor(text=_plain("jump"), name="s1")
+    assert rich_messages.rich_text_to_markdown(anchor) == "jump"
+
+
+# --- blocks ------------------------------------------------------------------
+
+
+def test_headings_lists_and_code():
+    blocks = [
+        types.PageBlockHeader(text=_plain("Report")),
+        types.PageBlockParagraph(text=_plain("Body text.")),
+        types.PageBlockOrderedList(
+            items=[
+                types.PageListOrderedItemText(num="1", text=_plain("first")),
+                types.PageListOrderedItemText(num="2", text=_plain("second")),
+            ]
+        ),
+        types.PageBlockPreformatted(text=_plain("print(1)"), language="python"),
+        types.PageBlockDivider(),
+    ]
+    out = rich_messages.rich_message_to_markdown(_rich(blocks))
+    assert "# Report" in out
+    assert "Body text." in out
+    assert "1. first" in out and "2. second" in out
+    assert "```python\nprint(1)\n```" in out
+    assert "---" in out
+
+
+def test_table_uses_the_header_row():
+    rows = [
+        types.PageTableRow(
+            cells=[
+                types.PageTableCell(header=True, text=_plain("name")),
+                types.PageTableCell(header=True, text=_plain("value")),
+            ]
+        ),
+        types.PageTableRow(
+            cells=[
+                types.PageTableCell(text=_plain("alpha")),
+                types.PageTableCell(text=_plain("1")),
+            ]
+        ),
+    ]
+    block = types.PageBlockTable(title=_plain("Numbers"), rows=rows)
+    out = rich_messages.page_block_to_markdown(block)
+    assert "| name | value |" in out
+    assert "| alpha | 1 |" in out
+    assert out.index("| name | value |") < out.index("| alpha | 1 |")
+
+
+def test_table_without_header_keeps_every_data_row():
+    """A header-less table must not lose its first row to the header slot."""
+    rows = [
+        types.PageTableRow(cells=[types.PageTableCell(text=_plain("a"))]),
+        types.PageTableRow(cells=[types.PageTableCell(text=_plain("b"))]),
+    ]
+    out = rich_messages.page_block_to_markdown(
+        types.PageBlockTable(title=types.TextEmpty(), rows=rows)
+    )
+    assert "| a |" in out and "| b |" in out
+
+
+def test_collapsible_section_keeps_its_state():
+    block = types.PageBlockDetails(
+        blocks=[types.PageBlockParagraph(text=_plain("hidden detail"))],
+        title=_plain("More"),
+        open=False,
+    )
+    out = rich_messages.page_block_to_markdown(block)
+    assert "**More** (collapsed)" in out
+    assert "hidden detail" in out
+
+
+def test_unknown_block_is_labelled_not_dropped():
+    class PageBlockSomethingNew:
+        text = None
+
+    assert rich_messages.page_block_to_markdown(PageBlockSomethingNew()) == "[somethingnew]"
+
+
+# --- the read path -----------------------------------------------------------
+
+
+def _message(rich=None, text=None):
+    return SimpleNamespace(
+        id=7,
+        message=text,
+        date=None,
+        media=None,
+        rich_message=rich,
+        sender=None,
+        sender_id=None,
+        reply_to=None,
+        out=False,
+    )
+
+
+def test_rich_message_without_plain_text_is_not_empty():
+    """The actual defect: such a message used to read as an empty line."""
+    rich = _rich(
+        [
+            types.PageBlockHeader(text=_plain("Q3")),
+            types.PageBlockParagraph(text=_plain("revenue up")),
+        ]
+    )
+    d = messages.message_to_dict(_message(rich=rich))
+    assert "# Q3" in d["text"]
+    assert "revenue up" in d["text"]
+    assert d["rich_message"] == {}  # no photos, documents or flags to report
+
+
+def test_rich_markdown_is_not_duplicated_when_plain_text_exists():
+    rich = _rich([types.PageBlockParagraph(text=_plain("rich body"))])
+    d = messages.message_to_dict(_message(rich=rich, text="fallback text"))
+    assert d["text"] == "fallback text"
+    assert d["rich_message"]["markdown"] == "rich body"
+
+
+def test_partial_rich_message_is_flagged():
+    rich = _rich([types.PageBlockParagraph(text=_plain("half a th"))], part=True)
+    d = messages.message_to_dict(_message(rich=rich))
+    assert d["rich_message"]["partial"] is True
+
+
+def test_plain_message_gains_no_rich_key():
+    d = messages.message_to_dict(_message(text="hello"))
+    assert "rich_message" not in d
+
+
+# --- streaming drafts --------------------------------------------------------
+
+
+class _FakeClient:
+    def __init__(self, premium=True):
+        self._premium = premium
+        self.requests = []
+
+    async def get_me(self):
+        return SimpleNamespace(premium=self._premium)
+
+    async def __call__(self, request):
+        self.requests.append(request)
+        return SimpleNamespace()
+
+
+@pytest.mark.asyncio
+async def test_rich_draft_is_a_typing_action_not_a_message():
+    cl = _FakeClient()
+    result = json.loads(await messages._send_rich_draft(cl, "peer", "# partial", "rich_md", None))
+
+    assert result["draft"] is True
+    (req,) = cl.requests
+    assert isinstance(req, messages.functions.messages.SetTypingRequest)
+    assert isinstance(req.action, types.InputSendMessageRichMessageDraftAction)
+    assert isinstance(req.action.rich_message, types.InputRichMessageMarkdown)
+
+
+@pytest.mark.asyncio
+async def test_rich_draft_id_is_reused_so_updates_replace_each_other():
+    cl = _FakeClient()
+    first = json.loads(await messages._send_rich_draft(cl, "peer", "one", "rich_md", None))
+    second = json.loads(
+        await messages._send_rich_draft(cl, "peer", "one two", "rich_md", first["draft_id"])
+    )
+
+    assert second["draft_id"] == first["draft_id"]
+    assert [r.action.random_id for r in cl.requests] == [first["draft_id"]] * 2
+
+
+@pytest.mark.asyncio
+async def test_rich_draft_without_premium_sends_nothing():
+    cl = _FakeClient(premium=False)
+    result = json.loads(await messages._send_rich_draft(cl, "peer", "x", "rich_md", None))
+
+    assert result["sent"] is False
+    assert result["reason"] == "telegram_premium_required"
+    assert cl.requests == []

--- a/tests/test_rich_message_reading.py
+++ b/tests/test_rich_message_reading.py
@@ -8,13 +8,16 @@ reader actually gets rather than on the renderer alone.
 """
 
 import json
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
 from telethon.tl import types
 
-from telegram_mcp import rich_messages
+from telegram_mcp import rich_messages, runtime
 from telegram_mcp.tools import messages
+
+DT = datetime(2026, 8, 27, tzinfo=timezone.utc)
 
 
 def _plain(text):
@@ -222,3 +225,89 @@ async def test_rich_draft_without_premium_sends_nothing():
     assert result["sent"] is False
     assert result["reason"] == "telegram_premium_required"
     assert cl.requests == []
+
+
+# --- the readers, not just the renderer --------------------------------------
+#
+# The renderer had tests and they were all green while every reading tool still
+# returned "[empty]" for a rich message: each tool built its record by hand and
+# sanitized `msg.message`, which is empty on a rich message and comes back as
+# the "[empty]" marker. So these tests sit at the tool boundary, where the
+# reader actually is.
+
+
+def _rich_message(**overrides):
+    """A message whose whole content lives in page blocks."""
+    base = dict(
+        id=860243,
+        sender=None,
+        sender_id=42,
+        date=DT,
+        message=None,
+        reply_to=None,
+        chat_id=555,
+        chat=SimpleNamespace(title="Chat"),
+        rich_message=_rich([types.PageBlockParagraph(text=_plain("Точка эквайринг"))]),
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class _ReadingClient:
+    """Just enough client for the reading tools: it hands back messages."""
+
+    def __init__(self, messages_list):
+        self._list = messages_list
+
+    async def get_messages(self, entity, limit=None, ids=None, **kwargs):
+        return self._list[:limit] if limit else list(self._list)
+
+    async def get_input_entity(self, entity):
+        return "peer"
+
+
+def _patch_client(monkeypatch, client):
+    async def _entity(*args, **kwargs):
+        return SimpleNamespace()
+
+    monkeypatch.setattr(messages, "get_client", lambda account=None: client)
+    monkeypatch.setattr(messages, "resolve_entity", _entity)
+    monkeypatch.setattr(messages, "get_marked_id", lambda e: 555)
+
+
+@pytest.mark.asyncio
+async def test_list_messages_shows_a_rich_message_instead_of_empty(monkeypatch):
+    _patch_client(monkeypatch, _ReadingClient([_rich_message()]))
+
+    result = await messages.list_messages(chat_id=555, limit=10, account=None)
+
+    record = json.loads(result)["results"][0]
+    assert record["text"] != "[empty]"
+    assert "Точка эквайринг" in record["text"]
+
+
+@pytest.mark.asyncio
+async def test_search_messages_shows_a_rich_message_instead_of_empty(monkeypatch):
+    _patch_client(monkeypatch, _ReadingClient([_rich_message()]))
+
+    result = await messages.search_messages(chat_id=555, query="эквайринг", account=None)
+
+    record = json.loads(result)["results"][0]
+    assert "Точка эквайринг" in record["text"]
+
+
+def test_a_message_with_its_own_text_keeps_it(monkeypatch):
+    # The rendering must not overwrite what the sender actually typed; it goes
+    # into rich_message.markdown instead.
+    record = {}
+    runtime.attach_message_text(record, _rich_message(message="caption"))
+
+    assert record["text"] == "caption"
+    assert "Точка эквайринг" in record["rich_message"]["markdown"]
+
+
+def test_a_truly_empty_message_still_reads_as_empty():
+    record = {}
+    runtime.attach_message_text(record, _rich_message(message=None, rich_message=None))
+
+    assert record["text"] == "[empty]"

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -133,8 +133,7 @@ def test_legacy_cache_keyed_without_engine_is_migrated_in_place(transcript_cache
     path = transcription._cache_db_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(str(path))
-    conn.executescript(
-        """
+    conn.executescript("""
         CREATE TABLE transcripts (
             chat_id INTEGER NOT NULL,
             message_id INTEGER NOT NULL,
@@ -146,8 +145,7 @@ def test_legacy_cache_keyed_without_engine_is_migrated_in_place(transcript_cache
             PRIMARY KEY (chat_id, message_id)
         );
         INSERT INTO transcripts VALUES (1, 2, 'telegram', 'old row', 23, 'ru', '2026-08-20');
-        """
-    )
+        """)
     conn.commit()
     conn.close()
 

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -107,6 +107,57 @@ def test_cache_keyed_by_chat_and_message_independently(transcript_cache_dir):
     assert transcription.get_cached_transcript(1, 999) is None
 
 
+def test_cache_pinned_to_an_engine_never_serves_the_other_engines_text(transcript_cache_dir):
+    """The whole point of choosing groq is that the native engine drops the
+    recording's last segment. A telegram transcript answering a groq request
+    would hand back that truncated text with no way to tell."""
+    transcription.save_transcript(1, 2, "telegram", "truncated tail")
+    assert transcription.get_cached_transcript(1, 2, source="groq") is None
+    assert transcription.get_cached_transcript(1, 2, source="telegram")["text"] == (
+        "truncated tail"
+    )
+
+
+def test_cache_keeps_both_engines_side_by_side(transcript_cache_dir):
+    transcription.save_transcript(1, 2, "telegram", "native text")
+    transcription.save_transcript(1, 2, "groq", "groq text")
+    assert transcription.get_cached_transcript(1, 2, source="telegram")["text"] == "native text"
+    assert transcription.get_cached_transcript(1, 2, source="groq")["text"] == "groq text"
+
+
+def test_legacy_cache_keyed_without_engine_is_migrated_in_place(transcript_cache_dir):
+    """Builds before the fix keyed on (chat_id, message_id) alone. Rows must
+    survive the rebuild, and the pinned lookup must start working on them."""
+    import sqlite3
+
+    path = transcription._cache_db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE transcripts (
+            chat_id INTEGER NOT NULL,
+            message_id INTEGER NOT NULL,
+            source TEXT NOT NULL,
+            text TEXT NOT NULL,
+            duration INTEGER,
+            lang TEXT,
+            created_at TEXT NOT NULL,
+            PRIMARY KEY (chat_id, message_id)
+        );
+        INSERT INTO transcripts VALUES (1, 2, 'telegram', 'old row', 23, 'ru', '2026-08-20');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    assert transcription.get_cached_transcript(1, 2, source="telegram")["text"] == "old row"
+    assert transcription.get_cached_transcript(1, 2, source="groq") is None
+    transcription.save_transcript(1, 2, "groq", "new row")
+    assert transcription.get_cached_transcript(1, 2, source="groq")["text"] == "new row"
+    assert transcription.get_cached_transcript(1, 2, source="telegram")["text"] == "old row"
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX permissions only")
 def test_cache_file_and_directory_get_restrictive_permissions(transcript_cache_dir):
     transcription.save_transcript(1, 2, "groq", "hi")

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -1,0 +1,549 @@
+"""Tests for telegram_mcp/transcription.py: config, cache, engines, budget, render."""
+
+import os
+import stat
+from types import SimpleNamespace
+
+import pytest
+
+from telegram_mcp import transcription
+
+
+def _async_return(value):
+    async def _inner(*args, **kwargs):
+        return value
+
+    return _inner
+
+
+def _voice_msg(**overrides):
+    base = dict(
+        id=1,
+        message=None,
+        voice=SimpleNamespace(),
+        video_note=None,
+        file=SimpleNamespace(duration=23, ext=".oga", mime_type="audio/ogg"),
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+# ---------------------------------------------------------------------------
+# Config toggles
+# ---------------------------------------------------------------------------
+
+
+def test_transcribe_mode_defaults_to_on_demand(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_TRANSCRIBE", raising=False)
+    assert transcription.transcribe_mode() == "on-demand"
+
+
+@pytest.mark.parametrize("value", ["off", "on-demand", "auto", "AUTO", " off "])
+def test_transcribe_mode_accepts_known_values_case_and_space_insensitive(monkeypatch, value):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", value)
+    assert transcription.transcribe_mode() == value.strip().lower()
+
+
+def test_transcribe_mode_rejects_unknown_value(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "sometimes")
+    with pytest.raises(SystemExit):
+        transcription.transcribe_mode()
+
+
+def test_default_engine_defaults_to_groq(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_TRANSCRIBE_ENGINE", raising=False)
+    assert transcription.default_engine() == "groq"
+
+
+def test_default_engine_accepts_telegram(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE_ENGINE", "telegram")
+    assert transcription.default_engine() == "telegram"
+
+
+def test_default_engine_rejects_unknown_value(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE_ENGINE", "whisper-local")
+    with pytest.raises(SystemExit):
+        transcription.default_engine()
+
+
+def test_validate_transcription_config_raises_on_bad_mode(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "always")
+    with pytest.raises(SystemExit):
+        transcription.validate_transcription_config()
+
+
+# ---------------------------------------------------------------------------
+# SQLite cache
+# ---------------------------------------------------------------------------
+
+
+def test_cache_miss_returns_none(transcript_cache_dir):
+    assert transcription.get_cached_transcript(1, 2) is None
+
+
+def test_cache_round_trip(transcript_cache_dir):
+    transcription.save_transcript(1, 2, "groq", "hello world", duration=23, lang="ru")
+    cached = transcription.get_cached_transcript(1, 2)
+    assert cached["text"] == "hello world"
+    assert cached["source"] == "groq"
+    assert cached["duration"] == 23
+    assert cached["lang"] == "ru"
+    assert cached["created_at"]
+
+
+def test_cache_upsert_overwrites_previous_entry(transcript_cache_dir):
+    transcription.save_transcript(1, 2, "telegram", "first pass")
+    transcription.save_transcript(1, 2, "groq", "second pass")
+    cached = transcription.get_cached_transcript(1, 2)
+    assert cached["text"] == "second pass"
+    assert cached["source"] == "groq"
+
+
+def test_cache_keyed_by_chat_and_message_independently(transcript_cache_dir):
+    transcription.save_transcript(1, 100, "groq", "chat one")
+    transcription.save_transcript(2, 100, "groq", "chat two")
+    assert transcription.get_cached_transcript(1, 100)["text"] == "chat one"
+    assert transcription.get_cached_transcript(2, 100)["text"] == "chat two"
+    assert transcription.get_cached_transcript(1, 999) is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permissions only")
+def test_cache_file_and_directory_get_restrictive_permissions(transcript_cache_dir):
+    transcription.save_transcript(1, 2, "groq", "hi")
+    db_path = transcription.cache_dir() / "transcripts.db"
+    assert stat.S_IMODE(db_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(transcript_cache_dir.stat().st_mode) == 0o700
+
+
+# ---------------------------------------------------------------------------
+# Voice/video-note detection and formatting
+# ---------------------------------------------------------------------------
+
+
+def test_is_transcribable_true_for_voice():
+    assert transcription.is_transcribable(_voice_msg())
+
+
+def test_is_transcribable_true_for_video_note():
+    assert transcription.is_transcribable(_voice_msg(voice=None, video_note=SimpleNamespace()))
+
+
+def test_is_transcribable_false_for_plain_message():
+    assert not transcription.is_transcribable(_voice_msg(voice=None, file=None))
+
+
+def test_voice_duration_reads_file_attribute():
+    assert transcription.voice_duration(_voice_msg()) == 23
+
+
+def test_voice_duration_none_without_file():
+    assert transcription.voice_duration(_voice_msg(file=None)) is None
+
+
+@pytest.mark.parametrize(
+    "seconds,expected",
+    [(0, "0:00"), (23, "0:23"), (83, "1:23"), (3661, "1:01:01"), (None, "?:??")],
+)
+def test_format_duration(seconds, expected):
+    assert transcription.format_duration(seconds) == expected
+
+
+# ---------------------------------------------------------------------------
+# Batch budget
+# ---------------------------------------------------------------------------
+
+
+def test_budget_reads_defaults_from_env(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE_MAX_VOICES", "2")
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE_MAX_SECONDS", "60")
+    budget = transcription.TranscribeBudget()
+    assert budget.max_voices == 2
+    assert budget.max_seconds == 60
+
+
+def test_budget_voice_count_cap():
+    budget = transcription.TranscribeBudget(max_voices=2, max_seconds=10_000)
+    assert budget.can_afford(10)
+    budget.charge(10)
+    assert budget.can_afford(10)
+    budget.charge(10)
+    assert not budget.can_afford(1)
+
+
+def test_budget_seconds_cap():
+    budget = transcription.TranscribeBudget(max_voices=10, max_seconds=50)
+    assert budget.can_afford(40)
+    budget.charge(40)
+    assert not budget.can_afford(20)  # 40 + 20 > 50
+    assert budget.can_afford(10)  # 40 + 10 <= 50
+
+
+# ---------------------------------------------------------------------------
+# voice_attachment_info / render_voice_text
+# ---------------------------------------------------------------------------
+
+
+def test_voice_attachment_info_none_for_non_voice_message():
+    msg = SimpleNamespace(id=1, voice=None, video_note=None, file=None)
+    assert transcription.voice_attachment_info(msg, chat_id=1) is None
+
+
+def test_voice_attachment_info_shows_duration_only_without_chat_id(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    info = transcription.voice_attachment_info(_voice_msg(), chat_id=None)
+    assert info == {
+        "duration": 23,
+        "transcript": None,
+        "transcript_source": None,
+        "transcript_status": None,
+    }
+
+
+def test_voice_attachment_info_disabled_when_mode_off(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "off")
+    transcription.save_transcript(1, 1, "groq", "should not surface")
+    info = transcription.voice_attachment_info(_voice_msg(id=1), chat_id=1)
+    assert info["transcript_status"] is None
+    assert info["transcript"] is None
+    assert info["duration"] == 23  # duration is free, shown regardless of the toggle
+
+
+def test_voice_attachment_info_cache_hit_is_ready(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    transcription.save_transcript(1, 1, "groq", "hello", duration=23)
+    info = transcription.voice_attachment_info(_voice_msg(id=1), chat_id=1)
+    assert info["transcript_status"] == "ready"
+    assert info["transcript"] == "hello"
+    assert info["transcript_source"] == "groq"
+
+
+def test_voice_attachment_info_cache_miss_is_pending(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    info = transcription.voice_attachment_info(_voice_msg(id=99), chat_id=1)
+    assert info["transcript_status"] == "pending"
+    assert info["transcript"] is None
+
+
+def test_render_voice_text_ready_marks_source_and_not_verbatim():
+    info = {
+        "duration": 23,
+        "transcript": "hi there",
+        "transcript_source": "groq",
+        "transcript_status": "ready",
+    }
+    assert (
+        transcription.render_voice_text(info)
+        == "voice 0:23 | transcript (groq, not verbatim): hi there"
+    )
+
+
+def test_render_voice_text_pending():
+    info = {
+        "duration": 23,
+        "transcript": None,
+        "transcript_source": None,
+        "transcript_status": "pending",
+    }
+    assert transcription.render_voice_text(info) == "voice 0:23 | transcript pending"
+
+
+def test_render_voice_text_disabled_shows_duration_only():
+    info = {
+        "duration": 23,
+        "transcript": None,
+        "transcript_source": None,
+        "transcript_status": None,
+    }
+    assert transcription.render_voice_text(info) == "voice 0:23"
+
+
+# ---------------------------------------------------------------------------
+# Telegram engine: pending must be polled, not silently dropped
+# ---------------------------------------------------------------------------
+
+
+class _FakeTelegramClient:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = 0
+
+    async def get_input_entity(self, entity):
+        return "peer"
+
+    async def __call__(self, request):
+        self.calls += 1
+        resp = self._responses.pop(0)
+        if isinstance(resp, Exception):
+            raise resp
+        return resp
+
+
+@pytest.mark.asyncio
+async def test_transcribe_via_telegram_polls_until_ready(monkeypatch):
+    monkeypatch.setattr(transcription, "account_is_premium", _async_return(True))
+    monkeypatch.setattr(transcription.asyncio, "sleep", _async_return(None))
+    client = _FakeTelegramClient(
+        [
+            SimpleNamespace(pending=True, text=None),
+            SimpleNamespace(pending=True, text=None),
+            SimpleNamespace(pending=False, text="full text, no dropped tail"),
+        ]
+    )
+
+    result = await transcription._transcribe_via_telegram(client, object(), SimpleNamespace(id=42))
+
+    assert result == {"status": "ok", "text": "full text, no dropped tail"}
+    assert client.calls == 3  # 1 initial + 2 polls, matches the live 83s-recording measurement
+
+
+@pytest.mark.asyncio
+async def test_transcribe_via_telegram_first_call_ready_needs_no_poll(monkeypatch):
+    monkeypatch.setattr(transcription, "account_is_premium", _async_return(True))
+    monkeypatch.setattr(transcription.asyncio, "sleep", _async_return(None))
+    client = _FakeTelegramClient([SimpleNamespace(pending=False, text="instant")])
+
+    result = await transcription._transcribe_via_telegram(client, object(), SimpleNamespace(id=1))
+
+    assert result == {"status": "ok", "text": "instant"}
+    assert client.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_transcribe_via_telegram_gives_up_after_poll_budget_and_degrades(monkeypatch):
+    monkeypatch.setattr(transcription, "account_is_premium", _async_return(True))
+    monkeypatch.setattr(transcription.asyncio, "sleep", _async_return(None))
+    monkeypatch.setattr(transcription, "_POLL_ATTEMPTS", 2)
+    client = _FakeTelegramClient([SimpleNamespace(pending=True, text=None)] * 10)
+
+    result = await transcription._transcribe_via_telegram(client, object(), SimpleNamespace(id=1))
+
+    assert result == {"status": "pending"}  # honest degradation, not a crash
+
+
+@pytest.mark.asyncio
+async def test_transcribe_via_telegram_requires_premium(monkeypatch):
+    monkeypatch.setattr(transcription, "account_is_premium", _async_return(False))
+    client = _FakeTelegramClient([])
+
+    result = await transcription._transcribe_via_telegram(client, object(), SimpleNamespace(id=1))
+
+    assert result == {"status": "premium_required"}
+    assert client.calls == 0  # never even attempted the RPC
+
+
+@pytest.mark.asyncio
+async def test_transcribe_via_telegram_rpc_error_maps_to_premium_required(monkeypatch):
+    monkeypatch.setattr(transcription, "account_is_premium", _async_return(True))
+    monkeypatch.setattr(transcription, "is_premium_rpc_error", lambda e: True)
+    client = _FakeTelegramClient([RuntimeError("PREMIUM_ACCOUNT_REQUIRED")])
+
+    result = await transcription._transcribe_via_telegram(client, object(), SimpleNamespace(id=1))
+
+    assert result == {"status": "premium_required"}
+
+
+# ---------------------------------------------------------------------------
+# Groq engine: in-memory download, never touches disk
+# ---------------------------------------------------------------------------
+
+
+class _FakeGroqResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+class _FakeHttpxClient:
+    def __init__(self, response, capture):
+        self._response = response
+        self._capture = capture
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def post(self, url, headers=None, data=None, files=None):
+        self._capture.append({"url": url, "headers": headers, "data": data, "files": files})
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_transcribe_via_groq_success(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    calls = []
+    response = _FakeGroqResponse({"text": " hello world ", "language": "ru"})
+    monkeypatch.setattr(
+        transcription.httpx, "AsyncClient", lambda **kw: _FakeHttpxClient(response, calls)
+    )
+
+    msg = _voice_msg()
+
+    async def _download_media(m, file=None):
+        assert m is msg
+        assert file is bytes  # in-memory download, no disk path
+        return b"raw-audio-bytes"
+
+    client = SimpleNamespace(download_media=_download_media)
+
+    result = await transcription._transcribe_via_groq(client, msg)
+
+    assert result == {"status": "ok", "text": "hello world", "lang": "ru"}
+    assert calls[0]["headers"]["Authorization"] == "Bearer test-key"
+    assert calls[0]["files"]["file"][0] == "voice.oga"
+    assert calls[0]["data"]["model"] == transcription.GROQ_MODEL
+
+
+@pytest.mark.asyncio
+async def test_transcribe_via_groq_requires_api_key(monkeypatch):
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+
+    result = await transcription._transcribe_via_groq(SimpleNamespace(), _voice_msg())
+
+    assert result["status"] == "error"
+    assert "GROQ_API_KEY" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_transcribe_via_groq_empty_download_is_error(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "k")
+
+    async def _download_media(m, file=None):
+        return b""
+
+    client = SimpleNamespace(download_media=_download_media)
+    result = await transcription._transcribe_via_groq(client, _voice_msg())
+
+    assert result["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_transcribe_via_groq_empty_transcript_is_error(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    response = _FakeGroqResponse({"text": "", "language": "ru"})
+    monkeypatch.setattr(
+        transcription.httpx, "AsyncClient", lambda **kw: _FakeHttpxClient(response, [])
+    )
+
+    async def _download_media(m, file=None):
+        return b"raw-audio-bytes"
+
+    client = SimpleNamespace(download_media=_download_media)
+    result = await transcription._transcribe_via_groq(client, _voice_msg())
+
+    assert result["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# transcribe() dispatcher
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_transcribe_dispatches_to_telegram_engine(monkeypatch):
+    monkeypatch.setattr(
+        transcription, "_transcribe_via_telegram", _async_return({"status": "ok", "text": "tg"})
+    )
+    result = await transcription.transcribe(None, None, None, "telegram")
+    assert result["text"] == "tg"
+
+
+@pytest.mark.asyncio
+async def test_transcribe_dispatches_to_groq_engine(monkeypatch):
+    monkeypatch.setattr(
+        transcription, "_transcribe_via_groq", _async_return({"status": "ok", "text": "groq"})
+    )
+    result = await transcription.transcribe(None, None, None, "groq")
+    assert result["text"] == "groq"
+
+
+@pytest.mark.asyncio
+async def test_transcribe_unknown_engine_is_an_error():
+    result = await transcription.transcribe(None, None, None, "bogus")
+    assert result["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Batch prefetch (mode="auto")
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prefetch_is_noop_outside_auto_mode(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    monkeypatch.setattr(transcription, "transcribe", _async_return({"status": "ok", "text": "x"}))
+
+    await transcription.prefetch_transcripts(None, None, 1, [_voice_msg(id=1)])
+
+    assert transcription.get_cached_transcript(1, 1) is None
+
+
+@pytest.mark.asyncio
+async def test_prefetch_fills_cache_up_to_voice_budget(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "auto")
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE_MAX_VOICES", "1")
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE_MAX_SECONDS", "1000")
+
+    calls = []
+
+    async def _fake_transcribe(cl, entity, msg, engine):
+        calls.append(msg.id)
+        return {"status": "ok", "text": f"text-{msg.id}", "lang": "ru"}
+
+    monkeypatch.setattr(transcription, "transcribe", _fake_transcribe)
+
+    await transcription.prefetch_transcripts(None, None, 7, [_voice_msg(id=1), _voice_msg(id=2)])
+
+    assert calls == [1]  # budget exhausted after the first voice message
+    assert transcription.get_cached_transcript(7, 1)["text"] == "text-1"
+    assert transcription.get_cached_transcript(7, 2) is None  # left for next explicit call
+
+
+@pytest.mark.asyncio
+async def test_prefetch_skips_cached_and_already_texted_messages(
+    monkeypatch, transcript_cache_dir
+):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "auto")
+    transcription.save_transcript(7, 1, "telegram", "already have it")
+    calls = []
+
+    async def _fake_transcribe(cl, entity, msg, engine):
+        calls.append(msg.id)
+        return {"status": "ok", "text": "new"}
+
+    monkeypatch.setattr(transcription, "transcribe", _fake_transcribe)
+
+    messages = [_voice_msg(id=1), _voice_msg(id=2, message="already has text")]
+    await transcription.prefetch_transcripts(None, None, 7, messages)
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_prefetch_swallows_engine_errors_without_raising(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "auto")
+
+    async def _boom(cl, entity, msg, engine):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(transcription, "transcribe", _boom)
+
+    await transcription.prefetch_transcripts(None, None, 7, [_voice_msg(id=5)])  # must not raise
+
+    assert transcription.get_cached_transcript(7, 5) is None
+
+
+@pytest.mark.asyncio
+async def test_prefetch_does_not_cache_pending_results(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "auto")
+    monkeypatch.setattr(transcription, "transcribe", _async_return({"status": "pending"}))
+
+    await transcription.prefetch_transcripts(None, None, 7, [_voice_msg(id=5)])
+
+    assert transcription.get_cached_transcript(7, 5) is None

--- a/tests/test_voice_transcripts.py
+++ b/tests/test_voice_transcripts.py
@@ -1,0 +1,487 @@
+"""Integration tests: transcript mixing into message_to_dict / format_message_line /
+list_messages, plus the transcribe_voice tool.
+
+message_to_dict/format_message_line are also exercised directly (without a
+chat_id) by test_reply_quote.py and test_forward_attribution.py with bare fake
+messages that have no voice/video_note attribute - those keep passing
+unmodified, which is the backward-compatibility contract these tests pin down
+explicitly for the voice case.
+"""
+
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from telegram_mcp import transcription
+from telegram_mcp.tools import messages
+from telegram_mcp.tools.messages import format_message_line, message_to_dict
+
+
+def _async_return(value):
+    async def _inner(*args, **kwargs):
+        return value
+
+    return _inner
+
+
+def _msg(**overrides):
+    base = dict(
+        id=200,
+        sender=None,
+        sender_id=42,
+        date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        message=None,
+        reply_to=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _voice_msg(**overrides):
+    base = dict(
+        voice=SimpleNamespace(),
+        video_note=None,
+        file=SimpleNamespace(duration=23, ext=".oga", mime_type="audio/ogg"),
+    )
+    base.update(overrides)
+    return _msg(**base)
+
+
+class _FakeClient:
+    def __init__(self, messages_list=None, messages_by_id=None):
+        self._list = messages_list or []
+        self._by_id = messages_by_id or {}
+        self.download_calls = []
+
+    async def get_messages(self, entity, limit=None, ids=None, **kwargs):
+        if ids is not None:
+            return self._by_id.get(ids)
+        return self._list[:limit] if limit else list(self._list)
+
+    async def get_input_entity(self, entity):
+        return "peer"
+
+    async def __call__(self, request):
+        raise AssertionError("no raw RPC expected in this test")
+
+    async def download_media(self, msg, file=None):
+        self.download_calls.append(msg.id)
+        return b"audio-bytes"
+
+
+def _patch_client(monkeypatch, client, entity, numeric_chat_id):
+    monkeypatch.setattr(messages, "get_client", lambda account=None: client)
+    monkeypatch.setattr(messages, "resolve_entity", _async_return(entity))
+    monkeypatch.setattr(messages, "get_marked_id", lambda e: numeric_chat_id)
+
+
+# ---------------------------------------------------------------------------
+# message_to_dict
+# ---------------------------------------------------------------------------
+
+
+def test_message_to_dict_voice_without_chat_id_is_backward_compatible():
+    d = message_to_dict(_voice_msg())  # no chat_id, as existing callers use it
+    assert d["media"] == "voice"
+    assert d["duration"] == 23
+    assert "transcript" not in d
+    assert "transcript_status" not in d
+
+
+def test_message_to_dict_voice_cache_miss_is_pending(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    d = message_to_dict(_voice_msg(id=5), chat_id=1)
+    assert d["duration"] == 23
+    assert d["transcript_status"] == "pending"
+    assert "transcript" not in d
+
+
+def test_message_to_dict_voice_cache_hit_includes_source_and_note(
+    monkeypatch, transcript_cache_dir
+):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    transcription.save_transcript(1, 5, "groq", "hello there", duration=23)
+
+    d = message_to_dict(_voice_msg(id=5), chat_id=1)
+
+    assert d["transcript"] == "hello there"
+    assert d["transcript_source"] == "groq"
+    assert "not a verbatim quote" in d["transcript_note"]
+    assert "transcript_status" not in d
+
+
+def test_message_to_dict_voice_off_mode_shows_duration_only(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "off")
+    transcription.save_transcript(1, 5, "groq", "must not surface")
+
+    d = message_to_dict(_voice_msg(id=5), chat_id=1)
+
+    assert d["duration"] == 23
+    assert "transcript" not in d
+    assert "transcript_status" not in d
+
+
+def test_message_to_dict_text_message_untouched():
+    d = message_to_dict(_msg(message="hello"))
+    assert d["text"] == "hello"
+    assert "duration" not in d
+    assert "transcript" not in d
+
+
+# ---------------------------------------------------------------------------
+# format_message_line
+# ---------------------------------------------------------------------------
+
+
+def test_format_message_line_voice_without_chat_id_shows_duration_only():
+    line = format_message_line(
+        _voice_msg(file=SimpleNamespace(duration=83, ext=".oga", mime_type="audio/ogg"))
+    )
+    assert "Message: voice 1:23" in line
+    assert "transcript" not in line
+
+
+def test_format_message_line_voice_ready_includes_transcript_and_source(
+    monkeypatch, transcript_cache_dir
+):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    transcription.save_transcript(1, 5, "telegram", "we should ship this")
+
+    line = format_message_line(_voice_msg(id=5), chat_id=1)
+
+    assert "voice 0:23 | transcript (telegram, not verbatim): we should ship this" in line
+
+
+def test_format_message_line_voice_pending(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+
+    line = format_message_line(_voice_msg(id=5), chat_id=1)
+
+    assert "Message: voice 0:23 | transcript pending" in line
+
+
+def test_format_message_line_text_message_still_shows_empty_literal():
+    line = format_message_line(_msg(message=None))
+    assert "Message: [empty]" in line
+
+
+# ---------------------------------------------------------------------------
+# list_messages: media-label bugfix + transcript mixing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_messages_photo_shows_media_label(monkeypatch, transcript_cache_dir):
+    """Upstream bug: list_messages built its record by hand and never called
+    get_media_label, so any media-with-no-caption message looked exactly like
+    an empty text message. Independent of transcription."""
+    entity = SimpleNamespace()
+    photo_msg = _msg(id=8, photo=SimpleNamespace())
+    client = _FakeClient(messages_list=[photo_msg])
+    _patch_client(monkeypatch, client, entity, 555)
+
+    result = await messages.list_messages(chat_id=555, limit=10, account=None)
+
+    rec = json.loads(result)["results"][0]
+    assert rec["media"] == "photo"
+
+
+@pytest.mark.asyncio
+async def test_list_messages_voice_shows_media_label_and_cached_transcript(
+    monkeypatch, transcript_cache_dir
+):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    entity = SimpleNamespace()
+    voice_msg = _voice_msg(id=7)
+    transcription.save_transcript(555, 7, "groq", "we should ship this", duration=23)
+    client = _FakeClient(messages_list=[voice_msg])
+    _patch_client(monkeypatch, client, entity, 555)
+
+    result = await messages.list_messages(chat_id=555, limit=10, account=None)
+
+    rec = json.loads(result)["results"][0]
+    assert rec["media"] == "voice"
+    assert rec["transcript"] == "we should ship this"
+    assert rec["transcript_source"] == "groq"
+
+
+@pytest.mark.asyncio
+async def test_list_messages_voice_cache_miss_is_pending_on_demand(
+    monkeypatch, transcript_cache_dir
+):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_list=[_voice_msg(id=7)])
+    _patch_client(monkeypatch, client, entity, 555)
+
+    result = await messages.list_messages(chat_id=555, limit=10, account=None)
+
+    rec = json.loads(result)["results"][0]
+    assert rec["transcript_status"] == "pending"
+    assert "transcript" not in rec
+
+
+@pytest.mark.asyncio
+async def test_list_messages_auto_mode_prefetches_and_caches(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "auto")
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE_MAX_VOICES", "5")
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE_MAX_SECONDS", "500")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_list=[_voice_msg(id=9)])
+    _patch_client(monkeypatch, client, entity, 555)
+    monkeypatch.setattr(
+        transcription,
+        "transcribe",
+        _async_return({"status": "ok", "text": "prefetched text", "lang": "ru"}),
+    )
+
+    result = await messages.list_messages(chat_id=555, limit=10, account=None)
+
+    rec = json.loads(result)["results"][0]
+    assert rec["transcript"] == "prefetched text"
+    assert transcription.get_cached_transcript(555, 9)["text"] == "prefetched text"
+
+
+@pytest.mark.asyncio
+async def test_list_messages_on_demand_mode_never_prefetches(monkeypatch, transcript_cache_dir):
+    """The expensive Groq path must never fire on a plain listing call - only
+    auto mode (or an explicit transcribe_voice call) is allowed to spend it."""
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_list=[_voice_msg(id=9)])
+    _patch_client(monkeypatch, client, entity, 555)
+
+    async def _must_not_be_called(*a, **kw):
+        raise AssertionError("on-demand mode must not call the transcription engine")
+
+    monkeypatch.setattr(transcription, "transcribe", _must_not_be_called)
+
+    await messages.list_messages(chat_id=555, limit=10, account=None)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# get_history / get_messages threading chat_id through to the cache
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_history_fills_cached_transcript(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_list=[_voice_msg(id=7)])
+    _patch_client(monkeypatch, client, entity, 555)
+    transcription.save_transcript(555, 7, "telegram", "hello from cache")
+
+    result = await messages.get_history(chat_id=555, limit=10, account=None)
+
+    rec = json.loads(result)["results"][0]
+    assert rec["transcript"] == "hello from cache"
+
+
+@pytest.mark.asyncio
+async def test_get_messages_fills_cached_transcript_in_text_line(
+    monkeypatch, transcript_cache_dir
+):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_list=[_voice_msg(id=7)])
+    _patch_client(monkeypatch, client, entity, 555)
+    transcription.save_transcript(555, 7, "groq", "cached line text")
+
+    result = await messages.get_messages(chat_id=555, page=1, page_size=10, account=None)
+
+    assert "cached line text" in result
+    assert "(groq, not verbatim)" in result
+
+
+# ---------------------------------------------------------------------------
+# transcribe_voice tool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_transcribe_voice_disabled_by_toggle(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "off")
+
+    result = await messages.transcribe_voice(chat_id=1, message_id=1, account=None)
+
+    payload = json.loads(result)
+    assert payload["transcribed"] is False
+    assert payload["reason"] == "transcription_disabled"
+
+
+@pytest.mark.asyncio
+async def test_transcribe_voice_returns_cached_without_calling_engine(
+    monkeypatch, transcript_cache_dir
+):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    transcription.save_transcript(555, 42, "groq", "cached text", duration=23)
+    entity = SimpleNamespace()
+    client = _FakeClient()
+    _patch_client(monkeypatch, client, entity, 555)
+
+    async def _must_not_be_called(*a, **kw):
+        raise AssertionError("must not call the engine on a cache hit")
+
+    monkeypatch.setattr(transcription, "transcribe", _must_not_be_called)
+
+    result = await messages.transcribe_voice(chat_id=555, message_id=42, account=None)
+
+    payload = json.loads(result)
+    assert payload == {
+        "transcribed": True,
+        "cached": True,
+        "text": "cached text",
+        "source": "groq",
+        "duration": 23,
+        "note": "Machine transcript, not a verbatim quote.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_transcribe_voice_rejects_non_voice_message(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    entity = SimpleNamespace()
+    text_msg = _msg(id=9, message="hi")
+    client = _FakeClient(messages_by_id={9: text_msg})
+    _patch_client(monkeypatch, client, entity, 1)
+
+    result = await messages.transcribe_voice(chat_id=1, message_id=9, account=None)
+
+    assert "no voice message" in result
+
+
+@pytest.mark.asyncio
+async def test_transcribe_voice_rejects_unknown_engine(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_by_id={5: _voice_msg(id=5)})
+    _patch_client(monkeypatch, client, entity, 1)
+
+    result = await messages.transcribe_voice(
+        chat_id=1, message_id=5, engine="whisper-cloud", account=None
+    )
+
+    assert "Invalid engine" in result
+
+
+@pytest.mark.asyncio
+async def test_transcribe_voice_groq_without_api_key(monkeypatch, transcript_cache_dir):
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_by_id={5: _voice_msg(id=5)})
+    _patch_client(monkeypatch, client, entity, 1)
+
+    result = await messages.transcribe_voice(chat_id=1, message_id=5, engine="groq", account=None)
+
+    assert "GROQ_API_KEY" in result
+
+
+@pytest.mark.asyncio
+async def test_transcribe_voice_pending_degrades_gracefully_without_caching(
+    monkeypatch, transcript_cache_dir
+):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_by_id={5: _voice_msg(id=5)})
+    _patch_client(monkeypatch, client, entity, 1)
+    monkeypatch.setattr(transcription, "transcribe", _async_return({"status": "pending"}))
+
+    result = await messages.transcribe_voice(
+        chat_id=1, message_id=5, engine="telegram", account=None
+    )
+
+    payload = json.loads(result)
+    assert payload["transcribed"] is False
+    assert payload["reason"] == "pending"
+    assert transcription.get_cached_transcript(1, 5) is None
+
+
+@pytest.mark.asyncio
+async def test_transcribe_voice_premium_required_degrades_gracefully(
+    monkeypatch, transcript_cache_dir
+):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_by_id={5: _voice_msg(id=5)})
+    _patch_client(monkeypatch, client, entity, 1)
+    monkeypatch.setattr(transcription, "transcribe", _async_return({"status": "premium_required"}))
+
+    result = await messages.transcribe_voice(
+        chat_id=1, message_id=5, engine="telegram", account=None
+    )
+
+    payload = json.loads(result)
+    assert payload["sent"] is False
+    assert payload["reason"] == "telegram_premium_required"
+
+
+@pytest.mark.asyncio
+async def test_transcribe_voice_success_caches_result(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_by_id={5: _voice_msg(id=5)})
+    _patch_client(monkeypatch, client, entity, 1)
+    monkeypatch.setattr(
+        transcription, "transcribe", _async_return({"status": "ok", "text": "hi", "lang": "ru"})
+    )
+
+    result = await messages.transcribe_voice(
+        chat_id=1, message_id=5, engine="telegram", account=None
+    )
+
+    payload = json.loads(result)
+    assert payload["transcribed"] is True
+    assert payload["cached"] is False
+    assert payload["text"] == "hi"
+    assert payload["source"] == "telegram"
+    cached = transcription.get_cached_transcript(1, 5)
+    assert cached["text"] == "hi"
+    assert cached["lang"] == "ru"
+
+
+@pytest.mark.asyncio
+async def test_transcribe_voice_defaults_to_configured_engine(monkeypatch, transcript_cache_dir):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE_ENGINE", "telegram")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_by_id={5: _voice_msg(id=5)})
+    _patch_client(monkeypatch, client, entity, 1)
+
+    seen_engine = {}
+
+    async def _fake_transcribe(cl, ent, msg, engine):
+        seen_engine["engine"] = engine
+        return {"status": "ok", "text": "x"}
+
+    monkeypatch.setattr(transcription, "transcribe", _fake_transcribe)
+
+    await messages.transcribe_voice(chat_id=1, message_id=5, account=None)  # no engine= passed
+
+    assert seen_engine["engine"] == "telegram"
+
+
+@pytest.mark.asyncio
+async def test_transcribe_voice_explicit_engine_overrides_default(
+    monkeypatch, transcript_cache_dir
+):
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE", "on-demand")
+    monkeypatch.setenv("TELEGRAM_TRANSCRIBE_ENGINE", "groq")
+    entity = SimpleNamespace()
+    client = _FakeClient(messages_by_id={5: _voice_msg(id=5)})
+    _patch_client(monkeypatch, client, entity, 1)
+
+    seen_engine = {}
+
+    async def _fake_transcribe(cl, ent, msg, engine):
+        seen_engine["engine"] = engine
+        return {"status": "ok", "text": "x"}
+
+    monkeypatch.setattr(transcription, "transcribe", _fake_transcribe)
+
+    await messages.transcribe_voice(chat_id=1, message_id=5, engine="telegram", account=None)
+
+    assert seen_engine["engine"] == "telegram"


### PR DESCRIPTION
## What

Closes the two halves of #159 that #176 left open: reading rich messages, and streaming rich drafts.

## Reading

A rich message keeps its content in page blocks, not in `message`. Every read tool (`list_messages`, `get_messages`, `search_messages`, `get_message_context`, ...) therefore returned an empty message with no hint that anything was there.

`telegram_mcp/rich_messages.py` renders the blocks to Markdown: headings, lists, tables, blockquotes, preformatted blocks with a language, formulas, collapsible details (open state preserved), anchors, media placeholders. `message_to_dict` now returns

```json
"rich_message": {"blocks": 4, "photos": 1, "documents": 0, "rtl": false}
```

and puts the rendering into `text` only when the message has no plain text of its own; otherwise it goes to `rich_message.markdown` so nothing is overwritten. A partially loaded message is flagged `"partial": true`.

Dispatch is by type name rather than `isinstance` chains, so a block type from a future layer degrades to `[unsupported: PageBlockWhatever]` instead of disappearing. One subtlety worth flagging: a table with no header row gets a synthesised empty header, because Markdown otherwise swallows its first data row.

## Streaming drafts

`stream_rich_draft(chat_id, text, parse_mode="rich_md", draft_id=None, account=None)` shows the recipient a live rich draft the way Telegram's own AI features type into a chat. It sends `messages.SetTypingRequest` with `InputSendMessageRichMessageDraftAction` - a typing action, not a message, so nothing lands in history and the draft expires on its own. Pass the returned `draft_id` back in to keep updating the same draft.

Premium-gated the same way the send path is, and deliberately without `readOnlyHint`, so read-only deployments prune it.

## Tests

`tests/test_rich_message_reading.py`, 14 tests, covering nested rich text, empty and unknown blocks, header-less tables, collapsible state, the partial flag, no duplication when plain text exists, a plain message gaining no rich key, and the three draft behaviours (typing action not message, draft id reuse, Premium gate).

Mutant check: removing the read-path wiring from `message_to_dict` turns exactly three of them red and leaves the other eleven green.

Full suite passes; `black --check` and `flake8 --select=E9,F63,F7,F82` are clean. The first commit is a lint-only fix - `main` carries an unformatted `telegram_mcp/transcription.py`, so `black --check` fails on any branch cut from it (same fix as in #197).
