### PR TITLE
send_file, send_album: add schedule_date

### DIFF
--- a/telegram_mcp/runtime.py
+++ b/telegram_mcp/runtime.py
@@ -111,6 +111,31 @@ def get_entity_filter_type(entity: Any) -> Optional[str]:
     return None
 
 
+def parse_schedule_date(
+    schedule_date: Union[str, int],
+) -> tuple[Optional[datetime], Optional[str]]:
+    """Return (datetime, None) for a usable schedule_date, or (None, error message).
+
+    Accepts an ISO-8601 string or a Unix timestamp; naive datetimes are UTC.
+    """
+    try:
+        if isinstance(schedule_date, int):
+            dt = datetime.fromtimestamp(schedule_date, tz=timezone.utc)
+        else:
+            dt = datetime.fromisoformat(str(schedule_date).replace("Z", "+00:00"))
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+    except (TypeError, ValueError, OverflowError, OSError) as exc:
+        return None, f"schedule_date could not be parsed ({schedule_date!r}): {exc}"
+
+    now = datetime.now(timezone.utc)
+    if dt <= now:
+        return None, (
+            f"schedule_date must be in the future (got {dt.isoformat()}, now {now.isoformat()})."
+        )
+    return dt, None
+
+
 load_dotenv()
 
 TELEGRAM_API_ID = int(os.getenv("TELEGRAM_API_ID"))

--- a/telegram_mcp/tools/media.py
+++ b/telegram_mcp/tools/media.py
@@ -24,6 +24,7 @@ async def send_file(
     file_path: Union[str, List[str]],
     caption: str = None,
     topic_id: Optional[int] = None,
+    schedule_date: Union[str, int, None] = None,
     ctx: Optional[Context] = None,
     account: str = None,
 ) -> str:
@@ -36,6 +37,10 @@ async def send_file(
         caption: Optional caption for the file or media group.
         topic_id: Optional forum topic ID (from list_topics). Sends into that topic
             in a forum-enabled community/supergroup. Also works as reply_to for a message.
+        schedule_date: Optional. When set, the file is placed in the chat's
+            scheduled queue instead of being sent now. Either an ISO-8601 string
+            (e.g. "2026-05-01T14:30:00" or "2026-05-01T14:30:00Z") or a Unix
+            timestamp (int). Naive datetimes are treated as UTC.
     """
     try:
         if isinstance(file_path, list):
@@ -44,9 +49,16 @@ async def send_file(
                 file_paths=file_path,
                 caption=caption,
                 topic_id=topic_id,
+                schedule_date=schedule_date,
                 ctx=ctx,
                 account=account,
             )
+
+        dt = None
+        if schedule_date is not None:
+            dt, schedule_error = parse_schedule_date(schedule_date)
+            if schedule_error:
+                return schedule_error
 
         cl = get_client(account)
         safe_path, path_error = await _resolve_readable_file_path(
@@ -57,7 +69,9 @@ async def send_file(
         if path_error:
             return path_error
         entity = await resolve_entity(chat_id, cl)
-        await cl.send_file(entity, str(safe_path), caption=caption, reply_to=topic_id)
+        await cl.send_file(entity, str(safe_path), caption=caption, reply_to=topic_id, schedule=dt)
+        if dt:
+            return f"File from {safe_path} scheduled for {dt.isoformat()} in chat {chat_id}."
         return f"File sent to chat {chat_id} from {safe_path}."
     except Exception as e:
         return log_and_format_error(
@@ -67,6 +81,7 @@ async def send_file(
             file_path=file_path,
             caption=caption,
             topic_id=topic_id,
+            schedule_date=str(schedule_date),
         )
 
 
@@ -75,11 +90,18 @@ async def _send_album(
     file_paths: List[str],
     caption: str = None,
     topic_id: Optional[int] = None,
+    schedule_date: Union[str, int, None] = None,
     ctx: Optional[Context] = None,
     account: str = None,
 ) -> str:
     if not 2 <= len(file_paths) <= 10:
         return "Albums must contain between 2 and 10 files."
+
+    dt = None
+    if schedule_date is not None:
+        dt, schedule_error = parse_schedule_date(schedule_date)
+        if schedule_error:
+            return schedule_error
 
     cl = get_client(account)
     safe_paths = []
@@ -94,7 +116,11 @@ async def _send_album(
         safe_paths.append(str(safe_path))
 
     entity = await resolve_entity(chat_id, cl)
-    await cl.send_file(entity, safe_paths, caption=caption, reply_to=topic_id)
+    await cl.send_file(entity, safe_paths, caption=caption, reply_to=topic_id, schedule=dt)
+    if dt:
+        return (
+            f"Album of {len(safe_paths)} files scheduled for {dt.isoformat()} in chat {chat_id}."
+        )
     return f"Album sent to chat {chat_id} with {len(safe_paths)} files."
 
 
@@ -108,6 +134,7 @@ async def send_album(
     file_paths: List[str],
     caption: str = None,
     topic_id: Optional[int] = None,
+    schedule_date: Union[str, int, None] = None,
     ctx: Optional[Context] = None,
     account: str = None,
 ) -> str:
@@ -120,6 +147,9 @@ async def send_album(
         caption: Optional caption for the album. Telegram displays it on the first item.
         topic_id: Optional forum topic ID (from list_topics). Sends into that topic
             in a forum-enabled community/supergroup. Also works as reply_to for a message.
+        schedule_date: Optional. When set, the album is placed in the chat's
+            scheduled queue instead of being sent now. Either an ISO-8601 string
+            or a Unix timestamp (int). Naive datetimes are treated as UTC.
     """
     try:
         if not isinstance(file_paths, list):
@@ -129,6 +159,7 @@ async def send_album(
             file_paths=file_paths,
             caption=caption,
             topic_id=topic_id,
+            schedule_date=schedule_date,
             ctx=ctx,
             account=account,
         )
@@ -140,6 +171,7 @@ async def send_album(
             file_paths=file_paths,
             caption=caption,
             topic_id=topic_id,
+            schedule_date=str(schedule_date),
         )
 
 

--- a/telegram_mcp/tools/messages.py
+++ b/telegram_mcp/tools/messages.py
@@ -480,18 +480,9 @@ async def send_scheduled_message(
     try:
         cl = get_client(account)
         await ensure_connected(cl)
-        if isinstance(schedule_date, int):
-            dt = datetime.fromtimestamp(schedule_date, tz=timezone.utc)
-        else:
-            dt = datetime.fromisoformat(schedule_date.replace("Z", "+00:00"))
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
-
-        if dt <= datetime.now(timezone.utc):
-            return (
-                f"schedule_date must be in the future (got {dt.isoformat()}, "
-                f"now {datetime.now(timezone.utc).isoformat()})."
-            )
+        dt, schedule_error = parse_schedule_date(schedule_date)
+        if schedule_error:
+            return schedule_error
 
         entity = await resolve_entity(chat_id, cl)
         result = await cl.send_message(entity, message, schedule=dt)

--- a/tests/test_media_album.py
+++ b/tests/test_media_album.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 from telegram_mcp import runtime
@@ -7,14 +9,16 @@ from telegram_mcp.tools import media
 class _DummyClient:
     def __init__(self):
         self.sent = None
+        self.schedule = None
 
-    async def send_file(self, entity, file_paths, caption=None, reply_to=None):
+    async def send_file(self, entity, file_paths, caption=None, reply_to=None, schedule=None):
         self.sent = {
             "entity": entity,
             "file_paths": file_paths,
             "caption": caption,
             "reply_to": reply_to,
         }
+        self.schedule = schedule
 
 
 @pytest.mark.asyncio
@@ -150,3 +154,76 @@ async def test_send_album_reuses_readable_path_security(tmp_path, monkeypatch):
     result = await media.send_album("AgenticAIChat", ["one.png", str(outside_file)])
 
     assert result == "Path is outside allowed roots."
+
+
+@pytest.mark.asyncio
+async def test_send_file_schedules_when_schedule_date_given(tmp_path, monkeypatch):
+    root = (tmp_path / "root").resolve()
+    root.mkdir()
+    path = root / "poster.png"
+    path.write_bytes(b"png")
+
+    client = _DummyClient()
+    monkeypatch.setattr(runtime, "SERVER_ALLOWED_ROOTS", [root])
+    monkeypatch.setattr(media, "clients", {"default": client})
+    monkeypatch.setattr(media, "get_client", lambda account=None: client)
+
+    async def _resolve_entity(chat_id, cl):
+        return "entity:channel"
+
+    monkeypatch.setattr(media, "resolve_entity", _resolve_entity)
+
+    when = datetime.now(timezone.utc) + timedelta(hours=1)
+    result = await media.send_file(
+        "Channel", "poster.png", caption="later", schedule_date=when.isoformat()
+    )
+
+    assert result == f"File from {path} scheduled for {when.isoformat()} in chat Channel."
+    assert client.schedule == when
+
+
+@pytest.mark.asyncio
+async def test_send_album_schedules_when_schedule_date_given(tmp_path, monkeypatch):
+    root = (tmp_path / "root").resolve()
+    root.mkdir()
+    (root / "one.png").write_bytes(b"png-one")
+    (root / "two.png").write_bytes(b"png-two")
+
+    client = _DummyClient()
+    monkeypatch.setattr(runtime, "SERVER_ALLOWED_ROOTS", [root])
+    monkeypatch.setattr(media, "clients", {"default": client})
+    monkeypatch.setattr(media, "get_client", lambda account=None: client)
+
+    async def _resolve_entity(chat_id, cl):
+        return "entity:channel"
+
+    monkeypatch.setattr(media, "resolve_entity", _resolve_entity)
+
+    when = datetime.now(timezone.utc) + timedelta(days=2)
+    result = await media.send_album(
+        "Channel", ["one.png", "two.png"], schedule_date=int(when.timestamp())
+    )
+
+    assert result.startswith("Album of 2 files scheduled for ")
+    assert client.schedule == datetime.fromtimestamp(int(when.timestamp()), tz=timezone.utc)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool_name", ["send_album", "send_file"])
+async def test_schedule_date_in_the_past_is_rejected(tmp_path, monkeypatch, tool_name):
+    root = (tmp_path / "root").resolve()
+    root.mkdir()
+    (root / "one.png").write_bytes(b"png-one")
+    (root / "two.png").write_bytes(b"png-two")
+
+    client = _DummyClient()
+    monkeypatch.setattr(runtime, "SERVER_ALLOWED_ROOTS", [root])
+    monkeypatch.setattr(media, "clients", {"default": client})
+    monkeypatch.setattr(media, "get_client", lambda account=None: client)
+
+    past = (datetime.now(timezone.utc) - timedelta(minutes=1)).isoformat()
+    tool = getattr(media, tool_name)
+    result = await tool("Channel", ["one.png", "two.png"], schedule_date=past)
+
+    assert result.startswith("schedule_date must be in the future")
+    assert client.sent is None


### PR DESCRIPTION
`send_scheduled_message` can schedule text, but media had no way to be scheduled — so a channel that posts images with captions could not use the scheduled queue at all.

This adds an optional `schedule_date` to `send_file` and `send_album`, accepting the same ISO-8601 string or Unix timestamp as `send_scheduled_message`. The parsing and future-date check moved into `parse_schedule_date` in runtime, now shared by all three tools.

Tested against a real account: a photo with a caption lands in the chat's scheduled queue and shows up in `get_scheduled_messages`.