### PR TITLE
fix(groups): pass the resolved Chat.id to messages.* edit requests

### DIFF
--- a/telegram_mcp/tools/groups.py
+++ b/telegram_mcp/tools/groups.py
@@ -360,7 +360,9 @@ async def edit_chat_title(chat_id: Union[int, str], title: str, account: str = N
         if isinstance(entity, Channel):
             await cl(functions.channels.EditTitleRequest(channel=entity, title=title))
         elif isinstance(entity, Chat):
-            await cl(functions.messages.EditChatTitleRequest(chat_id=chat_id, title=title))
+            # messages.* requests take the positive Chat.id; the raw argument may be a
+            # negative Bot-API-style id or a username, which Telegram rejects.
+            await cl(functions.messages.EditChatTitleRequest(chat_id=entity.id, title=title))
         else:
             return f"Cannot edit title for this entity type ({type(entity)})."
         return f"Chat {chat_id} title updated to '{sanitize_name(title)}'."
@@ -405,7 +407,7 @@ async def edit_chat_photo(
         elif isinstance(entity, Chat):
             # For basic groups, use EditChatPhotoRequest with InputChatUploadedPhoto
             input_photo = InputChatUploadedPhoto(file=uploaded_file)
-            await cl(functions.messages.EditChatPhotoRequest(chat_id=chat_id, photo=input_photo))
+            await cl(functions.messages.EditChatPhotoRequest(chat_id=entity.id, photo=input_photo))
         else:
             return f"Cannot edit photo for this entity type ({type(entity)})."
 
@@ -473,7 +475,7 @@ async def delete_chat_photo(chat_id: Union[int, str], account: str = None) -> st
             # Use None (or InputChatPhotoEmpty) for basic groups
             await cl(
                 functions.messages.EditChatPhotoRequest(
-                    chat_id=chat_id, photo=InputChatPhotoEmpty()
+                    chat_id=entity.id, photo=InputChatPhotoEmpty()
                 )
             )
         else:

--- a/tests/test_edit_chat_basic_group.py
+++ b/tests/test_edit_chat_basic_group.py
@@ -1,0 +1,120 @@
+"""Tests for edit_chat_title / edit_chat_photo / delete_chat_photo on basic groups.
+
+Regression guard: the basic-group branches passed the raw ``chat_id`` argument
+straight into ``messages.EditChatTitle`` / ``messages.EditChatPhoto``. Those
+requests take the positive ``Chat.id``; the negative Bot-API-style id (or a
+string) that MCP callers pass is rejected by Telegram — CHAT_ID_INVALID, or
+repeated internal errors until Telethon gives up. The resolved entity's id must
+be used, exactly as the channel branches already pass the resolved entity.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from telethon.tl import functions, types
+
+from telegram_mcp.tools import groups
+
+BASIC_GROUP_ID = 5317263588  # Telegram's positive Chat.id
+BOT_API_ID = -BASIC_GROUP_ID  # the spelling MCP callers typically pass
+
+
+class FakeClient:
+    """Records every raw request and stubs the upload used by edit_chat_photo."""
+
+    def __init__(self):
+        self.requests = []
+
+    async def __call__(self, request):
+        self.requests.append(request)
+        return SimpleNamespace()
+
+    async def upload_file(self, path):
+        return SimpleNamespace(name=Path(path).name)
+
+
+def _basic_group():
+    return types.Chat(
+        id=BASIC_GROUP_ID,
+        title="Basic Group",
+        photo=types.ChatPhotoEmpty(),
+        participants_count=3,
+        date=None,
+        version=1,
+    )
+
+
+def _patch(monkeypatch, client, entity):
+    async def fake_resolve(identifier, cl):
+        # Like telethon, any spelling of the id resolves to the same entity.
+        return entity
+
+    async def fake_readable_path(raw_path, ctx, tool_name):
+        return Path(raw_path), None
+
+    monkeypatch.setattr(groups, "get_client", lambda account=None: client)
+    monkeypatch.setattr(groups, "resolve_entity", fake_resolve)
+    monkeypatch.setattr(groups, "_resolve_readable_file_path", fake_readable_path)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("chat_id", [BOT_API_ID, str(BOT_API_ID)])
+async def test_edit_chat_title_basic_group_uses_resolved_id(monkeypatch, chat_id):
+    client = FakeClient()
+    _patch(monkeypatch, client, _basic_group())
+
+    result = await groups.edit_chat_title(chat_id=chat_id, title="New Title", account=None)
+
+    (request,) = client.requests
+    assert isinstance(request, functions.messages.EditChatTitleRequest)
+    assert request.chat_id == BASIC_GROUP_ID
+    assert request.title == "New Title"
+    assert "title updated to 'New Title'" in result
+
+
+@pytest.mark.asyncio
+async def test_edit_chat_photo_basic_group_uses_resolved_id(monkeypatch):
+    client = FakeClient()
+    _patch(monkeypatch, client, _basic_group())
+
+    result = await groups.edit_chat_photo(chat_id=BOT_API_ID, file_path="avatar.jpg", account=None)
+
+    (request,) = client.requests
+    assert isinstance(request, functions.messages.EditChatPhotoRequest)
+    assert request.chat_id == BASIC_GROUP_ID
+    assert isinstance(request.photo, types.InputChatUploadedPhoto)
+    assert request.photo.file.name == "avatar.jpg"
+    assert "photo updated from avatar.jpg" in result
+
+
+@pytest.mark.asyncio
+async def test_delete_chat_photo_basic_group_uses_resolved_id(monkeypatch):
+    client = FakeClient()
+    _patch(monkeypatch, client, _basic_group())
+
+    result = await groups.delete_chat_photo(chat_id=BOT_API_ID, account=None)
+
+    (request,) = client.requests
+    assert isinstance(request, functions.messages.EditChatPhotoRequest)
+    assert request.chat_id == BASIC_GROUP_ID
+    assert isinstance(request.photo, types.InputChatPhotoEmpty)
+    assert "photo deleted" in result
+
+
+@pytest.mark.asyncio
+async def test_channel_branches_still_pass_the_entity(monkeypatch):
+    channel = types.Channel(id=777, title="Announcements", photo=None, date=None)
+    client = FakeClient()
+    _patch(monkeypatch, client, channel)
+
+    await groups.edit_chat_title(chat_id=-1000000000777, title="Title", account=None)
+    await groups.edit_chat_photo(chat_id=-1000000000777, file_path="avatar.jpg", account=None)
+    await groups.delete_chat_photo(chat_id=-1000000000777, account=None)
+
+    title, photo, delete = client.requests
+    assert isinstance(title, functions.channels.EditTitleRequest)
+    assert isinstance(photo, functions.channels.EditPhotoRequest)
+    assert isinstance(delete, functions.channels.EditPhotoRequest)
+    assert all(request.channel is channel for request in client.requests)
+    assert isinstance(delete.photo, types.InputChatPhotoEmpty)


### PR DESCRIPTION
## Problem

`edit_chat_title`, `edit_chat_photo` and `delete_chat_photo` resolve the entity but then pass the raw `chat_id` argument into `messages.EditChatTitle` / `messages.EditChatPhoto`. Those requests take the positive basic-group id; the negative Bot-API-style id (or a string) that MCP callers pass is rejected by Telegram:

- `edit_chat_title` → `CHAT_ID_INVALID`
- `edit_chat_photo` → repeated internal errors until Telethon gives up (`Request was unsuccessful 6 time(s)`)

The channel/supergroup branches pass the resolved entity and are unaffected, which is why this only ever fails on basic groups.

## Fix

Use `entity.id` in all three basic-group branches — the same way `invite_to_group`, `leave_chat` and `get_invite_link` already do. No other TL request in the package passes the raw argument.

## Tests

`tests/test_edit_chat_basic_group.py`: each tool, with a basic group resolved from the negative (and string) id, asserts the request carries the positive `Chat.id`; a channel case guards the existing branches. Full suite: 451 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9bK1HpUomZE9ioLWvy4cm
