### PR TITLE
fix: read rich (block-format) messages instead of reporting them empty

### DIFF
--- a/telegram_mcp/runtime.py
+++ b/telegram_mcp/runtime.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from difflib import SequenceMatcher
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import List, Dict, Optional, Union, Any
+from typing import List, Dict, Optional, Union, Any, get_args
 from pathlib import Path
 from urllib.parse import unquote, urlparse
 
@@ -966,6 +966,83 @@ def make_rich_input(parse_mode: str, text: str):
     if parse_mode == "rich_html":
         return types.InputRichMessageHTML(html=text)
     return types.InputRichMessageMarkdown(markdown=text)
+
+
+# Reading a rich message is the other direction, and it needs its own walk: a
+# channel posting in this format leaves msg.message empty and carries every word
+# as Instant-View page blocks, so a reader that only looks at msg.message
+# reports the whole post as empty.
+_RICH_TEXT_TYPES = tuple(get_args(types.TypeRichText))
+
+# RichText is a recursive tree: a node either holds a plain string, wraps
+# another node, or concatenates a list of them. Dispatching on the field rather
+# than on the class keeps a node type Telegram adds later flattening instead of
+# vanishing.
+_RICH_TEXT_FIELDS = ("texts", "text", "alt", "source")
+
+# Where a page block, list item, table row or caption keeps its words. Same walk
+# covers the blocks nested inside details, collages and embedded posts.
+_PAGE_TEXT_FIELDS = (
+    "title",
+    "subtitle",
+    "author",
+    "text",
+    "caption",
+    "credit",
+    "items",
+    "blocks",
+    "rows",
+    "articles",
+)
+
+
+def rich_text_to_str(node) -> str:
+    """Flatten one RichText node into plain text.
+
+    TextCustomEmoji contributes its alt character - dropping it would silently
+    eat the emoji a channel used as a bullet or a heading marker.
+    """
+    if node is None:
+        return ""
+    if isinstance(node, str):
+        return node
+    if isinstance(node, (list, tuple)):
+        return "".join(rich_text_to_str(item) for item in node)
+    for field in _RICH_TEXT_FIELDS:
+        value = getattr(node, field, None)
+        if value is not None:
+            return rich_text_to_str(value)
+    return ""  # TextEmpty, TextImage and anything else carrying no text
+
+
+def _page_lines(node) -> List[str]:
+    """Text lines carried by a page block, list item, table row or caption."""
+    if node is None:
+        return []
+    if isinstance(node, (list, tuple)):
+        return [line for item in node for line in _page_lines(item)]
+    if isinstance(node, _RICH_TEXT_TYPES):
+        text = rich_text_to_str(node).strip()
+        return [text] if text else []
+    cells = getattr(node, "cells", None)
+    if cells is not None:  # a table row reads as one line, not one line per cell
+        row = " | ".join(line for cell in cells for line in _page_lines(cell))
+        return [row] if row else []
+    return [line for f in _PAGE_TEXT_FIELDS for line in _page_lines(getattr(node, f, None))]
+
+
+def rich_message_text(msg) -> str:
+    """Plain text of a rich (block-format) message, "" when there is none.
+
+    Each block becomes a paragraph and the lines within one block stay together,
+    so a list reads as a list instead of one run-on line. An unknown block type
+    yields nothing rather than breaking the whole message.
+    """
+    blocks = getattr(getattr(msg, "rich_message", None), "blocks", None)
+    if not blocks:
+        return ""
+    paragraphs = ("\n".join(_page_lines(block)) for block in blocks)
+    return "\n\n".join(p for p in paragraphs if p)
 
 
 def premium_required_result(action: str) -> str:

--- a/telegram_mcp/tools/messages.py
+++ b/telegram_mcp/tools/messages.py
@@ -141,8 +141,18 @@ def message_to_dict(msg, chat_id: Optional[int] = None) -> dict:
         d["out"] = True
 
     text = sanitize_user_content(msg.message) if getattr(msg, "message", None) else ""
+    rich = False
+    if not text:
+        # Block-format posts leave .message empty and keep the words in
+        # .rich_message; without this the whole post reads back as "[empty]".
+        rich_text = rich_message_text(msg)
+        if rich_text:
+            text = sanitize_user_content(rich_text)
+            rich = True
     if text:
         d["text"] = text
+    if rich:
+        d["rich"] = True  # text rebuilt from page blocks, not a verbatim .message
 
     media_label = get_media_label(msg)
     if media_label:
@@ -327,6 +337,11 @@ def format_message_line(msg, chat_id: Optional[int] = None) -> str:
         parts.append(engagement_info)
 
     raw = sanitize_user_content(msg.message) if getattr(msg, "message", None) else ""
+    if not raw:
+        rich_text = rich_message_text(msg)
+        if rich_text:
+            raw = sanitize_user_content(rich_text)
+            parts.append("rich")
     if raw:
         safe_text = raw.replace("\n", "\\n")
     else:

--- a/tests/test_rich_messages.py
+++ b/tests/test_rich_messages.py
@@ -117,3 +117,169 @@ async def test_edit_rich_both_premium_cases():
     result = json.loads(await messages._edit_rich(no, "peer", 7, "new", "rich"))
     assert result["reason"] == "telegram_premium_required"
     assert no.requests == []
+
+
+# --- reading rich messages -------------------------------------------------
+# A channel posting in the block format leaves msg.message empty and puts every
+# word into msg.rich_message, so such a post used to read back as "[empty]".
+
+types = runtime.types
+
+
+def _msg(**overrides):
+    base = dict(
+        id=224,
+        sender=None,
+        sender_id=42,
+        date="2026-09-03",
+        message="",
+        reply_to=None,
+        rich_message=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _plain(text):
+    return types.TextPlain(text=text)
+
+
+def _rich(*blocks):
+    return types.RichMessage(blocks=list(blocks), photos=[], documents=[])
+
+
+def _cell(text):
+    return types.PageTableCell(
+        header=False,
+        align_center=False,
+        align_right=False,
+        valign_middle=False,
+        valign_bottom=False,
+        text=_plain(text),
+        colspan=None,
+        rowspan=None,
+    )
+
+
+def _post_like_agents_lab_224():
+    """The shape a real block-format post arrives in: a heading carrying a
+    custom emoji, an uncaptioned photo, then paragraphs."""
+    return _rich(
+        types.PageBlockHeading1(
+            text=types.TextConcat(
+                texts=[
+                    _plain("Личная CRM "),
+                    types.TextCustomEmoji(document_id=5927026418616636353, alt="🧠"),
+                ]
+            )
+        ),
+        types.PageBlockPhoto(
+            photo_id=5197653938998550234,
+            caption=types.PageCaption(text=types.TextEmpty(), credit=types.TextEmpty()),
+            spoiler=False,
+            url=None,
+            webpage_id=None,
+        ),
+        types.PageBlockParagraph(text=_plain("Первый абзац.")),
+        types.PageBlockParagraph(text=_plain("Второй абзац.")),
+    )
+
+
+def test_rich_text_flattens_every_nesting_shape():
+    node = types.TextConcat(
+        texts=[
+            _plain("plain "),
+            types.TextBold(text=_plain("bold ")),
+            types.TextUrl(text=_plain("link"), url="https://example.com", webpage_id=0),
+            types.TextCustomEmoji(document_id=1, alt="🧠"),
+            types.TextEmpty(),
+        ]
+    )
+
+    assert runtime.rich_text_to_str(node) == "plain bold link🧠"
+
+
+def test_rich_text_ignores_nodes_that_carry_no_text():
+    assert runtime.rich_text_to_str(types.TextEmpty()) == ""
+    assert runtime.rich_text_to_str(types.TextImage(document_id=1, w=10, h=10)) == ""
+    assert runtime.rich_text_to_str(None) == ""
+
+
+def test_rich_message_text_walks_blocks():
+    text = runtime.rich_message_text(_msg(rich_message=_post_like_agents_lab_224()))
+
+    # One paragraph per block; the empty photo caption contributes nothing.
+    assert text == "Личная CRM 🧠\n\nПервый абзац.\n\nВторой абзац."
+
+
+def test_rich_message_text_reaches_captions_lists_tables_and_details():
+    rich = _rich(
+        types.PageBlockVideo(
+            video_id=1,
+            caption=types.PageCaption(text=_plain("под видео"), credit=types.TextEmpty()),
+            autoplay=False,
+            loop=False,
+            spoiler=False,
+        ),
+        types.PageBlockList(
+            items=[
+                types.PageListItemText(text=_plain("первый"), checkbox=None, checked=None),
+                types.PageListItemBlocks(
+                    blocks=[types.PageBlockParagraph(text=_plain("второй"))],
+                    checkbox=None,
+                    checked=None,
+                ),
+            ]
+        ),
+        types.PageBlockTable(
+            title=types.TextEmpty(),
+            rows=[types.PageTableRow(cells=[_cell("A"), _cell("B")])],
+            bordered=False,
+            striped=False,
+        ),
+        types.PageBlockDetails(
+            blocks=[types.PageBlockParagraph(text=_plain("скрытое"))],
+            title=_plain("подробнее"),
+            open=False,
+        ),
+    )
+
+    assert runtime.rich_message_text(_msg(rich_message=rich)) == (
+        "под видео\n\nпервый\nвторой\n\nA | B\n\nподробнее\nскрытое"
+    )
+
+
+def test_rich_message_text_skips_unknown_blocks_instead_of_failing():
+    rich = _rich(
+        SimpleNamespace(),  # a block type Telegram adds after this telethon build
+        types.PageBlockParagraph(text=_plain("уцелевший абзац")),
+    )
+
+    assert runtime.rich_message_text(_msg(rich_message=rich)) == "уцелевший абзац"
+
+
+def test_rich_message_text_is_empty_without_a_rich_message():
+    assert runtime.rich_message_text(_msg()) == ""
+    assert runtime.rich_message_text(SimpleNamespace()) == ""
+
+
+def test_message_to_dict_falls_back_to_rich_message():
+    d = messages.message_to_dict(_msg(rich_message=_post_like_agents_lab_224()))
+
+    assert d["text"].startswith("Личная CRM 🧠")
+    assert d["rich"] is True
+
+
+def test_format_message_line_falls_back_to_rich_message():
+    line = messages.format_message_line(_msg(rich_message=_post_like_agents_lab_224()))
+
+    assert "Message: [empty]" not in line
+    assert "Личная CRM 🧠\\n\\nПервый абзац." in line
+    assert "rich" in line
+
+
+def test_plain_message_text_still_wins_over_rich_message():
+    msg = _msg(message="обычный текст", rich_message=_post_like_agents_lab_224())
+
+    assert messages.message_to_dict(msg)["text"] == "обычный текст"
+    assert "обычный текст" in messages.format_message_line(msg)


### PR DESCRIPTION
## The defect

A channel posting in the rich (block) format leaves `msg.message` empty and carries every word
in `msg.rich_message` as Instant-View page blocks. Both readers — `message_to_dict` and
`format_message_line` — look only at `msg.message`, so an entire post comes back as:

```
ID: 224 | Agents Lab (@agents_lab) | Date: 2026-08-18 ... | Message: [empty]
```

It is not a permissions problem: the account is subscribed, the channel is not `restricted`,
`noforwards=False`, and a plain-text post in another channel reads back in full.

**Reproduces on a public post:** `t.me/agents_lab/224` — `get_messages(chat_id="agents_lab")`
returns `Message: [empty]` for it and for every other rich post in that channel (20 of 20 on
page 1 before this change, 0 of 20 after).

The rich side of the codebase so far only went outwards — `make_rich_input` for `send_message` /
`edit_message`, added in 272d780. This adds the way back.

## The change

`runtime.rich_text_to_str(node)` flattens one `RichText` tree. It dispatches on the field
(`texts` / `text` / `alt` / `source`) rather than on the class, so a node type Telegram adds
later still flattens instead of vanishing. `TextCustomEmoji` contributes its `alt`, otherwise an
emoji a channel uses as a bullet or a heading marker is silently eaten.

`runtime.rich_message_text(msg)` walks the page blocks: one paragraph per block, lines inside one
block kept together (so a list reads as a list, not one run-on line), table rows joined with
`" | "`, and an unknown block type contributes nothing instead of breaking the whole message.

Both readers fall back to it only when `msg.message` is empty, so plain messages are untouched.
Reconstructed text is marked — `"rich": true` in `message_to_dict`, a `rich` flag in
`format_message_line` — so a consumer can tell it apart from a verbatim `msg.message`.

## Coverage

Block types were taken from a census of the last 120 messages of one channel (45 of them rich),
not guessed:

`PageBlockHeading1…6`, `Paragraph`, `Photo`, `Video`, `List`, `OrderedList`, `Pullquote`,
`Divider`, `Footer`, `Details`, `Table`, `Slideshow`, `Collage`, `Preformatted` — and the rich
text types `TextConcat`, `TextPlain`, `TextCustomEmoji`, `TextUrl`, `TextBold`, `TextEmpty`,
`TextFixed`, `TextItalic`, `TextMarked`, `TextAutoUrl`.

## Tests

Eight cases added to `tests/test_rich_messages.py`, next to the existing send-side ones. Each was
confirmed to fail on unpatched `main` before the fix landed; the regression case
(plain `msg.message` still wins over `rich_message`) passes both before and after.

- `uv run pytest` — 476 passed, coverage 92.72% (gate 80%)
- `uv run black --check .` — clean
- `flake8 --select=E9,F63,F7,F82` — 0

Also verified against the live API: `agents_lab/224` returns its text, and a plain-text control
channel is unchanged (its only remaining `[empty]` is a `MessageActionChannelCreate` service
message, which has no text by nature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
