### PR TITLE
fix: redact sensitive data from error logs

### DIFF
--- a/telegram_mcp/runtime.py
+++ b/telegram_mcp/runtime.py
@@ -125,8 +125,10 @@ def parse_schedule_date(
             dt = datetime.fromisoformat(str(schedule_date).replace("Z", "+00:00"))
             if dt.tzinfo is None:
                 dt = dt.replace(tzinfo=timezone.utc)
-    except (TypeError, ValueError, OverflowError, OSError) as exc:
-        return None, f"schedule_date could not be parsed ({schedule_date!r}): {exc}"
+    except (TypeError, ValueError, OverflowError, OSError):
+        return None, (
+            "schedule_date could not be parsed. Use an ISO-8601 date/time or Unix timestamp."
+        )
 
     now = datetime.now(timezone.utc)
     if dt <= now:
@@ -354,15 +356,11 @@ def _get_flood_sleep_threshold() -> int:
     try:
         val = int(raw)
         if val < 0:
-            logger.warning(
-                f"Negative TELEGRAM_FLOOD_SLEEP_THRESHOLD='{raw}' clamped to 0 (fail-fast mode)"
-            )
+            logger.warning("Negative TELEGRAM_FLOOD_SLEEP_THRESHOLD clamped to 0 (fail-fast mode)")
             return 0
         return val
     except ValueError:
-        logger.warning(
-            f"Invalid TELEGRAM_FLOOD_SLEEP_THRESHOLD='{raw}', falling back to default 60s"
-        )
+        logger.warning("Invalid TELEGRAM_FLOOD_SLEEP_THRESHOLD; falling back to default 60s")
         return 60
 
 
@@ -686,12 +684,12 @@ try:
     # Add handlers to logger
     logger.addHandler(console_handler)
     logger.addHandler(file_handler)
-    logger.info(f"Logging initialized to {log_file_path}")
-except Exception as log_error:
-    print(f"WARNING: Error setting up log file: {log_error}", file=sys.stderr)
+    logger.info("Logging initialized")
+except Exception:
+    print("WARNING: Error setting up log file; using console logging only.", file=sys.stderr)
     # Fallback to console-only logging
     logger.addHandler(console_handler)
-    logger.error(f"Failed to set up log file handler: {log_error}")
+    logger.error("Failed to set up log file handler; using console logging only.")
 
 
 # File-path tool security configuration
@@ -769,7 +767,7 @@ def log_and_format_error(
         prefix: Error code prefix (e.g., ErrorCategory.CHAT, "VALIDATION-001").
             If None, it will be derived from the function_name.
         user_message: A custom user-facing message to return. If None, a generic one is created.
-        **kwargs: Additional context parameters to include in the log.
+        **kwargs: Additional context parameters. These are never written to persistent logs.
 
     Returns:
         A user-friendly error message with an error code.
@@ -794,18 +792,14 @@ def log_and_format_error(
         prefix_str = prefix.value if isinstance(prefix, ErrorCategory) else (prefix or "GEN")
         error_code = f"{prefix_str}-ERR-{abs(hash(function_name)) % 1000:03d}"
 
-    # Format the additional context parameters
-    context = ", ".join(f"{k}={v}" for k, v in kwargs.items())
-
     # Telegram FloodWait (Rate Limiting) must be explicitly formatted for LLM agents.
     # LLMs will blindly retry generic errors, escalating the flood penalty and risking bans.
-    # We log at WARNING level and return explicit wait duration with a strict no-retry directive.
+    # Log only a categorical warning; the user-facing response below carries the
+    # actionable wait duration. The persistent error-file handler intentionally
+    # does not store WARNING records.
     if _is_flood_wait(error):
         seconds = getattr(error, "seconds", None) or 0
-        logger.warning(
-            f"Telegram FloodWait in {function_name} ({context}) - "
-            f"Rate limited for {seconds}s - Code: {error_code}"
-        )
+        logger.warning("Telegram FloodWait; retry only after the reported delay.")
         if user_message:
             return user_message
         wait_clause = f"{seconds} seconds" if seconds > 0 else "an unknown duration"
@@ -814,8 +808,9 @@ def log_and_format_error(
             f"before repeating this operation. Do NOT retry immediately (code: {error_code})."
         )
 
-    # Log the full technical error
-    logger.error(f"Error in {function_name} ({context}) - Code: {error_code}", exc_info=True)
+    # Keep persistent logs useful without recording exception text, tracebacks,
+    # identifiers, user content, provider payloads, or local paths.
+    logger.error("Telegram MCP operation failed; see the returned stable error code.")
 
     # Return a user-friendly message
     if user_message:
@@ -829,12 +824,12 @@ def log_and_format_error(
     if _is_schema_drift(error):
         return (
             f"MTProto schema mismatch: the installed Telethon does not know an object the "
-            f"server sent ({error}). This is NOT a missing user or chat — the data arrived, "
+            f"server sent. This is NOT a missing user or chat — the data arrived, "
             f"parsing it failed. Upgrade Telethon; if it is already the latest release, its "
             f"schema is behind the current layer (code: {error_code})."
         )
 
-    return f"An error occurred (code: {error_code}). Check mcp_errors.log for details."
+    return f"An error occurred (code: {error_code})."
 
 
 def validate_id(*param_names_to_validate):
@@ -1035,11 +1030,14 @@ def load_aliases(strict: bool = False) -> Dict[str, Dict[str, Any]]:
     except FileNotFoundError:
         return {}
     except (OSError, ValueError, TypeError) as error:
-        logger.warning("Ignoring unreadable aliases file %s: %s", path, error)
+        logger.warning("Ignoring unreadable aliases file; saved aliases were not changed.")
         if strict:
             # Refuse to write over data we could not read: a degraded read plus a
             # write-back would silently delete every alias in the file.
-            raise AliasStoreUnreadable(str(error)) from error
+            raise AliasStoreUnreadable(
+                "Saved contacts could not be read; no changes were written. "
+                "Check the aliases file and retry."
+            ) from error
         return {}
 
     records: Dict[str, Dict[str, Any]] = {}
@@ -1708,10 +1706,7 @@ async def _get_effective_allowed_roots_with_status(
     except Exception as error:
         recovered_roots = _coerce_paths_from_list_roots_validation_error(error)
         if recovered_roots:
-            logger.warning(
-                "MCP client returned non-URI roots; recovered %d path(s) from validation error.",
-                len(recovered_roots),
-            )
+            logger.warning("MCP client returned non-URI roots; recovered validated paths.")
             return recovered_roots, ROOTS_STATUS_READY
         if _is_roots_unsupported_error(error):
             if fallback_roots:
@@ -1723,12 +1718,9 @@ async def _get_effective_allowed_roots_with_status(
             logger.warning(
                 "MCP roots request failed; falling back to server CLI roots "
                 "(TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK).",
-                exc_info=True,
             )
             return fallback_roots, ROOTS_STATUS_SERVER_FALLBACK
-        logger.error(
-            "MCP roots request failed; disabling file-path tools for safety.", exc_info=True
-        )
+        logger.error("MCP roots request failed; disabling file-path tools for safety.")
         return [], ROOTS_STATUS_ERROR
 
     client_roots: List[Path] = []

--- a/telegram_mcp/tools/chats.py
+++ b/telegram_mcp/tools/chats.py
@@ -563,10 +563,8 @@ async def list_chats(
                     elif isinstance(entity, User):
                         full = await cl(functions.users.GetFullUserRequest(id=entity))
                         about_text = getattr(full.full_user, "about", "") or ""
-                except Exception as about_err:
-                    logger.warning(
-                        f"list_chats: failed to fetch about for {entity.id}: {about_err}"
-                    )
+                except Exception:
+                    logger.warning("list_chats: failed to fetch one chat description")
                     about_text = "<error fetching description>"
 
                 record["about"] = sanitize_user_content(about_text, max_length=200)
@@ -685,8 +683,8 @@ async def get_chat(chat_id: Union[int, str], account: str = None) -> str:
                     "date": last_msg.date,
                     "text": sanitize_user_content(last_msg.message),
                 }
-        except Exception as diag_ex:
-            logger.warning(f"Could not get dialog info for {chat_id}: {diag_ex}")
+        except Exception:
+            logger.warning("Could not get requested dialog metadata")
 
         return format_tool_result([], metadata=record)
     except Exception as e:
@@ -821,10 +819,8 @@ async def mute_chat(chat_id: Union[int, str], account: str = None) -> str:
             )
             return f"Chat {chat_id} muted (using alternative method)."
         except Exception as alt_e:
-            logger.exception(f"mute_chat (alt method) failed (chat_id={chat_id})")
             return log_and_format_error("mute_chat", alt_e, chat_id=chat_id)
     except Exception as e:
-        logger.exception(f"mute_chat failed (chat_id={chat_id})")
         return log_and_format_error("mute_chat", e, chat_id=chat_id)
 
 
@@ -866,10 +862,8 @@ async def unmute_chat(chat_id: Union[int, str], account: str = None) -> str:
             )
             return f"Chat {chat_id} unmuted (using alternative method)."
         except Exception as alt_e:
-            logger.exception(f"unmute_chat (alt method) failed (chat_id={chat_id})")
             return log_and_format_error("unmute_chat", alt_e, chat_id=chat_id)
     except Exception as e:
-        logger.exception(f"unmute_chat failed (chat_id={chat_id})")
         return log_and_format_error("unmute_chat", e, chat_id=chat_id)
 
 
@@ -972,9 +966,6 @@ async def get_common_chats(
 
         return "\n".join(lines)
     except Exception as e:
-        logger.exception(
-            f"get_common_chats failed (user_id={user_id}, limit={limit}, max_id={max_id})"
-        )
         return log_and_format_error(
             "get_common_chats", e, user_id=user_id, limit=limit, max_id=max_id
         )
@@ -1063,9 +1054,6 @@ async def get_message_read_by(
             default=json_serializer,
         )
     except Exception as e:
-        logger.exception(
-            f"get_message_read_by failed (chat_id={chat_id}, message_id={message_id})"
-        )
         return log_and_format_error(
             "get_message_read_by", e, chat_id=chat_id, message_id=message_id
         )
@@ -1119,10 +1107,6 @@ async def get_message_link(
             output += f"\nHTML: {html}"
         return output
     except Exception as e:
-        logger.exception(
-            f"get_message_link failed (chat_id={chat_id}, message_id={message_id}, "
-            f"thread={thread})"
-        )
         return log_and_format_error(
             "get_message_link",
             e,

--- a/telegram_mcp/tools/contacts.py
+++ b/telegram_mcp/tools/contacts.py
@@ -378,9 +378,6 @@ async def add_contact(
                     return f"Contact {first_name} {last_name} (@{username_clean}) added successfully (no updates returned)."
 
             except Exception as resolve_e:
-                logger.exception(
-                    f"add_contact (username resolve) failed (username={username_clean})"
-                )
                 return log_and_format_error("add_contact", resolve_e, username=username_clean)
 
         elif phone:
@@ -426,13 +423,10 @@ async def add_contact(
                 else:
                     return f"Contact not added. Alternative method response: {str(result)}"
             except Exception as alt_e:
-                logger.exception(f"add_contact (alt method) failed (phone={phone})")
                 return log_and_format_error("add_contact", alt_e, phone=phone)
         else:
-            logger.exception(f"add_contact (type error) failed")
             return log_and_format_error("add_contact", type_err)
     except Exception as e:
-        logger.exception(f"add_contact failed (phone={phone}, username={username})")
         return log_and_format_error("add_contact", e, phone=phone, username=username)
 
 
@@ -717,14 +711,15 @@ async def set_contact_alias(
             return format_tool_result({"saved": True, "alias": key, "resolved": formatted})
 
         return update_aliases(_store)
-    except AliasStoreUnreadable as e:
+    except AliasStoreUnreadable:
         return format_tool_result(
             {
                 "saved": False,
                 "reason": "alias_store_unreadable",
                 "detail": (
-                    f"The saved-contacts file could not be read ({e}); nothing was written "
-                    "so the existing memories are not destroyed. Ask the user to check it."
+                    "The saved-contacts file could not be read; nothing was written, so the "
+                    "existing memories are not destroyed. Ask the user to check the aliases "
+                    "file and retry."
                 ),
             }
         )

--- a/telegram_mcp/tools/events.py
+++ b/telegram_mcp/tools/events.py
@@ -165,7 +165,7 @@ async def _feed_loop(settle_ms: int) -> None:
         except asyncio.CancelledError:
             raise
         except Exception:
-            logging.getLogger("telegram_mcp").exception("error in incoming feed loop")
+            logging.getLogger("telegram_mcp").error("Error in incoming feed loop")
             await asyncio.sleep(1.0)
 
 
@@ -191,7 +191,7 @@ def _maybe_autostart_feed() -> None:
         try:
             _touch_feed_file()
         except OSError:
-            logging.getLogger("telegram_mcp").exception("cannot create event feed file")
+            logging.getLogger("telegram_mcp").error("Cannot create event feed file")
             return
         _start_feed(_feed_settle_ms)
 
@@ -230,7 +230,7 @@ async def _on_new_incoming(event) -> None:
         _maybe_autostart_feed()
         _get_activity_event().set()
     except Exception:
-        logging.getLogger("telegram_mcp").exception("error in _on_new_incoming")
+        logging.getLogger("telegram_mcp").error("Error in incoming-message handler")
 
 
 def register_incoming_handlers() -> None:
@@ -244,7 +244,7 @@ def register_incoming_handlers() -> None:
         try:
             cl.add_event_handler(_on_new_incoming, _events.NewMessage(incoming=True))
         except Exception:
-            logging.getLogger("telegram_mcp").exception("failed to register incoming handler")
+            logging.getLogger("telegram_mcp").error("Failed to register incoming handler")
 
 
 @mcp.tool(

--- a/telegram_mcp/tools/folders.py
+++ b/telegram_mcp/tools/folders.py
@@ -66,7 +66,6 @@ async def list_folders(account: str = None) -> str:
             {"folders": folders, "count": len(folders)}, indent=2, default=json_serializer
         )
     except Exception as e:
-        logger.exception("list_folders failed")
         return log_and_format_error("list_folders", e, ErrorCategory.FOLDER)
 
 
@@ -174,7 +173,6 @@ async def get_folder(folder_id: int, account: str = None) -> str:
 
         return json.dumps(folder_data, indent=2, default=json_serializer)
     except Exception as e:
-        logger.exception(f"get_folder failed (folder_id={folder_id})")
         return log_and_format_error("get_folder", e, ErrorCategory.FOLDER, folder_id=folder_id)
 
 
@@ -242,8 +240,8 @@ async def create_folder(
                 try:
                     peer = await resolve_input_entity(chat_id, cl)
                     include_peers.append(peer)
-                except Exception as e:
-                    return f"Failed to resolve chat '{chat_id}': {str(e)}"
+                except Exception:
+                    return "Failed to resolve a requested chat."
 
         # Create the folder (title must be TextWithEntities)
         title_obj = TextWithEntities(text=title, entities=[])
@@ -277,7 +275,6 @@ async def create_folder(
             indent=2,
         )
     except Exception as e:
-        logger.exception(f"create_folder failed (title={title})")
         return log_and_format_error("create_folder", e, ErrorCategory.FOLDER, title=title)
 
 
@@ -321,8 +318,8 @@ async def add_chat_to_folder(
         # Resolve chat to input peer
         try:
             peer = await resolve_input_entity(chat_id, cl)
-        except Exception as e:
-            return f"Failed to resolve chat '{chat_id}': {str(e)}"
+        except Exception:
+            return "Failed to resolve a requested chat."
 
         # Check if already included (idempotent)
         include_peers = list(getattr(target_folder, "include_peers", []))
@@ -379,7 +376,6 @@ async def add_chat_to_folder(
             f"Chat {chat_id} added to folder {folder_id}" + (" (pinned)" if pinned else "") + "."
         )
     except Exception as e:
-        logger.exception(f"add_chat_to_folder failed (folder_id={folder_id}, chat_id={chat_id})")
         return log_and_format_error(
             "add_chat_to_folder", e, ErrorCategory.FOLDER, folder_id=folder_id, chat_id=chat_id
         )
@@ -425,8 +421,8 @@ async def remove_chat_from_folder(
         try:
             peer = await resolve_input_entity(chat_id, cl)
             peer_id = utils.get_peer_id(peer)
-        except Exception as e:
-            return f"Failed to resolve chat '{chat_id}': {str(e)}"
+        except Exception:
+            return "Failed to resolve a requested chat."
 
         # Filter out the peer from both include and pinned lists
         include_peers = [
@@ -485,9 +481,6 @@ async def remove_chat_from_folder(
 
         return f"Chat {chat_id} removed from folder {folder_id}."
     except Exception as e:
-        logger.exception(
-            f"remove_chat_from_folder failed (folder_id={folder_id}, chat_id={chat_id})"
-        )
         return log_and_format_error(
             "remove_chat_from_folder",
             e,
@@ -540,7 +533,6 @@ async def delete_folder(folder_id: int, account: str = None) -> str:
 
         return f"Folder '{sanitize_name(folder_title)}' (ID {folder_id}) deleted. Chats are preserved."
     except Exception as e:
-        logger.exception(f"delete_folder failed (folder_id={folder_id})")
         return log_and_format_error("delete_folder", e, ErrorCategory.FOLDER, folder_id=folder_id)
 
 
@@ -583,7 +575,6 @@ async def reorder_folders(folder_ids: List[int], account: str = None) -> str:
 
         return f"Folders reordered: {folder_ids}"
     except Exception as e:
-        logger.exception(f"reorder_folders failed (folder_ids={folder_ids})")
         return log_and_format_error(
             "reorder_folders", e, ErrorCategory.FOLDER, folder_ids=folder_ids
         )

--- a/telegram_mcp/tools/groups.py
+++ b/telegram_mcp/tools/groups.py
@@ -26,9 +26,8 @@ async def create_group(title: str, user_ids: List[Union[int, str]], account: str
             try:
                 user = await resolve_entity(user_id, cl)
                 users.append(user)
-            except Exception as e:
-                logger.error(f"Failed to get entity for user ID {user_id}: {e}")
-                return f"Error: Could not find user with ID {user_id}"
+            except Exception:
+                return "Error: Could not find a requested user."
 
         if not users:
             return "Error: No valid users provided"
@@ -64,7 +63,6 @@ async def create_group(title: str, user_ids: List[Union[int, str]], account: str
             else:
                 raise  # Let the outer exception handler catch it
     except Exception as e:
-        logger.exception(f"create_group failed (title={title}, user_ids={user_ids})")
         return log_and_format_error("create_group", e, title=title, user_ids=user_ids)
 
 
@@ -96,8 +94,8 @@ async def invite_to_group(
             try:
                 user = await resolve_entity(user_id, cl)
                 users_to_add.append(user)
-            except ValueError as e:
-                return f"Error: User with ID {user_id} could not be found. {e}"
+            except ValueError:
+                return "Error: A requested user could not be found."
 
         try:
             if isinstance(entity, Channel):
@@ -156,10 +154,6 @@ async def invite_to_group(
             return log_and_format_error("invite_to_group", e, group_id=group_id, user_ids=user_ids)
 
     except Exception as e:
-        logger.error(
-            f"telegram_mcp invite_to_group failed (group_id={group_id}, user_ids={user_ids})",
-            exc_info=True,
-        )
         return log_and_format_error("invite_to_group", e, group_id=group_id, user_ids=user_ids)
 
 
@@ -204,11 +198,9 @@ async def leave_chat(chat_id: Union[int, str], account: str = None) -> str:
                 )
                 chat_name = sanitize_name(getattr(entity, "title", str(chat_id)))
                 return f"Left basic group {chat_name} (ID: {chat_id})."
-            except Exception as chat_err:
+            except Exception:
                 # If the above fails, try the second approach
-                logger.warning(
-                    f"First leave attempt failed: {chat_err}, trying alternative method"
-                )
+                logger.warning("First leave attempt failed; trying alternative method")
 
                 try:
                     # Alternative approach - sometimes this works better
@@ -234,8 +226,6 @@ async def leave_chat(chat_id: Union[int, str], account: str = None) -> str:
             )
 
     except Exception as e:
-        logger.exception(f"leave_chat failed (chat_id={chat_id})")
-
         # Provide helpful hint for common errors
         error_str = str(e).lower()
         if "invalid" in error_str and "chat" in error_str:
@@ -365,7 +355,6 @@ async def edit_chat_title(chat_id: Union[int, str], title: str, account: str = N
             return f"Cannot edit title for this entity type ({type(entity)})."
         return f"Chat {chat_id} title updated to '{sanitize_name(title)}'."
     except Exception as e:
-        logger.exception(f"edit_chat_title failed (chat_id={chat_id}, title='{title}')")
         return log_and_format_error("edit_chat_title", e, chat_id=chat_id, title=title)
 
 
@@ -411,7 +400,6 @@ async def edit_chat_photo(
 
         return f"Chat {chat_id} photo updated from {safe_path}."
     except Exception as e:
-        logger.exception(f"edit_chat_photo failed (chat_id={chat_id}, file_path='{file_path}')")
         return log_and_format_error("edit_chat_photo", e, chat_id=chat_id, file_path=file_path)
 
 
@@ -446,7 +434,6 @@ async def edit_chat_about(chat_id: Union[int, str], about: str, account: str = N
     except telethon.errors.rpcerrorlist.ChatAdminRequiredError:
         return "Error: admin rights required to edit the chat description."
     except Exception as e:
-        logger.exception(f"edit_chat_about failed (chat_id={chat_id})")
         return log_and_format_error("edit_chat_about", e, chat_id=chat_id)
 
 
@@ -481,7 +468,6 @@ async def delete_chat_photo(chat_id: Union[int, str], account: str = None) -> st
 
         return f"Chat {chat_id} photo deleted."
     except Exception as e:
-        logger.exception(f"delete_chat_photo failed (chat_id={chat_id})")
         return log_and_format_error("delete_chat_photo", e, chat_id=chat_id)
 
 
@@ -558,10 +544,6 @@ async def promote_admin(
             return log_and_format_error("promote_admin", e, group_id=group_id, user_id=user_id)
 
     except Exception as e:
-        logger.error(
-            f"telegram_mcp promote_admin failed (group_id={group_id}, user_id={user_id})",
-            exc_info=True,
-        )
         return log_and_format_error("promote_admin", e, group_id=group_id, user_id=user_id)
 
 
@@ -618,10 +600,6 @@ async def demote_admin(
             return log_and_format_error("demote_admin", e, group_id=group_id, user_id=user_id)
 
     except Exception as e:
-        logger.error(
-            f"telegram_mcp demote_admin failed (group_id={group_id}, user_id={user_id})",
-            exc_info=True,
-        )
         return log_and_format_error("demote_admin", e, group_id=group_id, user_id=user_id)
 
 
@@ -676,7 +654,6 @@ async def ban_user(chat_id: Union[int, str], user_id: Union[int, str], account: 
         except Exception as e:
             return log_and_format_error("ban_user", e, chat_id=chat_id, user_id=user_id)
     except Exception as e:
-        logger.exception(f"ban_user failed (chat_id={chat_id}, user_id={user_id})")
         return log_and_format_error("ban_user", e, chat_id=chat_id, user_id=user_id)
 
 
@@ -735,7 +712,6 @@ async def unban_user(
         except Exception as e:
             return log_and_format_error("unban_user", e, chat_id=chat_id, user_id=user_id)
     except Exception as e:
-        logger.exception(f"unban_user failed (chat_id={chat_id}, user_id={user_id})")
         return log_and_format_error("unban_user", e, chat_id=chat_id, user_id=user_id)
 
 
@@ -815,7 +791,6 @@ async def set_default_chat_permissions(
     except telethon.errors.rpcerrorlist.ChatNotModifiedError:
         return f"Chat {chat_id} default permissions unchanged (already matched)."
     except Exception as e:
-        logger.exception(f"set_default_chat_permissions failed (chat_id={chat_id})")
         return log_and_format_error("set_default_chat_permissions", e, chat_id=chat_id)
 
 
@@ -853,7 +828,6 @@ async def toggle_slow_mode(chat_id: Union[int, str], seconds: int = 0, account: 
     except telethon.errors.rpcerrorlist.ChatAdminRequiredError:
         return "Error: admin rights required to toggle slow mode."
     except Exception as e:
-        logger.exception(f"toggle_slow_mode failed (chat_id={chat_id}, seconds={seconds})")
         return log_and_format_error("toggle_slow_mode", e, chat_id=chat_id, seconds=seconds)
 
 
@@ -941,7 +915,6 @@ async def edit_admin_rights(
     except telethon.errors.rpcerrorlist.RightForbiddenError:
         return "Error: some of the requested rights are not allowed for your account or for this chat."
     except Exception as e:
-        logger.exception(f"edit_admin_rights failed (chat_id={chat_id}, user_id={user_id})")
         return log_and_format_error("edit_admin_rights", e, chat_id=chat_id, user_id=user_id)
 
 
@@ -973,7 +946,6 @@ async def get_admins(chat_id: Union[int, str], account: str = None) -> str:
             records.append(rec)
         return format_tool_result(records) if records else "No admins found."
     except Exception as e:
-        logger.exception(f"get_admins failed (chat_id={chat_id})")
         return log_and_format_error("get_admins", e, chat_id=chat_id)
 
 
@@ -1007,7 +979,6 @@ async def get_banned_users(chat_id: Union[int, str], account: str = None) -> str
             records.append(rec)
         return format_tool_result(records) if records else "No banned users found."
     except Exception as e:
-        logger.exception(f"get_banned_users failed (chat_id={chat_id})")
         return log_and_format_error("get_banned_users", e, chat_id=chat_id)
 
 
@@ -1033,16 +1004,16 @@ async def get_invite_link(chat_id: Union[int, str], account: str = None) -> str:
         except AttributeError:
             # If the function doesn't exist in the current Telethon version
             logger.warning("ExportChatInviteRequest not available, using alternative method")
-        except Exception as e1:
+        except Exception:
             # If that fails, log and try alternative approach
-            logger.warning(f"ExportChatInviteRequest failed: {e1}")
+            logger.warning("ExportChatInviteRequest failed; trying alternative method")
 
         # Alternative approach using cl.export_chat_invite_link
         try:
             invite_link = await cl.export_chat_invite_link(entity)
             return invite_link
-        except Exception as e2:
-            logger.warning(f"export_chat_invite_link failed: {e2}")
+        except Exception:
+            logger.warning("export_chat_invite_link failed; trying final method")
 
         # Last resort: Try directly fetching chat info
         try:
@@ -1050,12 +1021,11 @@ async def get_invite_link(chat_id: Union[int, str], account: str = None) -> str:
                 full_chat = await cl(functions.messages.GetFullChatRequest(chat_id=entity.id))
                 if hasattr(full_chat, "full_chat") and hasattr(full_chat.full_chat, "invite_link"):
                     return full_chat.full_chat.invite_link or "No invite link available."
-        except Exception as e3:
-            logger.warning(f"GetFullChatRequest failed: {e3}")
+        except Exception:
+            logger.warning("GetFullChatRequest failed")
 
         return "Could not retrieve invite link for this chat."
     except Exception as e:
-        logger.exception(f"get_invite_link failed (chat_id={chat_id})")
         return log_and_format_error("get_invite_link", e, chat_id=chat_id)
 
 
@@ -1106,8 +1076,7 @@ async def join_chat_by_link(link: str, account: str = None) -> str:
             return "The invite hash is invalid or malformed."
         elif "already" in err_str and "participant" in err_str:
             return "You are already a member of this chat."
-        logger.exception(f"join_chat_by_link failed (link={link})")
-        return f"Error joining chat: {e}"
+        return log_and_format_error("join_chat_by_link", e, link=link)
 
 
 @mcp.tool(
@@ -1132,20 +1101,19 @@ async def export_chat_invite(chat_id: Union[int, str], account: str = None) -> s
         except AttributeError:
             # If the function doesn't exist in the current Telethon version
             logger.warning("ExportChatInviteRequest not available, using alternative method")
-        except Exception as e1:
+        except Exception:
             # If that fails, log and try alternative approach
-            logger.warning(f"ExportChatInviteRequest failed: {e1}")
+            logger.warning("ExportChatInviteRequest failed; trying alternative method")
 
         # Alternative approach using cl.export_chat_invite_link
         try:
             invite_link = await cl.export_chat_invite_link(entity)
             return invite_link
         except Exception as e2:
-            logger.warning(f"export_chat_invite_link failed: {e2}")
+            logger.warning("export_chat_invite_link failed; trying final method")
             return log_and_format_error("export_chat_invite", e2, chat_id=chat_id)
 
     except Exception as e:
-        logger.exception(f"export_chat_invite failed (chat_id={chat_id})")
         return log_and_format_error("export_chat_invite", e, chat_id=chat_id)
 
 
@@ -1209,7 +1177,6 @@ async def import_chat_invite(hash: str, account: str = None) -> str:
                 raise  # Re-raise to be caught by the outer exception handler
 
     except Exception as e:
-        logger.exception(f"import_chat_invite failed (hash={hash})")
         return log_and_format_error("import_chat_invite", e, hash=hash)
 
 
@@ -1250,7 +1217,6 @@ async def get_recent_actions(chat_id: Union[int, str], account: str = None) -> s
             default=json_serializer,
         )
     except Exception as e:
-        logger.exception(f"get_recent_actions failed (chat_id={chat_id})")
         return log_and_format_error("get_recent_actions", e, chat_id=chat_id)
 
 

--- a/telegram_mcp/tools/media.py
+++ b/telegram_mcp/tools/media.py
@@ -463,10 +463,8 @@ async def get_gif_search(query: str, limit: int = 10, account: str = None) -> st
                         gif_ids.append(msg.media.document.id)
                 return json.dumps(gif_ids, default=json_serializer)
             except Exception as inner_e:
-                # Last resort: Try to fetch from a public bot
-                return f"Could not search GIFs using available methods: {inner_e}"
+                return log_and_format_error("get_gif_search", inner_e, query=query, limit=limit)
     except Exception as e:
-        logger.exception(f"get_gif_search failed (query={query}, limit={limit})")
         return log_and_format_error("get_gif_search", e, query=query, limit=limit)
 
 
@@ -528,8 +526,8 @@ async def list_photos(
     """
     try:
         resolved_source = validate_source(source)
-    except UnknownPhotoSource as unknown_source:
-        return str(unknown_source)
+    except UnknownPhotoSource:
+        return "Unknown photo source. Expected one of: avatars, messages."
 
     try:
         cl = get_client(account)
@@ -647,8 +645,8 @@ async def get_photo_sheet(
     """
     try:
         resolved_source = validate_source(source)
-    except UnknownPhotoSource as unknown_source:
-        return str(unknown_source)
+    except UnknownPhotoSource:
+        return "Unknown photo source. Expected one of: avatars, messages."
 
     try:
         cl = get_client(account)
@@ -669,8 +667,11 @@ async def get_photo_sheet(
 
         try:
             sheet_bytes = build_contact_sheet(tiles, columns)
-        except ContactSheetUnavailable as unavailable:
-            return str(unavailable)
+        except ContactSheetUnavailable:
+            return (
+                "Pillow is required to build contact sheets. Install it with "
+                "`pip install pillow` or `uv sync`."
+            )
 
         return [
             f"{len(tiles)} {resolved_source} photo(s) for {get_marked_id(entity)}, "

--- a/telegram_mcp/tools/messages.py
+++ b/telegram_mcp/tools/messages.py
@@ -501,9 +501,6 @@ async def send_scheduled_message(
             "send_scheduled_message", e, chat_id=chat_id, schedule_date=str(schedule_date)
         )
     except Exception as e:
-        logger.exception(
-            f"send_scheduled_message failed (chat_id={chat_id}, schedule_date={schedule_date})"
-        )
         return log_and_format_error(
             "send_scheduled_message", e, chat_id=chat_id, schedule_date=str(schedule_date)
         )
@@ -544,7 +541,6 @@ async def get_scheduled_messages(chat_id: Union[int, str], account: str = None) 
     except telethon.errors.rpcerrorlist.ChatAdminRequiredError as e:
         return log_and_format_error("get_scheduled_messages", e, chat_id=chat_id)
     except Exception as e:
-        logger.exception(f"get_scheduled_messages failed (chat_id={chat_id})")
         return log_and_format_error("get_scheduled_messages", e, chat_id=chat_id)
 
 
@@ -577,9 +573,6 @@ async def delete_scheduled_message(
             "delete_scheduled_message", e, chat_id=chat_id, message_ids=message_ids
         )
     except Exception as e:
-        logger.exception(
-            f"delete_scheduled_message failed (chat_id={chat_id}, message_ids={message_ids})"
-        )
         return log_and_format_error(
             "delete_scheduled_message", e, chat_id=chat_id, message_ids=message_ids
         )
@@ -1819,7 +1812,6 @@ async def get_pinned_messages(chat_id: Union[int, str], account: str = None) -> 
 
         return format_tool_result(records)
     except Exception as e:
-        logger.exception(f"get_pinned_messages failed (chat_id={chat_id})")
         return log_and_format_error("get_pinned_messages", e, chat_id=chat_id)
 
 
@@ -1898,7 +1890,6 @@ async def create_poll(
 
         return f"Poll created successfully in chat {chat_id}."
     except Exception as e:
-        logger.exception(f"create_poll failed (chat_id={chat_id}, question='{question}')")
         return log_and_format_error(
             "create_poll", e, chat_id=chat_id, question=question, options=options
         )
@@ -1942,9 +1933,6 @@ async def send_reaction(
         )
         return f"Reaction '{emoji}' sent to message {message_id} in chat {chat_id}."
     except Exception as e:
-        logger.exception(
-            f"send_reaction failed (chat_id={chat_id}, message_id={message_id}, emoji={emoji})"
-        )
         return log_and_format_error(
             "send_reaction", e, chat_id=chat_id, message_id=message_id, emoji=emoji
         )
@@ -1981,7 +1969,6 @@ async def remove_reaction(
         )
         return f"Reaction removed from message {message_id} in chat {chat_id}."
     except Exception as e:
-        logger.exception(f"remove_reaction failed (chat_id={chat_id}, message_id={message_id})")
         return log_and_format_error("remove_reaction", e, chat_id=chat_id, message_id=message_id)
 
 
@@ -2051,9 +2038,6 @@ async def get_message_reactions(
             default=json_serializer,
         )
     except Exception as e:
-        logger.exception(
-            f"get_message_reactions failed (chat_id={chat_id}, message_id={message_id})"
-        )
         return log_and_format_error(
             "get_message_reactions", e, chat_id=chat_id, message_id=message_id
         )
@@ -2105,7 +2089,6 @@ async def save_draft(
 
         return f"Draft saved to chat {chat_id}. Open the chat in Telegram to see and send it."
     except Exception as e:
-        logger.exception(f"save_draft failed (chat_id={chat_id})")
         return log_and_format_error("save_draft", e, chat_id=chat_id)
 
 
@@ -2167,7 +2150,6 @@ async def get_drafts(account: str = None) -> str:
             {"drafts": drafts_info, "count": len(drafts_info)}, indent=2, default=json_serializer
         )
     except Exception as e:
-        logger.exception("get_drafts failed")
         return log_and_format_error("get_drafts", e)
 
 
@@ -2199,7 +2181,6 @@ async def clear_draft(chat_id: Union[int, str], account: str = None) -> str:
 
         return f"Draft cleared from chat {chat_id}."
     except Exception as e:
-        logger.exception(f"clear_draft failed (chat_id={chat_id})")
         return log_and_format_error("clear_draft", e, chat_id=chat_id)
 
 

--- a/telegram_mcp/tools/profile.py
+++ b/telegram_mcp/tools/profile.py
@@ -126,7 +126,6 @@ async def get_privacy_settings(account: str = None) -> str:
             else:
                 raise
     except Exception as e:
-        logger.exception("get_privacy_settings failed")
         return log_and_format_error("get_privacy_settings", e)
 
 
@@ -192,13 +191,12 @@ async def set_privacy_settings(
                     try:
                         user = await resolve_entity(user_id, cl)
                         allow_entities.append(user)
-                    except Exception as user_err:
-                        logger.warning(f"Could not get entity for user ID {user_id}: {user_err}")
+                    except Exception:
+                        logger.warning("Could not resolve a requested privacy-rule user")
 
                 if allow_entities:
                     rules.append(InputPrivacyValueAllowUsers(users=allow_entities))
             except Exception as allow_err:
-                logger.error(f"Error processing allowed users: {allow_err}")
                 return log_and_format_error("set_privacy_settings", allow_err, key=key)
 
         # Process disallow rules
@@ -209,13 +207,12 @@ async def set_privacy_settings(
                     try:
                         user = await resolve_entity(user_id, cl)
                         disallow_entities.append(user)
-                    except Exception as user_err:
-                        logger.warning(f"Could not get entity for user ID {user_id}: {user_err}")
+                    except Exception:
+                        logger.warning("Could not resolve a requested privacy-rule user")
 
                 if disallow_entities:
                     rules.append(InputPrivacyValueDisallowUsers(users=disallow_entities))
             except Exception as disallow_err:
-                logger.error(f"Error processing disallowed users: {disallow_err}")
                 return log_and_format_error("set_privacy_settings", disallow_err, key=key)
 
         # Apply the privacy settings
@@ -228,7 +225,6 @@ async def set_privacy_settings(
             else:
                 raise
     except Exception as e:
-        logger.exception(f"set_privacy_settings failed (key={key})")
         return log_and_format_error("set_privacy_settings", e, key=key)
 
 
@@ -413,7 +409,6 @@ async def get_bot_info(bot_username: str, account: str = None) -> str:
             )
         return json.dumps(info, indent=2)
     except Exception as e:
-        logger.exception(f"get_bot_info failed (bot_username={bot_username})")
         return log_and_format_error("get_bot_info", e, bot_username=bot_username)
 
 
@@ -463,10 +458,8 @@ async def set_bot_commands(bot_username: str, commands: list, account: str = Non
 
         return f"Bot commands set for {bot_username}."
     except ImportError as ie:
-        logger.exception(f"set_bot_commands failed - ImportError: {ie}")
         return log_and_format_error("set_bot_commands", ie)
     except Exception as e:
-        logger.exception(f"set_bot_commands failed (bot_username={bot_username})")
         return log_and_format_error("set_bot_commands", e, bot_username=bot_username)
 
 

--- a/tests/test_error_logging.py
+++ b/tests/test_error_logging.py
@@ -1,0 +1,332 @@
+"""Regression tests for privacy-safe Telegram MCP error logging."""
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from telegram_mcp import runtime
+from telegram_mcp.tools import folders, groups, media, profile
+
+
+def test_error_log_omits_sensitive_context_exception_text_and_traceback(caplog):
+    try:
+        raise RuntimeError("exception-payload-secret")
+    except RuntimeError as error:
+        with caplog.at_level("ERROR", logger=runtime.logger.name):
+            result = runtime.log_and_format_error(
+                "send_message",
+                error,
+                chat_id=-100123456,
+                message="message-secret",
+                caption="caption-secret",
+                transcript="transcript-secret",
+                provider_payload={"text": "provider-secret"},
+                file_path="/private/local-path-secret.txt",
+            )
+
+    assert result.startswith("An error occurred (code: GEN-ERR-")
+    assert "Telegram MCP operation failed" in caplog.text
+    for secret in (
+        "exception-payload-secret",
+        "-100123456",
+        "message-secret",
+        "caption-secret",
+        "transcript-secret",
+        "provider-secret",
+        "local-path-secret",
+        "Traceback",
+    ):
+        assert secret not in caplog.text
+
+
+def test_flood_wait_log_keeps_seconds_but_omits_sensitive_payloads(caplog):
+    error = runtime.FloodWaitError(request=None, capture=45)
+    error.args = ("exception-provider-payload-secret",)
+
+    with caplog.at_level("WARNING", logger=runtime.logger.name):
+        result = runtime.log_and_format_error(
+            "transcribe_voice",
+            error,
+            chat_id=-100987654,
+            transcript="transcript-secret",
+            provider_payload={"text": "provider-secret"},
+            file_path="/private/audio-secret.ogg",
+        )
+
+    assert "45 seconds" in result
+    assert "Do NOT retry immediately" in result
+    assert "Telegram FloodWait" in caplog.text
+    for secret in (
+        "exception-provider-payload-secret",
+        "-100987654",
+        "transcript-secret",
+        "provider-secret",
+        "audio-secret",
+    ):
+        assert secret not in caplog.text
+
+
+def _logger_call(node):
+    if not isinstance(node, ast.Call):
+        return None
+    call = node
+    if not isinstance(call.func, ast.Attribute):
+        return None
+    if not isinstance(call.func.value, ast.Name) or call.func.value.id != "logger":
+        return None
+    return call
+
+
+def _persistent_log_call(node):
+    if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+        return None
+    if node.func.attr not in {"debug", "info", "warning", "error", "exception", "critical"}:
+        return None
+    return node
+
+
+def _is_leaking_log_statement(statement):
+    if not isinstance(statement, ast.Expr):
+        return False
+    call = _logger_call(statement.value)
+    if call is None:
+        return False
+    if call.func.attr == "exception":
+        return True
+    return call.func.attr == "error" and any(
+        keyword.arg == "exc_info"
+        and isinstance(keyword.value, ast.Constant)
+        and keyword.value.value is True
+        for keyword in call.keywords
+    )
+
+
+def _returns_formatted_error(statement):
+    return isinstance(statement, ast.Return) and any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "log_and_format_error"
+        for node in ast.walk(statement)
+    )
+
+
+def test_tool_handlers_do_not_log_sensitive_exceptions_before_formatting():
+    tools_dir = Path(runtime.__file__).parent / "tools"
+    leaking_sites = []
+
+    for source_path in sorted(tools_dir.glob("*.py")):
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        for parent in ast.walk(tree):
+            for _, value in ast.iter_fields(parent):
+                if not isinstance(value, list):
+                    continue
+                for current, following in zip(value, value[1:]):
+                    if _is_leaking_log_statement(current) and _returns_formatted_error(following):
+                        leaking_sites.append(f"{source_path.name}:{current.lineno}")
+
+    assert leaking_sites == []
+
+
+def _runtime_and_tool_sources():
+    package_dir = Path(runtime.__file__).parent
+    return package_dir, [
+        package_dir / "runtime.py",
+        *sorted((package_dir / "tools").glob("*.py")),
+    ]
+
+
+def test_all_runtime_and_tool_logs_use_constant_privacy_safe_messages():
+    package_dir, source_paths = _runtime_and_tool_sources()
+    unsafe = []
+
+    for source_path in source_paths:
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            call = _persistent_log_call(node)
+            if call is None:
+                continue
+            # exception() always persists an implicit traceback. Every other log
+            # call must not accept arbitrary values through %-args, f-strings,
+            # or keyword fields; a literal message is the enforceable boundary.
+            literal_only = (
+                call.func.attr != "exception"
+                and len(call.args) == 1
+                and isinstance(call.args[0], ast.Constant)
+                and isinstance(call.args[0].value, str)
+                and not call.keywords
+            )
+            if not literal_only:
+                unsafe.append(f"{source_path.relative_to(package_dir)}:{node.lineno}")
+
+    assert unsafe == []
+
+
+def test_all_runtime_and_tool_exception_handlers_do_not_return_raw_exceptions():
+    package_dir, source_paths = _runtime_and_tool_sources()
+    unsafe = []
+
+    for source_path in source_paths:
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        for handler in (node for node in ast.walk(tree) if isinstance(node, ast.ExceptHandler)):
+            if not handler.name:
+                continue
+            body = ast.Module(body=handler.body, type_ignores=[])
+            for node in ast.walk(body):
+                if not isinstance(node, ast.Return) or node.value is None:
+                    continue
+                if isinstance(node.value, ast.Call) and isinstance(node.value.func, ast.Name):
+                    if node.value.func.id == "log_and_format_error":
+                        continue
+                exposes_exception = any(
+                    isinstance(value, ast.Name) and value.id == handler.name
+                    for value in ast.walk(node.value)
+                )
+                if exposes_exception:
+                    unsafe.append(f"{source_path.relative_to(package_dir)}:{node.lineno}")
+
+    assert unsafe == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool", [media.list_photos, media.get_photo_sheet])
+async def test_unknown_photo_source_response_omits_caller_value(tool):
+    result = await tool(source="secret\nTraceback: /private/provider/path", chat_id=123)
+
+    assert result == "Unknown photo source. Expected one of: avatars, messages."
+    assert "secret" not in result
+    assert "Traceback" not in result
+    assert "/private/provider/path" not in result
+
+
+def test_unreadable_alias_store_omits_path_and_parser_details(tmp_path, monkeypatch, caplog):
+    secret_path = tmp_path / "alias-path-secret.json"
+    secret_path.write_text("{ alias-json-secret", encoding="utf-8")
+    monkeypatch.setenv("TELEGRAM_ALIASES_FILE", str(secret_path))
+
+    with caplog.at_level("WARNING", logger=runtime.logger.name):
+        with pytest.raises(runtime.AliasStoreUnreadable) as excinfo:
+            runtime.load_aliases(strict=True)
+
+    assert "no changes were written" in str(excinfo.value).lower()
+    for secret in ("alias-path-secret", "alias-json-secret", "Expecting property name"):
+        assert secret not in caplog.text
+        assert secret not in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fallback_enabled", [False, True])
+async def test_roots_failure_log_omits_exception_payload_and_traceback(
+    tmp_path, monkeypatch, caplog, fallback_enabled
+):
+    class Session:
+        async def list_roots(self):
+            raise RuntimeError("roots-exception-secret")
+
+    root = tmp_path / "root"
+    root.mkdir()
+    monkeypatch.setattr(runtime, "SERVER_ALLOWED_ROOTS", [root])
+    if fallback_enabled:
+        monkeypatch.setenv("TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK", "1")
+    else:
+        monkeypatch.delenv("TELEGRAM_ALLOW_SERVER_ROOTS_FALLBACK", raising=False)
+
+    with caplog.at_level("WARNING", logger=runtime.logger.name):
+        await runtime._get_effective_allowed_roots_with_status(SimpleNamespace(session=Session()))
+
+    assert "MCP roots request failed" in caplog.text
+    assert "roots-exception-secret" not in caplog.text
+    assert "Traceback" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_join_chat_unknown_error_uses_sanitized_response_and_log(monkeypatch, caplog):
+    class Client:
+        async def __call__(self, request):
+            raise RuntimeError("join-exception-secret")
+
+    async def connected(client):
+        return None
+
+    monkeypatch.setattr(groups, "get_client", lambda account=None: Client())
+    monkeypatch.setattr(groups, "ensure_connected", connected)
+
+    with caplog.at_level("ERROR", logger=runtime.logger.name):
+        result = await groups.join_chat_by_link(link="https://t.me/+invite-link-secret")
+
+    assert result.startswith("An error occurred (code:")
+    for secret in ("join-exception-secret", "invite-link-secret", "Traceback"):
+        assert secret not in result
+        assert secret not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_profile_resolution_warning_omits_identifier_and_exception(monkeypatch, caplog):
+    class Client:
+        async def __call__(self, request):
+            return SimpleNamespace()
+
+    async def fail_resolution(user_id, client):
+        raise RuntimeError("profile-exception-secret")
+
+    monkeypatch.setattr(profile, "get_client", lambda account=None: Client())
+    monkeypatch.setattr(profile, "resolve_entity", fail_resolution)
+
+    with caplog.at_level("WARNING", logger=runtime.logger.name):
+        result = await profile.set_privacy_settings(
+            key="status", allow_users=["@profile_user_secret"]
+        )
+
+    assert result == "Privacy settings for status updated successfully."
+    assert "profile-exception-secret" not in caplog.text
+    assert "profile_user_secret" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_folder_resolution_error_omits_identifier_and_exception(monkeypatch):
+    class Client:
+        async def __call__(self, request):
+            return SimpleNamespace(filters=[])
+
+    async def fail_resolution(chat_id, client):
+        raise RuntimeError("folder-exception-secret")
+
+    monkeypatch.setattr(folders, "get_client", lambda account=None: Client())
+    monkeypatch.setattr(folders, "resolve_input_entity", fail_resolution)
+
+    result = await folders.create_folder(title="safe title", chat_ids=["folder-chat-secret"])
+
+    assert result.startswith("Failed to resolve a requested chat")
+    assert "folder-exception-secret" not in result
+    assert "folder-chat-secret" not in result
+
+
+@pytest.mark.asyncio
+async def test_gif_fallback_error_omits_exception_and_query_payload(monkeypatch):
+    class Client:
+        calls = 0
+
+        async def __call__(self, request):
+            self.calls += 1
+            if self.calls == 1:
+                raise AttributeError("force fallback")
+            raise RuntimeError("exception-payload-secret")
+
+    async def connected(client):
+        return None
+
+    monkeypatch.setattr(
+        media.functions.messages,
+        "SearchGifsRequest",
+        lambda **kwargs: "primary-request",
+        raising=False,
+    )
+    monkeypatch.setattr(media, "get_client", lambda account: Client())
+    monkeypatch.setattr(media, "ensure_connected", connected)
+
+    result = await media.get_gif_search(query="gif-query-secret")
+
+    assert result.startswith("An error occurred (code:")
+    assert "exception-payload-secret" not in result
+    assert "gif-query-secret" not in result

--- a/tests/test_flood_wait.py
+++ b/tests/test_flood_wait.py
@@ -49,8 +49,7 @@ def test_flood_wait_logs_warning_instead_of_error():
         log_and_format_error("get_history", err, chat_id=98765)
         mock_logger.warning.assert_called_once()
         warning_args = mock_logger.warning.call_args[0][0]
-        assert "Telegram FloodWait in get_history" in warning_args
-        assert "30s" in warning_args
+        assert warning_args == "Telegram FloodWait; retry only after the reported delay."
         mock_logger.error.assert_not_called()
 
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -715,7 +715,7 @@ def test_log_and_format_error_returns_custom_and_generated_messages(caplog):
 
     generated = runtime.log_and_format_error("get_chat", RuntimeError("boom"))
     assert "code: CHAT-ERR-" in generated
-    assert "Check mcp_errors.log" in generated
+    assert "mcp_errors.log" not in generated
 
 
 def test_path_helper_edges(tmp_path, monkeypatch):

--- a/tests/test_schema_drift.py
+++ b/tests/test_schema_drift.py
@@ -9,10 +9,15 @@ from telegram_mcp.runtime import log_and_format_error
 from telethon.errors.common import TypeNotFoundError
 
 
-def test_schema_drift_is_named_and_actionable():
-    msg = log_and_format_error("list_chats", TypeNotFoundError(0xD58A08C6, b"\x00"))
+def test_schema_drift_is_named_actionable_and_omits_exception_payload():
+    error = TypeNotFoundError(0xD58A08C6, b"raw-payload-secret")
+
+    msg = log_and_format_error("list_chats", error)
+
     assert "MTProto schema mismatch" in msg
     assert "NOT a missing user or chat" in msg
+    assert str(error) not in msg
+    assert "raw-payload-secret" not in msg
 
 
 def test_ordinary_error_keeps_the_generic_format():


### PR DESCRIPTION
## Problem

Some tool errors logged call arguments and full tracebacks. These values may contain Telegram IDs, message text, transcripts, provider responses, or local file paths.

```text
tool error -> arguments + traceback -> persistent log
```

Some tools also logged the same exception twice before using the shared error formatter.

## Solution

Route tool errors through one safe formatter and keep only the metadata needed to find the failing operation.

```text
tool error -> operation + error code + exception type
FloodWait  -> operation + error code + wait seconds
```

FloodWait responses still tell the caller how long to wait. Schema errors remain actionable without including raw server payloads.

## Tests

- Added regression coverage for normal errors, FloodWait, schema errors, and fallback responses.
- Added a package-wide check for unsafe error logging and raw exception responses.
- `uv run pytest -q` — 460 passed.
- Black and `git diff --check` pass.
