### PR TITLE
feat(runtime): surface FloodWait rate limits with actionable wait instructions (closes #180)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,12 @@ prefetches per listing call; `TELEGRAM_TRANSCRIPT_CACHE_DIR` (default
 `data/transcripts`) sets where the SQLite cache is written; `TELEGRAM_TRANSCRIBE_GROQ_MAX_MB`
 (default 25) is the largest recording the groq engine will upload.
 
+Telegram rate limits (`FloodWaitError`) are surfaced transparently to MCP clients and LLM agents with the exact wait duration and an explicit instruction not to retry immediately. Configure Telethon's internal silent-sleep threshold (default: 60 seconds; set to `0` to fail fast and let the agent handle pacing):
+
+```env
+TELEGRAM_FLOOD_SLEEP_THRESHOLD=60   # Max seconds Telethon sleeps silently on FloodWait (default 60)
+```
+
 Run the server locally:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -196,7 +196,9 @@ prefetches per listing call; `TELEGRAM_TRANSCRIPT_CACHE_DIR` (default
 `data/transcripts`) sets where the SQLite cache is written; `TELEGRAM_TRANSCRIBE_GROQ_MAX_MB`
 (default 25) is the largest recording the groq engine will upload.
 
-Telegram rate limits (`FloodWaitError`) are surfaced transparently to MCP clients and LLM agents with the exact wait duration and an explicit instruction not to retry immediately. Configure Telethon's internal silent-sleep threshold (default: 60 seconds; set to `0` to fail fast and let the agent handle pacing):
+Telegram rate limits (`FloodWaitError`) are surfaced transparently to MCP clients and LLM agents with the exact wait duration and an explicit instruction not to retry immediately.
+
+Use `TELEGRAM_FLOOD_SLEEP_THRESHOLD` to configure Telethon's internal silent-sleep threshold (default: 60 seconds). Set to `0` to disable silent sleeping and let the agent manage all backoff pacing:
 
 ```env
 TELEGRAM_FLOOD_SLEEP_THRESHOLD=60   # Max seconds Telethon sleeps silently on FloodWait (default 60)

--- a/telegram_mcp/runtime.py
+++ b/telegram_mcp/runtime.py
@@ -23,7 +23,7 @@ from mcp.types import Annotations, ImageContent, TextContent, ToolAnnotations
 from mcp.shared.exceptions import McpError
 from pythonjsonlogger import jsonlogger
 from telethon import TelegramClient, functions, types, utils
-from telethon.errors import AuthKeyDuplicatedError
+from telethon.errors import AuthKeyDuplicatedError, FloodWaitError
 from telethon.sessions import StringSession
 from telethon.tl.types import (
     User,
@@ -328,7 +328,12 @@ def _get_flood_sleep_threshold() -> int:
     raw = os.getenv("TELEGRAM_FLOOD_SLEEP_THRESHOLD", "60").strip()
     try:
         val = int(raw)
-        return max(0, val)
+        if val < 0:
+            logger.warning(
+                f"Negative TELEGRAM_FLOOD_SLEEP_THRESHOLD='{raw}' clamped to 0 (fail-fast mode)"
+            )
+            return 0
+        return val
     except ValueError:
         logger.warning(
             f"Invalid TELEGRAM_FLOOD_SLEEP_THRESHOLD='{raw}', falling back to default 60s"
@@ -344,6 +349,7 @@ def _build_client(session: Any, label: str) -> TelegramClient:
         kwargs["proxy"] = proxy
     if connection is not None:
         kwargs["connection"] = connection
+    # Read flood sleep threshold dynamically so runtime env changes take effect
     kwargs["flood_sleep_threshold"] = _get_flood_sleep_threshold()
     kwargs.update(client_identity_kwargs())
     return TelegramClient(session, TELEGRAM_API_ID, TELEGRAM_API_HASH, **kwargs)
@@ -703,6 +709,23 @@ class ErrorCategory(str, Enum):
     FOLDER = "FOLDER"
 
 
+def _is_flood_wait(error: Exception) -> bool:
+    """True for Telethon FloodWaitError."""
+    try:
+        return isinstance(error, FloodWaitError)
+    except Exception:  # telethon missing or moved — not this helper's problem
+        return False
+
+
+def _is_schema_drift(error: Exception) -> bool:
+    """True for TypeNotFoundError — the installed TL schema is older than what the server sends."""
+    try:
+        from telethon.errors.common import TypeNotFoundError
+    except Exception:  # telethon missing or moved — not this helper's problem
+        return False
+    return isinstance(error, TypeNotFoundError)
+
+
 def log_and_format_error(
     function_name: str,
     error: Exception,
@@ -753,15 +776,16 @@ def log_and_format_error(
     # LLMs will blindly retry generic errors, escalating the flood penalty and risking bans.
     # We log at WARNING level and return explicit wait duration with a strict no-retry directive.
     if _is_flood_wait(error):
-        seconds = getattr(error, "seconds", 0)
+        seconds = getattr(error, "seconds", None) or 0
         logger.warning(
             f"Telegram FloodWait in {function_name} ({context}) - "
             f"Rate limited for {seconds}s - Code: {error_code}"
         )
         if user_message:
             return user_message
+        wait_clause = f"{seconds} seconds" if seconds > 0 else "an unknown duration"
         return (
-            f"Rate limit exceeded (FloodWait): Telegram requires waiting {seconds} seconds "
+            f"Rate limit exceeded (FloodWait): Telegram requires waiting {wait_clause} "
             f"before repeating this operation. Do NOT retry immediately (code: {error_code})."
         )
 
@@ -786,25 +810,6 @@ def log_and_format_error(
         )
 
     return f"An error occurred (code: {error_code}). Check mcp_errors.log for details."
-
-
-def _is_flood_wait(error: Exception) -> bool:
-    """True for Telethon FloodWaitError."""
-    try:
-        from telethon.errors import FloodWaitError
-
-        return isinstance(error, FloodWaitError)
-    except Exception:  # telethon missing or moved — not this helper's problem
-        return False
-
-
-def _is_schema_drift(error: Exception) -> bool:
-    """True for TypeNotFoundError — the installed TL schema is older than what the server sends."""
-    try:
-        from telethon.errors.common import TypeNotFoundError
-    except Exception:  # telethon missing or moved — not this helper's problem
-        return False
-    return isinstance(error, TypeNotFoundError)
 
 
 def validate_id(*param_names_to_validate):

--- a/telegram_mcp/runtime.py
+++ b/telegram_mcp/runtime.py
@@ -323,14 +323,28 @@ def _build_proxy_for_label(label: str) -> tuple[Optional[Any], Optional[Any]]:
     return proxy, None
 
 
+def _get_flood_sleep_threshold() -> int:
+    """Read TELEGRAM_FLOOD_SLEEP_THRESHOLD from environment (default: 60)."""
+    raw = os.getenv("TELEGRAM_FLOOD_SLEEP_THRESHOLD", "60").strip()
+    try:
+        val = int(raw)
+        return max(0, val)
+    except ValueError:
+        logger.warning(
+            f"Invalid TELEGRAM_FLOOD_SLEEP_THRESHOLD='{raw}', falling back to default 60s"
+        )
+        return 60
+
+
 def _build_client(session: Any, label: str) -> TelegramClient:
-    """Construct a ``TelegramClient`` honoring per-label proxy configuration."""
+    """Construct a ``TelegramClient`` honoring per-label proxy and flood sleep configuration."""
     proxy, connection = _build_proxy_for_label(label)
     kwargs: dict[str, Any] = {}
     if proxy is not None:
         kwargs["proxy"] = proxy
     if connection is not None:
         kwargs["connection"] = connection
+    kwargs["flood_sleep_threshold"] = _get_flood_sleep_threshold()
     kwargs.update(client_identity_kwargs())
     return TelegramClient(session, TELEGRAM_API_ID, TELEGRAM_API_HASH, **kwargs)
 
@@ -735,6 +749,22 @@ def log_and_format_error(
     # Format the additional context parameters
     context = ", ".join(f"{k}={v}" for k, v in kwargs.items())
 
+    # Telegram FloodWait (Rate Limiting) must be explicitly formatted for LLM agents.
+    # LLMs will blindly retry generic errors, escalating the flood penalty and risking bans.
+    # We log at WARNING level and return explicit wait duration with a strict no-retry directive.
+    if _is_flood_wait(error):
+        seconds = getattr(error, "seconds", 0)
+        logger.warning(
+            f"Telegram FloodWait in {function_name} ({context}) - "
+            f"Rate limited for {seconds}s - Code: {error_code}"
+        )
+        if user_message:
+            return user_message
+        return (
+            f"Rate limit exceeded (FloodWait): Telegram requires waiting {seconds} seconds "
+            f"before repeating this operation. Do NOT retry immediately (code: {error_code})."
+        )
+
     # Log the full technical error
     logger.error(f"Error in {function_name} ({context}) - Code: {error_code}", exc_info=True)
 
@@ -756,6 +786,16 @@ def log_and_format_error(
         )
 
     return f"An error occurred (code: {error_code}). Check mcp_errors.log for details."
+
+
+def _is_flood_wait(error: Exception) -> bool:
+    """True for Telethon FloodWaitError."""
+    try:
+        from telethon.errors import FloodWaitError
+
+        return isinstance(error, FloodWaitError)
+    except Exception:  # telethon missing or moved — not this helper's problem
+        return False
 
 
 def _is_schema_drift(error: Exception) -> bool:

--- a/tests/test_flood_wait.py
+++ b/tests/test_flood_wait.py
@@ -27,6 +27,16 @@ def test_flood_wait_is_named_and_actionable():
     assert "code: MSG-ERR-" in msg
 
 
+def test_flood_wait_zero_or_missing_seconds_formats_unknown_duration():
+    err = FloodWaitError(request=None, capture=0)
+    msg = log_and_format_error("send_message", err, prefix=ErrorCategory.MSG)
+
+    assert "Rate limit exceeded (FloodWait)" in msg
+    assert "an unknown duration" in msg
+    assert "Do NOT retry immediately" in msg
+    assert "0 seconds" not in msg
+
+
 def test_flood_wait_is_detected_by_helper():
     err = FloodWaitError(request=None, capture=120)
     assert _is_flood_wait(err) is True
@@ -61,6 +71,14 @@ def test_flood_sleep_threshold_custom_valid(monkeypatch):
 
     monkeypatch.setenv("TELEGRAM_FLOOD_SLEEP_THRESHOLD", "0")
     assert _get_flood_sleep_threshold() == 0
+
+
+def test_flood_sleep_threshold_negative_clamped_with_warning(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_FLOOD_SLEEP_THRESHOLD", "-5")
+    with patch("telegram_mcp.runtime.logger") as mock_logger:
+        assert _get_flood_sleep_threshold() == 0
+        mock_logger.warning.assert_called_once()
+        assert "Negative TELEGRAM_FLOOD_SLEEP_THRESHOLD" in mock_logger.warning.call_args[0][0]
 
 
 def test_flood_sleep_threshold_invalid_falls_back(monkeypatch):

--- a/tests/test_flood_wait.py
+++ b/tests/test_flood_wait.py
@@ -1,0 +1,88 @@
+"""FloodWait (rate limit) errors must be surfaced with actionable instructions for LLMs.
+
+When Telegram rate-limits a client with FloodWaitError, returning a generic error
+prompts LLM agents to retry immediately, worsening the rate limit and risking account bans.
+The error formatter must explicitly communicate the required wait duration and directive
+not to retry immediately, while allowing flood_sleep_threshold to be configured via environment.
+"""
+
+from unittest.mock import patch
+from telethon.errors import FloodWaitError
+from telegram_mcp.runtime import (
+    _get_flood_sleep_threshold,
+    _is_flood_wait,
+    _build_client,
+    log_and_format_error,
+    ErrorCategory,
+)
+
+
+def test_flood_wait_is_named_and_actionable():
+    err = FloodWaitError(request=None, capture=45)
+    msg = log_and_format_error("send_message", err, prefix=ErrorCategory.MSG, chat_id=123456)
+
+    assert "Rate limit exceeded (FloodWait)" in msg
+    assert "45 seconds" in msg
+    assert "Do NOT retry immediately" in msg
+    assert "code: MSG-ERR-" in msg
+
+
+def test_flood_wait_is_detected_by_helper():
+    err = FloodWaitError(request=None, capture=120)
+    assert _is_flood_wait(err) is True
+    assert _is_flood_wait(ValueError("other error")) is False
+
+
+def test_flood_wait_logs_warning_instead_of_error():
+    err = FloodWaitError(request=None, capture=30)
+    with patch("telegram_mcp.runtime.logger") as mock_logger:
+        log_and_format_error("get_history", err, chat_id=98765)
+        mock_logger.warning.assert_called_once()
+        warning_args = mock_logger.warning.call_args[0][0]
+        assert "Telegram FloodWait in get_history" in warning_args
+        assert "30s" in warning_args
+        mock_logger.error.assert_not_called()
+
+
+def test_flood_wait_with_custom_user_message():
+    err = FloodWaitError(request=None, capture=15)
+    msg = log_and_format_error("send_message", err, user_message="Custom rate limit message")
+    assert msg == "Custom rate limit message"
+
+
+def test_flood_sleep_threshold_default(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_FLOOD_SLEEP_THRESHOLD", raising=False)
+    assert _get_flood_sleep_threshold() == 60
+
+
+def test_flood_sleep_threshold_custom_valid(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_FLOOD_SLEEP_THRESHOLD", "15")
+    assert _get_flood_sleep_threshold() == 15
+
+    monkeypatch.setenv("TELEGRAM_FLOOD_SLEEP_THRESHOLD", "0")
+    assert _get_flood_sleep_threshold() == 0
+
+
+def test_flood_sleep_threshold_invalid_falls_back(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_FLOOD_SLEEP_THRESHOLD", "not_a_number")
+    with patch("telegram_mcp.runtime.logger") as mock_logger:
+        assert _get_flood_sleep_threshold() == 60
+        mock_logger.warning.assert_called_once()
+        assert "Invalid TELEGRAM_FLOOD_SLEEP_THRESHOLD" in mock_logger.warning.call_args[0][0]
+
+
+def test_build_client_passes_flood_sleep_threshold(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_FLOOD_SLEEP_THRESHOLD", "25")
+    with patch("telegram_mcp.runtime.TelegramClient") as mock_tc:
+        _build_client("dummy_session", "default")
+        mock_tc.assert_called_once()
+        _, kwargs = mock_tc.call_args
+        assert kwargs.get("flood_sleep_threshold") == 25
+
+
+def test_ordinary_error_retains_generic_error_format():
+    msg = log_and_format_error(
+        "send_message", ValueError("network error"), prefix=ErrorCategory.MSG
+    )
+    assert "An error occurred (code: MSG-ERR-" in msg
+    assert "Rate limit exceeded" not in msg


### PR DESCRIPTION
## Summary

Closes #180.

Telegram rate limits (`FloodWaitError`) previously suffered from two failure modes in the tool runtime:
1. **Silent latency accumulation:** `_build_client()` did not configure `flood_sleep_threshold`, inheriting Telethon's default of 60s silent sleep. When multiple operations (e.g. scanning dialogs) encountered short flood waits, sleeps stacked up past MCP client idle timeouts, creating false "server dead" hangs.
2. **Type erasure on long waits:** When a wait exceeded 60s, `FloodWaitError` was caught by `log_and_format_error()` and formatted as an opaque generic error (`GEN-ERR-...`), stripping the wait duration and exception type. AI/LLM agents would immediately retry the request, escalating the rate limit and risking account restrictions or bans.

## Changes

- **`telegram_mcp/runtime.py`**:
  - Added `_get_flood_sleep_threshold()` to read `TELEGRAM_FLOOD_SLEEP_THRESHOLD` (default: `60`s). Set to `0` to fail fast and let the agent manage backoff.
  - Configured `kwargs["flood_sleep_threshold"]` during `TelegramClient` initialization in `_build_client()`.
  - Added `_is_flood_wait()` helper and specialized handling in `log_and_format_error()`:
    - Logs a `WARNING` with the required wait duration instead of an unhandled error.
    - Returns an explicit, actionable message to LLMs containing the required wait seconds and a directive not to retry immediately:
      `"Rate limit exceeded (FloodWait): Telegram requires waiting N seconds before repeating this operation. Do NOT retry immediately (code: ...)."`
- **`README.md`**:
  - Documented `TELEGRAM_FLOOD_SLEEP_THRESHOLD` under environment configuration.
- **`tests/test_flood_wait.py`**:
  - Added 9 unit tests covering threshold parsing, custom and invalid fallbacks, client builder kwargs, warning logging, custom user messages, and explicit LLM instructions.

## Verification

```bash
uv run pytest tests/test_flood_wait.py
# 9 passed in 0.70s

uv run pytest
# 439 passed

uv run black --check telegram_mcp/ tests/test_flood_wait.py
uv run flake8 telegram_mcp/ tests/test_flood_wait.py --select=E9,F63,F7,F82
# Clean
```
